### PR TITLE
Archive C++ src on build and release

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -262,6 +262,7 @@ do-release:
 	cp $(agones_path)/cmd/sdk-server/bin/agonessdk-server-$(RELEASE_VERSION).zip $(agones_path)/release
 	cp $(agones_path)/sdks/cpp/bin/agonessdk-$(RELEASE_VERSION)-runtime-linux-arch_64.tar.gz $(agones_path)/release
 	cp $(agones_path)/sdks/cpp/bin/agonessdk-$(RELEASE_VERSION)-dev-linux-arch_64.tar.gz $(agones_path)/release
+	cp $(agones_path)/sdks/cpp/bin/agonessdk-$(RELEASE_VERSION)-src.zip $(agones_path)/release
 	cd $(agones_path) &&  zip -r ./release/agones-install-$(RELEASE_VERSION).zip ./README.md ./install ./LICENSE
 	$(MAKE) gcloud-auth-docker push VERSION=$(RELEASE_VERSION)
 	git push -u upstream release-$(RELEASE_VERSION)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,6 +34,9 @@ steps:
   dir: "sdks/cpp/bin"
   args: ['cp', '*.tar.gz', 'gs://agones-artifacts/cpp-sdk']
 - name: 'gcr.io/cloud-builders/gsutil'
+  dir: "sdks/cpp/bin"
+  args: ['cp', '*.zip', 'gs://agones-artifacts/cpp-sdk']
+- name: 'gcr.io/cloud-builders/gsutil'
   dir: "cmd/sdk-server/bin"
   args: ['cp', '*.zip', 'gs://agones-artifacts/sdk-server']
 - name: "make-docker"

--- a/sdks/cpp/Makefile
+++ b/sdks/cpp/Makefile
@@ -62,6 +62,7 @@ ensure-bin:
 # build dev and runtime tarballs
 archive: VERSION = "dev"
 archive:
+	-rm $(build_path)/bin/agonessdk-$(VERSION)-src.zip
 	-rm $(build_path)/bin/agonessdk-$(VERSION)-dev-linux-arch_64.tar.gz
 	-rm $(build_path)/bin/agonessdk-$(VERSION)-runtime-linux-arch_64.tar.gz
 	cp /usr/local/lib/libgrpc.so.5 $(build_path)/bin/
@@ -71,6 +72,7 @@ archive:
 	cp /usr/local/lib/libgrpc_unsecure.so.5 $(build_path)/bin/
 	cd $(build_path)/bin && tar cvf agonessdk-$(VERSION)-runtime-linux-arch_64.tar.gz *
 	cd /usr/local && tar cvf $(build_path)/bin/agonessdk-$(VERSION)-dev-linux-arch_64.tar.gz lib include
+	cd $(build_path) && zip ./bin/agonessdk-$(VERSION)-src.zip Makefile *.md *.cc *.h
 
 clean:
 	-rm -r $(build_path)/bin


### PR DESCRIPTION
Previously we only kept the C++ build artifacts for each build and release, which (if my understanding of C++ is correct - which I don't think it was a while ago) is relatively useless, unless you are on the same OS, compiler etc.

So here we are taking a zip of the src, and keeping it, pushing it to Cloud Storage when a PR is made, and also making sure it's in the releases folder on release.