### PR TITLE
Refactor of workerqueue health testing

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -109,7 +109,7 @@ func NewController(
 	c.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "gameserver-controller"})
 
 	c.workerqueue = workerqueue.NewWorkerQueue(c.syncGameServer, c.logger, stable.GroupName+".GameServerController")
-	health.AddLivenessCheck("game-server-worker-queue", healthcheck.Check(c.workerqueue.Healthy))
+	health.AddLivenessCheck("gameserver-workerqueue", healthcheck.Check(c.workerqueue.Healthy))
 
 	wh.AddHandler("/mutate", stablev1alpha1.Kind("GameServer"), admv1beta1.Create, c.creationMutationHandler)
 	wh.AddHandler("/validate", stablev1alpha1.Kind("GameServer"), admv1beta1.Create, c.creationValidationHandler)

--- a/pkg/gameservers/helper_test.go
+++ b/pkg/gameservers/helper_test.go
@@ -16,12 +16,11 @@ package gameservers
 
 import (
 	"context"
-	"time"
-
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	agonesfake "agones.dev/agones/pkg/client/clientset/versioned/fake"

--- a/pkg/util/workerqueue/workerqueue_test.go
+++ b/pkg/util/workerqueue/workerqueue_test.go
@@ -18,12 +18,20 @@ import (
 	"testing"
 	"time"
 
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/heptiolabs/healthcheck"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 )
 
 func TestWorkerQueueRun(t *testing.T) {
+	t.Parallel()
+
 	received := make(chan string)
 	defer close(received)
 
@@ -56,6 +64,8 @@ func TestWorkerQueueRun(t *testing.T) {
 }
 
 func TestWorkerQueueHealthy(t *testing.T) {
+	t.Parallel()
+
 	done := make(chan struct{})
 	handler := func(string) error {
 		<-done
@@ -80,4 +90,49 @@ func TestWorkerQueueHealthy(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	assert.Equal(t, 0, wq.RunCount())
 	assert.EqualError(t, wq.Healthy(), "want 1 worker goroutine(s), got 0")
+}
+
+func TestWorkQueueHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	health := healthcheck.NewHandler()
+	handler := func(string) error {
+		return nil
+	}
+	wq := NewWorkerQueue(handler, logrus.WithField("source", "test"), "test")
+	health.AddLivenessCheck("test", wq.Healthy)
+
+	server := httptest.NewServer(health)
+	defer server.Close()
+
+	stop := make(chan struct{})
+	go wq.Run(1, stop)
+
+	url := server.URL + "/live"
+
+	f := func(t *testing.T, url string, status int) {
+		resp, err := http.Get(url)
+		assert.Nil(t, err)
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.Nil(t, err)
+		assert.Equal(t, status, resp.StatusCode)
+		assert.Equal(t, []byte("{}\n"), body)
+	}
+
+	f(t, url, http.StatusOK)
+
+	close(stop)
+	// closing can take a short while
+	err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
+		rc := wq.RunCount()
+		logrus.WithField("runcount", rc).Info("Checking run count")
+		return rc == 0, nil
+	})
+	assert.Nil(t, err)
+
+	// gate
+	assert.Error(t, wq.Healthy())
+	f(t, url, http.StatusServiceUnavailable)
 }


### PR DESCRIPTION
- Moved the health check testing out of the gameserver controller, into the workerqueue test as the health check will be in place in multiple controllers
- Added the use of the `httptest` package, so we can run this test in parralel
- Updated more tests to be parralel.