### PR TITLE
Fixes for GKE issues with install/quickstart

### DIFF
--- a/docs/create_gameserver.md
+++ b/docs/create_gameserver.md
@@ -4,8 +4,8 @@ This guide covers how you can quickly get started using Agones to create GameSer
 
 ## Objectives
 
-- Create a GameServer in Kubernetes using Agones custom ressource.
-- Get informations about the GameServer such as IP address, port and state.
+- Create a GameServer in Kubernetes using Agones custom resource.
+- Get information about the GameServer such as IP address, port and state.
 - Connect to the GameServer.
 
 ## Prerequisites
@@ -133,7 +133,17 @@ This should ouput your Game Server IP address and port. (eg `10.130.65.208:7936`
 
 ### 3. Connect to the GameServer
 
+> NOTE: if you have Agones installed on Google Kubernetes Engine, and are using
+  Cloud Shell for your terminal, UDP is blocked. For this step, we recommend
+  SSH'ing into a running VM in your project, such as a Kubernetes node.
+  You can click the 'SSH' button on the [Google Compute Engine Instances](https://console.cloud.google.com/compute/instances)
+  page to do this. 
+
 You can now communicate with the Game Server :
+
+> NOTE: if you do not have netcat installed 
+  (i.e. you get a response of `nc: command not found`), 
+  you can install netcat by running `sudo apt install netcat`.
 
 ```
 nc -u {IP} {PORT}

--- a/docs/installing_agones.md
+++ b/docs/installing_agones.md
@@ -89,7 +89,7 @@ To install `gcloud` and `kubectl`, perform the following steps:
 A [cluster][cluster] consists of at least one *cluster master* machine and multiple worker machines called *nodes*: [Compute Engine virtual machine][vms] instances that run the Kubernetes processes necessary to make them part of the cluster.
 
 ```bash
-gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.9.2-gke.1 \
+gcloud container clusters create [CLUSTER_NAME] --cluster-version=1.9 \
   --no-enable-legacy-authorization \
   --tags=game-server \
   --enable-basic-auth \


### PR DESCRIPTION
Resolving some issues that new users found when trying to run through the quickstart with GKE and Cloud Shell.

Apparently Cloud Shell blocks UDP traffic, so dropped in a workaround.