### PR TITLE
fix podspec template broken link to documentation

### DIFF
--- a/docs/gameserver_spec.md
+++ b/docs/gameserver_spec.md
@@ -42,4 +42,4 @@ The `spec` field is the actual GameServer specification and it is composed as fo
 - `containerPort` the port that is being opened on the game server process, this is a required field.
 - `protocol` the protocol being used. Defaults to UDP. TCP is the only other option.
 - `health` to track the overall healthy state of the GameServer, more information available in the [health check documentation](./health_checking.md).
-- `template` the [pod spec template](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#pod-v1-core) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.
+- `template` the [pod spec template](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podtemplatespec-v1-core) to run your GameServer containers, [see](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates) for more information.


### PR DESCRIPTION
I was reading the documentation to see if we support `secrets` and found a broken link !