### PR TITLE
Centralise utilities for testing controllers

### DIFF
--- a/pkg/gameservers/helper_test.go
+++ b/pkg/gameservers/helper_test.go
@@ -23,62 +23,13 @@ import (
 	"time"
 
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
-	agonesfake "agones.dev/agones/pkg/client/clientset/versioned/fake"
-	"agones.dev/agones/pkg/client/informers/externalversions"
 	"agones.dev/agones/pkg/sdk"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 	corev1 "k8s.io/api/core/v1"
-	extfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/informers"
-	kubefake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 )
-
-// holder for all my fakes and mocks
-type mocks struct {
-	kubeClient             *kubefake.Clientset
-	kubeInformationFactory informers.SharedInformerFactory
-	extClient              *extfake.Clientset
-	agonesClient           *agonesfake.Clientset
-	agonesInformerFactory  externalversions.SharedInformerFactory
-	fakeRecorder           *record.FakeRecorder
-}
-
-func newMocks() mocks {
-	kubeClient := &kubefake.Clientset{}
-	kubeInformationFactory := informers.NewSharedInformerFactory(kubeClient, 30*time.Second)
-	extClient := &extfake.Clientset{}
-	agonesClient := &agonesfake.Clientset{}
-	agonesInformerFactory := externalversions.NewSharedInformerFactory(agonesClient, 30*time.Second)
-	m := mocks{
-		kubeClient:             kubeClient,
-		kubeInformationFactory: kubeInformationFactory,
-		extClient:              extClient,
-		agonesClient:           agonesClient,
-		agonesInformerFactory:  agonesInformerFactory,
-		fakeRecorder:           record.NewFakeRecorder(10),
-	}
-	return m
-}
-
-func startInformers(mocks mocks, sync ...cache.InformerSynced) (<-chan struct{}, context.CancelFunc) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	stop := ctx.Done()
-
-	mocks.kubeInformationFactory.Start(stop)
-	mocks.agonesInformerFactory.Start(stop)
-
-	logrus.Info("Wait for cache sync")
-	if !cache.WaitForCacheSync(stop, sync...) {
-		panic("Cache never synced")
-	}
-
-	return stop, cancel
-}
 
 func newSingleContainerSpec() v1alpha1.GameServerSpec {
 	return v1alpha1.GameServerSpec{

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -27,6 +27,7 @@ import (
 	"agones.dev/agones/pkg/util/runtime"
 	"agones.dev/agones/pkg/util/webhooks"
 	"agones.dev/agones/pkg/util/workerqueue"
+	"github.com/heptiolabs/healthcheck"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	admv1beta1 "k8s.io/api/admission/v1beta1"
@@ -41,7 +42,6 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"github.com/heptiolabs/healthcheck"
 )
 
 var (

--- a/pkg/testing/doc.go
+++ b/pkg/testing/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testing is for project wide testing utilities.
+package testing


### PR DESCRIPTION
Found myself repeating the same test setup when I started doing the Fleet controllers, so moved this
into a single location (`pkg/testing`) to make it easier to reuse.