### PR TITLE
Release steps of archiving installation resources and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more details on why this project was written, read the
 
 ## Installation
 
-Follow [these instructions](./docs/installing_agones.md) to create a cluster on Google Kubernetes Engine (GKE) or Minikube, and install Agones.
+Follow [these instructions](install/README.md) to create a cluster on Google Kubernetes Engine (GKE) or Minikube, and install Agones.
 
 ## Usage
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -259,7 +259,7 @@ do-release:
 	cp $(agones_path)/cmd/sdk-server/bin/agonessdk-server-$(RELEASE_VERSION).zip $(agones_path)/release
 	cp $(agones_path)/sdks/cpp/bin/agonessdk-$(RELEASE_VERSION)-runtime-linux-arch_64.tar.gz $(agones_path)/release
 	cp $(agones_path)/sdks/cpp/bin/agonessdk-$(RELEASE_VERSION)-dev-linux-arch_64.tar.gz $(agones_path)/release
-	zip --junk-paths $(agones_path)/release/agones-$(RELEASE_VERSION).zip $(agones_path)/README.md $(agones_path)/install.yaml $(agones_path)/LICENSE
+	cd $(agones_path) &&  zip -r ./release/agones-install-$(RELEASE_VERSION).zip ./README.md ./install ./LICENSE
 	$(MAKE) gcloud-auth-docker push VERSION=$(RELEASE_VERSION)
 	git push -u origin release-$(RELEASE_VERSION)
 	@echo "Now go make the $(RELEASE_VERSION) release on Github!"

--- a/docs/create_fleet.md
+++ b/docs/create_fleet.md
@@ -16,7 +16,7 @@ The following prerequisites are required to create a GameServer:
 
 >NOTE: Agones required Kubernetes versions 1.9+ to run. See the [cluster requirements](../README.md#requirements) for more details.
 
-If you don't have a Kubernetes cluster you can follow [these instructions](installing_agones.md) to create a cluster on Google Kubernetes Engine (GKE) or Minikube, and install Agones.
+If you don't have a Kubernetes cluster you can follow [these instructions](../install/README.md) to create a cluster on Google Kubernetes Engine (GKE) or Minikube, and install Agones.
 
 For the purpose of this guide we're going to use the [simple-udp](../examples/simple-udp/) example as the GameServer container. This example is very simple UDP server written in Go. Don't hesitate to look at the code of this example for more information.
 

--- a/docs/create_gameserver.md
+++ b/docs/create_gameserver.md
@@ -19,7 +19,7 @@ The following prerequisites are required to create a GameServer :
 
 >NOTE: Agones required Kubernetes versions 1.9 with role-based access controls (RBAC) and MutatingAdmissionWebhook features activated. To check your version, enter `kubectl version`.
 
-If you don't have a Kubernetes cluster you can follow [these instructions](installing_agones.md) to create a cluster on Google Kubernetes Engine (GKE) or Minikube, and install Agones.
+If you don't have a Kubernetes cluster you can follow [these instructions](../install/README.md) to create a cluster on Google Kubernetes Engine (GKE) or Minikube, and install Agones.
 
 For the purpose of this guide we're going to use the [simple-udp](../examples/simple-udp/) example as the GameServer container. This example is very simple UDP server written in Go. Don't hesitate to look at the code of this example for more information.
 

--- a/install/README.md
+++ b/install/README.md
@@ -203,7 +203,7 @@ Also, we can install Agones using [Helm][helm] package manager. If you want more
 options see the [Helm installation guide for Agones][agones-install-guide]
 
 [helm]: https://docs.helm.sh
-[agones-install-guide]: ../install/helm/README.md
+[agones-install-guide]: helm/README.md
 
 ## Confirming Agones started successfully
 

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -102,4 +102,4 @@ $ helm install --name my-release -f values.yaml agones
 
 ## Confirm Agones is running
 
-To confirm Agones is up and running, [go to the next section](../../docs/installing_agones.md#confirming-agones-started-successfully)
+To confirm Agones is up and running, [go to the next section](../README.md#confirming-agones-started-successfully)


### PR DESCRIPTION
Moved the installation documentation into the `install` directory and on release, zip up the install instructions and yaml files such that users can download and use them.