### PR TITLE
Release process documentation

### DIFF
--- a/docs/governance/release_process.md
+++ b/docs/governance/release_process.md
@@ -1,0 +1,32 @@
+# Agones Release Management
+
+# Release Cadence
+
+- Versioned releases will occur every 6 weeks
+- Releases occur on a Tuesday.
+- 5 week development cycle, at the end of a which a Release Candidate (RC) will be released with the contents of master.
+- For the next week, the project is in "feature freeze" - i.e. only bug and documentation (.md and examples) fixes during this time.
+  - Any new PRs that are submitted during feature freeze, will be tagged with the label `merge-after-release` 
+    to delineate that they should only be merged after the full release is complete. 
+- At the end of the RC week, the complete version release will occur.
+
+## Release Calendar
+
+> Release Calendar forthcoming once the 0.2 release is complete, when the scheduled release cadence will start.
+
+# Release Process
+
+1. Create a Release Issue from the [release issue template](./templates/release_issue.md).
+1. Label the issue `release`, and attach it to the milestone that it matches.
+1. Complete all items in the release issue checklist.
+1. Close the release issue.
+
+# Hot fix Process
+ 
+1. Hotfixes will occur as needed, to be determined by those will commit access on the repository.
+1. Create a Release Issue from the [release issue template](./templates/release_issue.md).
+1. Label the issue `release`, and attach it to the next upcoming milestone.
+1. Complete all items in the release issue checklist.
+1. Close the release issue.
+
+

--- a/docs/governance/templates/release.md
+++ b/docs/governance/templates/release.md
@@ -1,0 +1,20 @@
+# v{version}
+
+This is the {version} release of Agones.
+
+Check the [README](https://github.com/GoogleCloudPlatform/agones/tree/{release-branch}) for details on features, installation and usage.
+
+Features in this release:
+
+{ insert enhancements from the changelog }
+
+See [CHANGELOG.md](https://github.com/GoogleCloudPlatform/agones/blob/{release-branch}/CHANGELOG.md) for more details on changes.
+
+This software is currently alpha, and subject to change. Not to be used in production systems.
+
+Images available with this release:
+- [gcr.io/agones-images/agones-controller:{version}](https://gcr.io/agones-images/agones-controller:{version})
+- [gcr.io/agones-images/agones-sdk:{version}](https://gcr.io/agones-images/agones-sdk:{version})
+- [gcr.io/agones-images/cpp-simple-server:{example-version}](https://gcr.io/agones-images/cpp-simple-server:{example-version})
+- [gcr.io/agones-images/udp-server:{example-version}](https://gcr.io/agones-images/udp-server:{example-version})
+- [gcr.io/agones-images/xonotic-example:{example-version}](https://gcr.io/agones-images/xonotic-example:{example-version})

--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -1,0 +1,29 @@
+# Release {version}
+
+<!--
+This is the release issue template. Make a copy of the markdown in this page
+and copy it into a release issue. Fill in relevent values, found inside {}
+!-->
+
+- [ ] Review closed issues have appropriate tags.
+- [ ] Review closed issues have been applied to the current milestone.
+- [ ] Ensure the next version milestone is created.
+- [ ] Any issues in the current milestone that are not closed, move to next milestone.
+- [ ] Run `make gen-changelog` to generate the CHANGELOG.md
+- [ ] Ensure the [helm `tag` value][values] is correct (should be the {version} if a full release, {version}.rc if release candidate)
+- [ ] Create PR with these changes, and merge them with approval
+- [ ] If full release, close the current milestone.
+- [ ] Confirm local git remote `upstream` points at `git@github.com:GoogleCloudPlatform/agones.git`
+- [ ] Run `git checkout master && git reset --hard upstream/master` to ensure your code is in line with upstream  (unless this is a hotfix, then do the same, but for the the release branch)
+- [ ] Run `make do-release`. (if release candidate `make do-release RELEASE_VERSION={version}.rc`) to create and push the docker images.
+- [ ] Create a release with the [release template][release-template]
+  - [ ] Make a `tag` with the release version.
+  - [ ] Attach all assets found in the `release` folder to the release.
+- [ ] If full release, then increment the `base_version` in [`build/Makefile`][build-makefile]
+- [ ] Ensure the [the helm `tag` value][values] is the same at the above `base_version`
+- [ ] Create PR with these changes, and merge them with approval
+- [ ] Close this issue. *Congratulations!* - the release is now complete! :tada: :clap: :smile: :+1: 
+
+[values]: https://github.com/GoogleCloudPlatform/agones/blob/master/install/helm/agones/values.yaml#L33
+[release-template]: https://github.com/GoogleCloudPlatform/agones/blob/master/docs/governance/templates/release.md
+[build-makefile]: https://github.com/GoogleCloudPlatform/agones/blob/master/build/Makefile


### PR DESCRIPTION
Outlines a 6 week release process, with included templates for a release issue and github release.

The `make do-release` will need to be updated once this has been approved, and `make gen-changelog` will also need to implemented.

Closes #203