### PR TITLE
install.yaml now installs by default in agones-system

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -264,6 +264,7 @@ We can install Agones to the cluster using the
 [install.yaml](https://github.com/GoogleCloudPlatform/agones/blob/release-0.1/install.yaml) file.
 
 ```bash
+kubectl create namespace agones-system
 kubectl apply -f https://github.com/GoogleCloudPlatform/agones/raw/release-0.2.0/install/yaml/install.yaml
 ```
 

--- a/install/helm/agones/templates/admissionregistration.yaml
+++ b/install/helm/agones/templates/admissionregistration.yaml
@@ -93,6 +93,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "agones.fullname" . }}-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: agones-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     component: controller
     app: {{ template "agones.name" . }}

--- a/install/helm/agones/templates/service.yaml
+++ b/install/helm/agones/templates/service.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: agones-controller-service
+  namespace: {{ .Release.Namespace }}
   labels:
     component: controller
     app: {{ template "agones.name" . }}

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.agones.serviceaccount.controller }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
     chart: {{ template "agones.chart" . }}
@@ -27,6 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.agones.serviceaccount.controller }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
     chart: {{ template "agones.chart" . }}
@@ -56,6 +58,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.agones.serviceaccount.controller }}-access
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
     chart: {{ template "agones.chart" . }}

--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -29,6 +29,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.agones.serviceaccount.sdk }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "agones.name" . }}
     chart: {{ template "agones.chart" . }}

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: agones-controller
+  namespace: agones-system
   labels:
     app: agones
     chart: agones-0.3.0
@@ -28,6 +29,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: agones-controller
+  namespace: agones-system
   labels:
     app: agones
     chart: agones-0.3.0
@@ -57,6 +59,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: agones-controller-access
+  namespace: agones-system
   labels:
     app: agones
     chart: agones-0.3.0
@@ -101,6 +104,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: agones-sdk
+  namespace: agones-system
   labels:
     app: agones
     chart: agones-0.3.0
@@ -613,6 +617,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: agones-controller-service
+  namespace: agones-system
   labels:
     component: controller
     app: agones
@@ -645,6 +650,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: agones-controller
+  namespace: agones-system
   labels:
     component: controller
     app: agones
@@ -781,6 +787,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: agones-manual-cert
+  namespace: agones-system
   labels:
     app: agones-manual
     chart: "agones-0.3.0"


### PR DESCRIPTION
This should fix the issue where the install.yaml now installs by default in the default namespace.

I've added the namespace everywhere in helm so when you use template it is explicitly set in every files and you can use kubectl apply on the resulting file without worrying about namespaces. In normal case this is not required but since we use template to generate the install.yaml it is better to do so. (This comes from the fact that the yaml works accross multiple namespace)

Unfortunately  you need to create the namespace before and I've update the documentation accordingly and you can't use another namespace when using install.yaml unless you edit the file.

I think this is fine since if you want a quick testing setup you use the install.yaml but if you want more fine grained one, then helm is the way to go. (after all we're using a default values files for the install so it's already opinionated.)

Let me know WDYT.

PS: I've tested the quickstart on GKE with this new way to install and everything worked.