### PR TITLE
Status > AllocatedReplicas on Fleets & GameServers

### DIFF
--- a/pkg/apis/stable/v1alpha1/fleet.go
+++ b/pkg/apis/stable/v1alpha1/fleet.go
@@ -62,6 +62,8 @@ type FleetStatus struct {
 	Replicas int32 `json:"replicas"`
 	// ReadyReplicas are the number of Ready GameServer replicas
 	ReadyReplicas int32 `json:"readyReplicas"`
+	// AllocatedReplicas are the number of Allocated GameServer replicas
+	AllocatedReplicas int32 `json:"allocatedReplicas"`
 }
 
 // GameServerSet returns a single GameServerSet for this Fleet definition

--- a/pkg/apis/stable/v1alpha1/gameserverset.go
+++ b/pkg/apis/stable/v1alpha1/gameserverset.go
@@ -66,6 +66,8 @@ type GameServerSetStatus struct {
 	Replicas int32 `json:"replicas"`
 	// ReadyReplicas are the number of Ready GameServer replicas
 	ReadyReplicas int32 `json:"readyReplicas"`
+	// AllocatedReplicas are the number of Allocated GameServer replicas
+	AllocatedReplicas int32 `json:"allocatedReplicas"`
 }
 
 // ValidateUpdate validates when updates occur. The argument

