### PR TITLE
Windows eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-* text=auto
+# See https://github.com/golang/go/issues/9281
+* -text


### PR DESCRIPTION
Treat all files in the repo as binary, with no git magic updating line endings. Based on work in golang.org/issue/9281