### PR TITLE
Centralise the canonical import paths and more package docs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package agones is a library for hosting, running and scaling dedicated game servers on Kubernetes.
+package agones // import "agones.dev/agones"

--- a/pkg/apis/doc.go
+++ b/pkg/apis/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pkg
-
-var (
-	// Version is the global version for all binaries
-	// This is set at compile time by the build process
-	Version = "dev"
-)
+// Package apis contains all the types for the Custom Resource Definitions
+package apis

--- a/pkg/client/doc.go
+++ b/pkg/client/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pkg
-
-var (
-	// Version is the global version for all binaries
-	// This is set at compile time by the build process
-	Version = "dev"
-)
+// Package client contains the generated client for the Custom Resource Definitions
+package client

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,3 @@
 // limitations under the License.
 
 package pkg
-
-var (
-	// Version is the global version for all binaries
-	// This is set at compile time by the build process
-	Version = "dev"
-)

--- a/pkg/util/doc.go
+++ b/pkg/util/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All Rights Reserved.
+// Copyright 2018 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pkg
-
-var (
-	// Version is the global version for all binaries
-	// This is set at compile time by the build process
-	Version = "dev"
-)
+// Package util is for general libraries that aren't specific to Agones
+package util


### PR DESCRIPTION
Put the canonical import path into the main directory, to centralise it, and make sure it's applied across everything.

As a side effect of this work, also added some more package docs.