--- a/pkg/fleetallocation/controller_test.go
+++ b/pkg/fleetallocation/controller_test.go
@@ -15,22 +15,23 @@
 package fleetallocation
 
 import (
-	"testing"
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"testing"
+
+	"sync"
 
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	agtesting "agones.dev/agones/pkg/testing"
 	"agones.dev/agones/pkg/util/webhooks"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	admv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	k8stesting "k8s.io/client-go/testing"
-	"sync"
-	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -219,10 +219,12 @@ func (c *Controller) updateFleetStatus(fleet *stablev1alpha1.Fleet) error {
 	fCopy := fleet.DeepCopy()
 	fCopy.Status.Replicas = 0
 	fCopy.Status.ReadyReplicas = 0
+	fCopy.Status.AllocatedReplicas = 0
 
 	for _, gsSet := range list {
 		fCopy.Status.Replicas += gsSet.Status.Replicas
 		fCopy.Status.ReadyReplicas += gsSet.Status.ReadyReplicas
+		fCopy.Status.AllocatedReplicas += gsSet.Status.AllocatedReplicas
 	}
 
 	_, err = c.fleetGetter.Fleets(fCopy.Namespace).Update(fCopy)

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -207,11 +207,13 @@ func TestControllerUpdateFleetStatus(t *testing.T) {
 	gsSet1.ObjectMeta.Name = "gsSet1"
 	gsSet1.Status.Replicas = 3
 	gsSet1.Status.ReadyReplicas = 2
+	gsSet1.Status.AllocatedReplicas = 1
 
 	gsSet2 := fleet.GameServerSet()
 	gsSet2.ObjectMeta.Name = "gsSet2"
 	gsSet2.Status.Replicas = 5
 	gsSet2.Status.ReadyReplicas = 5
+	gsSet2.Status.AllocatedReplicas = 2
 
 	m.AgonesClient.AddReactor("list", "gameserversets",
 		func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -227,6 +229,7 @@ func TestControllerUpdateFleetStatus(t *testing.T) {
 
 			assert.Equal(t, gsSet1.Status.Replicas+gsSet2.Status.Replicas, fleet.Status.Replicas)
 			assert.Equal(t, gsSet1.Status.ReadyReplicas+gsSet2.Status.ReadyReplicas, fleet.Status.ReadyReplicas)
+			assert.Equal(t, gsSet1.Status.AllocatedReplicas+gsSet2.Status.AllocatedReplicas, fleet.Status.AllocatedReplicas)
 			return true, fleet, nil
 		})
 

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -317,13 +317,21 @@ func (c *Controller) syncLessGameSevers(gsSet *stablev1alpha1.GameServerSet, lis
 // syncGameServerSetState synchronises the GameServerSet State with active GameServer counts
 func (c *Controller) syncGameServerSetState(gsSet *stablev1alpha1.GameServerSet, list []*stablev1alpha1.GameServer) error {
 	rc := int32(0)
+	ac := int32(0)
 	for _, gs := range list {
-		if gs.Status.State == stablev1alpha1.Ready {
+		switch gs.Status.State {
+		case stablev1alpha1.Ready:
 			rc++
+		case stablev1alpha1.Allocated:
+			ac++
 		}
 	}
 
-	status := stablev1alpha1.GameServerSetStatus{Replicas: int32(len(list)), ReadyReplicas: rc}
+	status := stablev1alpha1.GameServerSetStatus{
+		Replicas:          int32(len(list)),
+		ReadyReplicas:     rc,
+		AllocatedReplicas: ac,
+	}
 	if gsSet.Status != status {
 		gsSetCopy := gsSet.DeepCopy()
 		gsSetCopy.Status = status

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -350,6 +350,7 @@ func TestControllerSyncGameServerSetState(t *testing.T) {
 
 			assert.Equal(t, int32(1), gsSet.Status.Replicas)
 			assert.Equal(t, int32(1), gsSet.Status.ReadyReplicas)
+			assert.Equal(t, int32(0), gsSet.Status.AllocatedReplicas)
 
 			return true, nil, nil
 		})
@@ -370,8 +371,9 @@ func TestControllerSyncGameServerSetState(t *testing.T) {
 			ua := action.(k8stesting.UpdateAction)
 			gsSet := ua.GetObject().(*v1alpha1.GameServerSet)
 
-			assert.Equal(t, int32(6), gsSet.Status.Replicas)
+			assert.Equal(t, int32(8), gsSet.Status.Replicas)
 			assert.Equal(t, int32(1), gsSet.Status.ReadyReplicas)
+			assert.Equal(t, int32(2), gsSet.Status.AllocatedReplicas)
 
 			return true, nil, nil
 		})
@@ -383,6 +385,8 @@ func TestControllerSyncGameServerSetState(t *testing.T) {
 			{Status: v1alpha1.GameServerStatus{State: v1alpha1.PortAllocation}},
 			{Status: v1alpha1.GameServerStatus{State: v1alpha1.Error}},
 			{Status: v1alpha1.GameServerStatus{State: v1alpha1.Creating}},
+			{Status: v1alpha1.GameServerStatus{State: v1alpha1.Allocated}},
+			{Status: v1alpha1.GameServerStatus{State: v1alpha1.Allocated}},
 		}
 		err := c.syncGameServerSetState(gsSet, list)
 		assert.Nil(t, err)


### PR DESCRIPTION
Track the number of allocated GameServer replicas on both GameServerSets and Fleets.

This is useful both from a statistical tracking perspective, but also when doing updates to Fleets, as it makes it easy to determine if a GameServerSet can be deleted or not (AllocatedReplicas == 0).

Example:
```
root@7662dad831f0:/go/src/agones.dev/agones# kubectl describe flt
Name:         simple-udp
Namespace:    default
Labels:       <none>
Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"stable.agones.dev/v1alpha1","kind":"Fleet","metadata":{"annotations":{},"name":"simple-udp","namespace":"default"},"spec":{"replicas":2,...
API Version:  stable.agones.dev/v1alpha1
Kind:         Fleet
Metadata:
  Cluster Name:
  Creation Timestamp:  2018-05-02T19:41:38Z
  Generation:          0
  Resource Version:    214268
  Self Link:           /apis/stable.agones.dev/v1alpha1/namespaces/default/fleets/simple-udp
  UID:                 d4aca215-4e40-11e8-a44a-42010a8a0197
Spec:
  Replicas:  2
  Template:
    Metadata:
      Creation Timestamp:  <nil>
    Spec:
      Container Port:  7654
      Health:
      Template:
        Metadata:
          Creation Timestamp:  <nil>
        Spec:
          Containers:
            Image:  gcr.io/agones-images/udp-server:0.1
            Name:   simple-udp
            Resources:
Status:
  Allocated Replicas:  1 # <=== look here! 😄
  Ready Replicas:      1
  Replicas:            2
Events:
  Type    Reason                 Age   From              Message
  ----    ------                 ----  ----              -------
  Normal  CreatingGameServerSet  13s   fleet-controller  Created GameServerSet simple-udp-qqmjq
```