### PR TITLE
go vet: 3 warnings, 2 of them are easy.

### DIFF
--- a/examples/simple-udp/server/main.go
+++ b/examples/simple-udp/server/main.go
@@ -107,7 +107,6 @@ func doHealth(sdk *sdk.SDK, stop <-chan bool) {
 		case <-stop:
 			log.Print("Stopped health pings")
 			return
-			break
 		case <-tick:
 		}
 	}

--- a/pkg/gameservers/helper_test.go
+++ b/pkg/gameservers/helper_test.go
@@ -144,7 +144,7 @@ func testHTTPHealth(t *testing.T, url string, expectedResponse string, expectedS
 	err := wait.PollImmediate(time.Second, 20*time.Second, func() (done bool, err error) {
 		resp, err := http.Get(url)
 		if err != nil {
-			logrus.WithError(err).Error("Error connecting to %v", url)
+			logrus.WithError(err).Error("Error connecting to ", url)
 			return false, nil
 		}
 


### PR DESCRIPTION
```
$ go test ./...
(ok)
$ go vet ./...
examples/simple-udp/server/main.go:110: unreachable code
exit status 1
pkg/client/clientset/versioned/fake/clientset_generated.go:45: literal copies lock value from fakePtr: agones.dev/agones/vendor/k8s.io/client-go/testing.Fake
exit status 1
pkg/gameservers/helper_test.go:147: possible formatting directive in Error call
exit status 1
```

Files edit

```
$ go test ./...
(ok)
$ go vet ./...
pkg/client/clientset/versioned/fake/clientset_generated.go:45: literal copies lock value from fakePtr: agones.dev/agones/vendor/k8s.io/client-go/testing.Fake
exit status 1
```