### PR TITLE
Don't allow allocation of Deleted GameServers

### DIFF
--- a/pkg/fleetallocation/controller.go
+++ b/pkg/fleetallocation/controller.go
@@ -269,7 +269,7 @@ func (c *Controller) allocate(f *stablev1alpha1.Fleet) (*stablev1alpha1.GameServ
 	}
 
 	for _, gs := range gsList {
-		if gs.Status.State == stablev1alpha1.Ready {
+		if gs.Status.State == stablev1alpha1.Ready && gs.ObjectMeta.DeletionTimestamp.IsZero() {
 			allocation = gs
 			break
 		}

--- a/pkg/fleetallocation/controller_test.go
+++ b/pkg/fleetallocation/controller_test.go
@@ -142,8 +142,10 @@ func TestControllerMutationValidationHandler(t *testing.T) {
 }
 
 func TestControllerAllocate(t *testing.T) {
-	f, gsSet, gsList := defaultFixtures(3)
+	f, gsSet, gsList := defaultFixtures(4)
 	c, m := newFakeController()
+	n := metav1.Now()
+	gsList[3].ObjectMeta.DeletionTimestamp = &n
 
 	m.AgonesClient.AddReactor("list", "fleets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, &v1alpha1.FleetList{Items: []v1alpha1.Fleet{*f}}, nil


### PR DESCRIPTION
Allocating GameServers that are in the process of being deleted would be bad, so let's not do this.