### PR TITLE
SDK `GameServer()` function for retrieving backing GameServer configuration

### DIFF
--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -12,6 +12,8 @@ and copy it into a release issue. Fill in relevent values, found inside {}
 - [ ] Run `make gen-changelog` to generate the CHANGELOG.md (if release candidate `make gen-changelog RELEASE_VERSION={version}.rc`)
 - [ ] Ensure the [helm `tag` value][values] is correct (should be the {version} if a full release, {version}.rc if release candidate)
 - [ ] Run `make gen-install`
+- [ ] Ensure all example images exist on gcr.io/agones-images
+- [ ] If full release, update documentation with updated example images tags
 - [ ] If RC release, update all ⚠️⚠️⚠️ warnings to: "**This is currently a release candidate feature**"
 - [ ] If full release, remove all instances of "⚠️⚠️⚠️ **This is currently a development feature and has not been released** ⚠️⚠️⚠️"
 - [ ] If full release, update install docs with the new release version

--- a/docs/sdk_rest_api.md
+++ b/docs/sdk_rest_api.md
@@ -63,3 +63,46 @@ Call when the GameServer session is over and it's time to shut down
 ```bash
 $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:59358/shutdown
 ```
+
+### GameServer
+
+⚠️⚠️⚠️ **/gameserver is currently a development feature and has not been released** ⚠️⚠️⚠️
+
+Call when you want to retrieve the backing `GameServer` configuration details
+
+- Path: `/gameserver`
+- Method: `GET`
+
+```bash
+$ curl -H "Content-Type: application/json" -X GET http://localhost:59358/gameserver
+```
+
+Response:
+```json
+{
+    "object_meta": {
+        "name": "local",
+        "namespace": "default",
+        "uid": "1234",
+        "resource_version": "v1",
+        "generation": "1",
+        "creation_timestamp": "1531795395",
+        "annotations": {
+            "annotation": "true"
+        },
+        "labels": {
+            "islocal": "true"
+        }
+    },
+    "status": {
+        "state": "Ready",
+        "address": "127.0.0.1",
+        "ports": [
+            {
+                "name": "default",
+                "port": 7777
+            }
+        ]
+    }
+}
+```

--- a/examples/cpp-simple/Makefile
+++ b/examples/cpp-simple/Makefile
@@ -32,7 +32,7 @@ REPOSITORY = gcr.io/agones-images
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/cpp-simple-server:0.1
+server_tag = $(REPOSITORY)/cpp-simple-server:0.2
 
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___

--- a/examples/cpp-simple/fleet.yaml
+++ b/examples/cpp-simple/fleet.yaml
@@ -30,5 +30,5 @@ spec:
         spec:
           containers:
             - name: cpp-simple
-              image: gcr.io/agones-images/cpp-simple-server:0.1
+              image: gcr.io/agones-images/cpp-simple-server:0.2
               # imagePullPolicy: Always # add for development

--- a/examples/cpp-simple/gameserver.yaml
+++ b/examples/cpp-simple/gameserver.yaml
@@ -27,5 +27,5 @@ spec:
     spec:
       containers:
       - name: cpp-simple
-        image: gcr.io/agones-images/cpp-simple-server:0.1
+        image: gcr.io/agones-images/cpp-simple-server:0.2
         # imagePullPolicy: Always # add for development

--- a/examples/cpp-simple/server.cc
+++ b/examples/cpp-simple/server.cc
@@ -55,7 +55,19 @@ int main() {
         std::cout << "Could not run Ready(): "+ status.error_message() + ". Exiting!" << std::endl;
         return -1;
     }
+
     std::cout << "...marked Ready" << std::endl;
+
+    std::cout << "Getting GameServer details..." << std::endl;
+    stable::agones::dev::sdk::GameServer gameserver;
+    status = sdk->GameServer(&gameserver);
+
+    if (!status.ok()) {
+        std::cout << "Could not run GameServer(): "+ status.error_message() + ". Exiting!" << std::endl;
+        return -1;
+    }
+
+    std::cout << "GameServer name: " << gameserver.object_meta().name() << std::endl;
 
     for (int i = 0; i < 10; i++) {
         int time = i*10;

--- a/examples/simple-udp/Makefile
+++ b/examples/simple-udp/Makefile
@@ -27,7 +27,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/udp-server:0.1
+server_tag = $(REPOSITORY)/udp-server:0.2
 package = agones.dev/agones/examples/simple-udp
 
 #   _____                    _

--- a/examples/simple-udp/server/Dockerfile
+++ b/examples/simple-udp/server/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.7
 
-RUN adduser -D server    
+RUN adduser -D server
 
 COPY ./bin/server /home/server/server
     

--- a/examples/simple-udp/server/fleet.yaml
+++ b/examples/simple-udp/server/fleet.yaml
@@ -31,4 +31,4 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.1
+            image: gcr.io/agones-images/udp-server:0.2

--- a/examples/simple-udp/server/gameserver-legacy.yaml
+++ b/examples/simple-udp/server/gameserver-legacy.yaml
@@ -25,4 +25,4 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.1
+        image: gcr.io/agones-images/udp-server:0.2

--- a/examples/simple-udp/server/gameserver.yaml
+++ b/examples/simple-udp/server/gameserver.yaml
@@ -25,4 +25,4 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.1
+        image: gcr.io/agones-images/udp-server:0.2

--- a/examples/simple-udp/server/gameserverset.yaml
+++ b/examples/simple-udp/server/gameserverset.yaml
@@ -31,4 +31,4 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.1
+            image: gcr.io/agones-images/udp-server:0.2

--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -38,7 +38,7 @@ metadata:
 rules:
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
-  verbs: ["get", "update"]
+  verbs: ["list", "update"]
 ---
   {{- range .Values.gameservers.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -113,7 +113,7 @@ metadata:
 rules:
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
-  verbs: ["get", "update"]
+  verbs: ["list", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/gameservers/localsdk.go
+++ b/pkg/gameservers/localsdk.go
@@ -17,6 +17,8 @@ package gameservers
 import (
 	"io"
 
+	"time"
+
 	"agones.dev/agones/pkg/sdk"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -56,4 +58,28 @@ func (l *LocalSDKServer) Health(stream sdk.SDK_HealthServer) error {
 		}
 		logrus.Info("Health Ping Received!")
 	}
+}
+
+// GetGameServer returns a dummy game server.
+func (l *LocalSDKServer) GetGameServer(context.Context, *sdk.Empty) (*sdk.GameServer, error) {
+	logrus.Info("getting GameServer details")
+	gs := &sdk.GameServer{
+		ObjectMeta: &sdk.GameServer_ObjectMeta{
+			Name:              "local",
+			Namespace:         "default",
+			Uid:               "1234",
+			Generation:        1,
+			ResourceVersion:   "v1",
+			CreationTimestamp: time.Now().Unix(),
+			Labels:            map[string]string{"islocal": "true"},
+			Annotations:       map[string]string{"annotation": "true"},
+		},
+		Status: &sdk.GameServer_Status{
+			State:   "Ready",
+			Address: "127.0.0.1",
+			Ports:   []*sdk.GameServer_Status_Port{{Name: "default", Port: 7777}},
+		},
+	}
+
+	return gs, nil
 }

--- a/pkg/gameservers/portallocator_test.go
+++ b/pkg/gameservers/portallocator_test.go
@@ -16,10 +16,10 @@ package gameservers
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
-	"strconv"
 
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	agtesting "agones.dev/agones/pkg/testing"

--- a/pkg/sdk/sdk.pb.go
+++ b/pkg/sdk/sdk.pb.go
@@ -49,7 +49,7 @@ func (m *Empty) Reset()         { *m = Empty{} }
 func (m *Empty) String() string { return proto.CompactTextString(m) }
 func (*Empty) ProtoMessage()    {}
 func (*Empty) Descriptor() ([]byte, []int) {
-	return fileDescriptor_sdk_6230b133a8116e3a, []int{0}
+	return fileDescriptor_sdk_39d49c489951ac60, []int{0}
 }
 func (m *Empty) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Empty.Unmarshal(m, b)
@@ -69,8 +69,378 @@ func (m *Empty) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Empty proto.InternalMessageInfo
 
+// A GameServer Custom Resource Definition object
+// We will only export those resources that make the most
+// sense. Can always expand to more as needed.
+type GameServer struct {
+	ObjectMeta           *GameServer_ObjectMeta `protobuf:"bytes,1,opt,name=object_meta,json=objectMeta" json:"object_meta,omitempty"`
+	Spec                 *GameServer_Spec       `protobuf:"bytes,2,opt,name=spec" json:"spec,omitempty"`
+	Status               *GameServer_Status     `protobuf:"bytes,3,opt,name=status" json:"status,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
+	XXX_unrecognized     []byte                 `json:"-"`
+	XXX_sizecache        int32                  `json:"-"`
+}
+
+func (m *GameServer) Reset()         { *m = GameServer{} }
+func (m *GameServer) String() string { return proto.CompactTextString(m) }
+func (*GameServer) ProtoMessage()    {}
+func (*GameServer) Descriptor() ([]byte, []int) {
+	return fileDescriptor_sdk_39d49c489951ac60, []int{1}
+}
+func (m *GameServer) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GameServer.Unmarshal(m, b)
+}
+func (m *GameServer) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GameServer.Marshal(b, m, deterministic)
+}
+func (dst *GameServer) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GameServer.Merge(dst, src)
+}
+func (m *GameServer) XXX_Size() int {
+	return xxx_messageInfo_GameServer.Size(m)
+}
+func (m *GameServer) XXX_DiscardUnknown() {
+	xxx_messageInfo_GameServer.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GameServer proto.InternalMessageInfo
+
+func (m *GameServer) GetObjectMeta() *GameServer_ObjectMeta {
+	if m != nil {
+		return m.ObjectMeta
+	}
+	return nil
+}
+
+func (m *GameServer) GetSpec() *GameServer_Spec {
+	if m != nil {
+		return m.Spec
+	}
+	return nil
+}
+
+func (m *GameServer) GetStatus() *GameServer_Status {
+	if m != nil {
+		return m.Status
+	}
+	return nil
+}
+
+// representation of the K8s ObjectMeta resource
+type GameServer_ObjectMeta struct {
+	Name            string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Namespace       string `protobuf:"bytes,2,opt,name=namespace" json:"namespace,omitempty"`
+	Uid             string `protobuf:"bytes,3,opt,name=uid" json:"uid,omitempty"`
+	ResourceVersion string `protobuf:"bytes,4,opt,name=resource_version,json=resourceVersion" json:"resource_version,omitempty"`
+	Generation      int64  `protobuf:"varint,5,opt,name=generation" json:"generation,omitempty"`
+	// timestamp is in Epoch format, unit: seconds
+	CreationTimestamp int64 `protobuf:"varint,6,opt,name=creation_timestamp,json=creationTimestamp" json:"creation_timestamp,omitempty"`
+	// optional deletion timestamp in Epoch format, unit: seconds
+	DeletionTimestamp    int64             `protobuf:"varint,7,opt,name=deletion_timestamp,json=deletionTimestamp" json:"deletion_timestamp,omitempty"`
+	Annotations          map[string]string `protobuf:"bytes,8,rep,name=annotations" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels               map[string]string `protobuf:"bytes,9,rep,name=labels" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
+}
+
+func (m *GameServer_ObjectMeta) Reset()         { *m = GameServer_ObjectMeta{} }
+func (m *GameServer_ObjectMeta) String() string { return proto.CompactTextString(m) }
+func (*GameServer_ObjectMeta) ProtoMessage()    {}
+func (*GameServer_ObjectMeta) Descriptor() ([]byte, []int) {
+	return fileDescriptor_sdk_39d49c489951ac60, []int{1, 0}
+}
+func (m *GameServer_ObjectMeta) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GameServer_ObjectMeta.Unmarshal(m, b)
+}
+func (m *GameServer_ObjectMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GameServer_ObjectMeta.Marshal(b, m, deterministic)
+}
+func (dst *GameServer_ObjectMeta) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GameServer_ObjectMeta.Merge(dst, src)
+}
+func (m *GameServer_ObjectMeta) XXX_Size() int {
+	return xxx_messageInfo_GameServer_ObjectMeta.Size(m)
+}
+func (m *GameServer_ObjectMeta) XXX_DiscardUnknown() {
+	xxx_messageInfo_GameServer_ObjectMeta.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GameServer_ObjectMeta proto.InternalMessageInfo
+
+func (m *GameServer_ObjectMeta) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *GameServer_ObjectMeta) GetNamespace() string {
+	if m != nil {
+		return m.Namespace
+	}
+	return ""
+}
+
+func (m *GameServer_ObjectMeta) GetUid() string {
+	if m != nil {
+		return m.Uid
+	}
+	return ""
+}
+
+func (m *GameServer_ObjectMeta) GetResourceVersion() string {
+	if m != nil {
+		return m.ResourceVersion
+	}
+	return ""
+}
+
+func (m *GameServer_ObjectMeta) GetGeneration() int64 {
+	if m != nil {
+		return m.Generation
+	}
+	return 0
+}
+
+func (m *GameServer_ObjectMeta) GetCreationTimestamp() int64 {
+	if m != nil {
+		return m.CreationTimestamp
+	}
+	return 0
+}
+
+func (m *GameServer_ObjectMeta) GetDeletionTimestamp() int64 {
+	if m != nil {
+		return m.DeletionTimestamp
+	}
+	return 0
+}
+
+func (m *GameServer_ObjectMeta) GetAnnotations() map[string]string {
+	if m != nil {
+		return m.Annotations
+	}
+	return nil
+}
+
+func (m *GameServer_ObjectMeta) GetLabels() map[string]string {
+	if m != nil {
+		return m.Labels
+	}
+	return nil
+}
+
+type GameServer_Spec struct {
+	Health               *GameServer_Spec_Health `protobuf:"bytes,1,opt,name=health" json:"health,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
+	XXX_unrecognized     []byte                  `json:"-"`
+	XXX_sizecache        int32                   `json:"-"`
+}
+
+func (m *GameServer_Spec) Reset()         { *m = GameServer_Spec{} }
+func (m *GameServer_Spec) String() string { return proto.CompactTextString(m) }
+func (*GameServer_Spec) ProtoMessage()    {}
+func (*GameServer_Spec) Descriptor() ([]byte, []int) {
+	return fileDescriptor_sdk_39d49c489951ac60, []int{1, 1}
+}
+func (m *GameServer_Spec) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GameServer_Spec.Unmarshal(m, b)
+}
+func (m *GameServer_Spec) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GameServer_Spec.Marshal(b, m, deterministic)
+}
+func (dst *GameServer_Spec) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GameServer_Spec.Merge(dst, src)
+}
+func (m *GameServer_Spec) XXX_Size() int {
+	return xxx_messageInfo_GameServer_Spec.Size(m)
+}
+func (m *GameServer_Spec) XXX_DiscardUnknown() {
+	xxx_messageInfo_GameServer_Spec.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GameServer_Spec proto.InternalMessageInfo
+
+func (m *GameServer_Spec) GetHealth() *GameServer_Spec_Health {
+	if m != nil {
+		return m.Health
+	}
+	return nil
+}
+
+type GameServer_Spec_Health struct {
+	Disabled             bool     `protobuf:"varint,1,opt,name=Disabled" json:"Disabled,omitempty"`
+	PeriodSeconds        int32    `protobuf:"varint,2,opt,name=PeriodSeconds" json:"PeriodSeconds,omitempty"`
+	FailureThreshold     int32    `protobuf:"varint,3,opt,name=FailureThreshold" json:"FailureThreshold,omitempty"`
+	InitialDelaySeconds  int32    `protobuf:"varint,4,opt,name=InitialDelaySeconds" json:"InitialDelaySeconds,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GameServer_Spec_Health) Reset()         { *m = GameServer_Spec_Health{} }
+func (m *GameServer_Spec_Health) String() string { return proto.CompactTextString(m) }
+func (*GameServer_Spec_Health) ProtoMessage()    {}
+func (*GameServer_Spec_Health) Descriptor() ([]byte, []int) {
+	return fileDescriptor_sdk_39d49c489951ac60, []int{1, 1, 0}
+}
+func (m *GameServer_Spec_Health) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GameServer_Spec_Health.Unmarshal(m, b)
+}
+func (m *GameServer_Spec_Health) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GameServer_Spec_Health.Marshal(b, m, deterministic)
+}
+func (dst *GameServer_Spec_Health) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GameServer_Spec_Health.Merge(dst, src)
+}
+func (m *GameServer_Spec_Health) XXX_Size() int {
+	return xxx_messageInfo_GameServer_Spec_Health.Size(m)
+}
+func (m *GameServer_Spec_Health) XXX_DiscardUnknown() {
+	xxx_messageInfo_GameServer_Spec_Health.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GameServer_Spec_Health proto.InternalMessageInfo
+
+func (m *GameServer_Spec_Health) GetDisabled() bool {
+	if m != nil {
+		return m.Disabled
+	}
+	return false
+}
+
+func (m *GameServer_Spec_Health) GetPeriodSeconds() int32 {
+	if m != nil {
+		return m.PeriodSeconds
+	}
+	return 0
+}
+
+func (m *GameServer_Spec_Health) GetFailureThreshold() int32 {
+	if m != nil {
+		return m.FailureThreshold
+	}
+	return 0
+}
+
+func (m *GameServer_Spec_Health) GetInitialDelaySeconds() int32 {
+	if m != nil {
+		return m.InitialDelaySeconds
+	}
+	return 0
+}
+
+type GameServer_Status struct {
+	State                string                    `protobuf:"bytes,1,opt,name=state" json:"state,omitempty"`
+	Address              string                    `protobuf:"bytes,2,opt,name=address" json:"address,omitempty"`
+	Ports                []*GameServer_Status_Port `protobuf:"bytes,3,rep,name=ports" json:"ports,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
+	XXX_unrecognized     []byte                    `json:"-"`
+	XXX_sizecache        int32                     `json:"-"`
+}
+
+func (m *GameServer_Status) Reset()         { *m = GameServer_Status{} }
+func (m *GameServer_Status) String() string { return proto.CompactTextString(m) }
+func (*GameServer_Status) ProtoMessage()    {}
+func (*GameServer_Status) Descriptor() ([]byte, []int) {
+	return fileDescriptor_sdk_39d49c489951ac60, []int{1, 2}
+}
+func (m *GameServer_Status) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GameServer_Status.Unmarshal(m, b)
+}
+func (m *GameServer_Status) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GameServer_Status.Marshal(b, m, deterministic)
+}
+func (dst *GameServer_Status) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GameServer_Status.Merge(dst, src)
+}
+func (m *GameServer_Status) XXX_Size() int {
+	return xxx_messageInfo_GameServer_Status.Size(m)
+}
+func (m *GameServer_Status) XXX_DiscardUnknown() {
+	xxx_messageInfo_GameServer_Status.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GameServer_Status proto.InternalMessageInfo
+
+func (m *GameServer_Status) GetState() string {
+	if m != nil {
+		return m.State
+	}
+	return ""
+}
+
+func (m *GameServer_Status) GetAddress() string {
+	if m != nil {
+		return m.Address
+	}
+	return ""
+}
+
+func (m *GameServer_Status) GetPorts() []*GameServer_Status_Port {
+	if m != nil {
+		return m.Ports
+	}
+	return nil
+}
+
+type GameServer_Status_Port struct {
+	Name                 string   `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Port                 int32    `protobuf:"varint,2,opt,name=port" json:"port,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GameServer_Status_Port) Reset()         { *m = GameServer_Status_Port{} }
+func (m *GameServer_Status_Port) String() string { return proto.CompactTextString(m) }
+func (*GameServer_Status_Port) ProtoMessage()    {}
+func (*GameServer_Status_Port) Descriptor() ([]byte, []int) {
+	return fileDescriptor_sdk_39d49c489951ac60, []int{1, 2, 0}
+}
+func (m *GameServer_Status_Port) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GameServer_Status_Port.Unmarshal(m, b)
+}
+func (m *GameServer_Status_Port) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GameServer_Status_Port.Marshal(b, m, deterministic)
+}
+func (dst *GameServer_Status_Port) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GameServer_Status_Port.Merge(dst, src)
+}
+func (m *GameServer_Status_Port) XXX_Size() int {
+	return xxx_messageInfo_GameServer_Status_Port.Size(m)
+}
+func (m *GameServer_Status_Port) XXX_DiscardUnknown() {
+	xxx_messageInfo_GameServer_Status_Port.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GameServer_Status_Port proto.InternalMessageInfo
+
+func (m *GameServer_Status_Port) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *GameServer_Status_Port) GetPort() int32 {
+	if m != nil {
+		return m.Port
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*Empty)(nil), "stable.agones.dev.sdk.Empty")
+	proto.RegisterType((*GameServer)(nil), "stable.agones.dev.sdk.GameServer")
+	proto.RegisterType((*GameServer_ObjectMeta)(nil), "stable.agones.dev.sdk.GameServer.ObjectMeta")
+	proto.RegisterMapType((map[string]string)(nil), "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry")
+	proto.RegisterMapType((map[string]string)(nil), "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry")
+	proto.RegisterType((*GameServer_Spec)(nil), "stable.agones.dev.sdk.GameServer.Spec")
+	proto.RegisterType((*GameServer_Spec_Health)(nil), "stable.agones.dev.sdk.GameServer.Spec.Health")
+	proto.RegisterType((*GameServer_Status)(nil), "stable.agones.dev.sdk.GameServer.Status")
+	proto.RegisterType((*GameServer_Status_Port)(nil), "stable.agones.dev.sdk.GameServer.Status.Port")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -90,6 +460,8 @@ type SDKClient interface {
 	Shutdown(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*Empty, error)
 	// Send a Empty every d Duration to declare that this GameSever is healthy
 	Health(ctx context.Context, opts ...grpc.CallOption) (SDK_HealthClient, error)
+	// Retrieve the current GameServer data
+	GetGameServer(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*GameServer, error)
 }
 
 type sDKClient struct {
@@ -152,6 +524,15 @@ func (x *sDKHealthClient) CloseAndRecv() (*Empty, error) {
 	return m, nil
 }
 
+func (c *sDKClient) GetGameServer(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*GameServer, error) {
+	out := new(GameServer)
+	err := grpc.Invoke(ctx, "/stable.agones.dev.sdk.SDK/GetGameServer", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for SDK service
 
 type SDKServer interface {
@@ -161,6 +542,8 @@ type SDKServer interface {
 	Shutdown(context.Context, *Empty) (*Empty, error)
 	// Send a Empty every d Duration to declare that this GameSever is healthy
 	Health(SDK_HealthServer) error
+	// Retrieve the current GameServer data
+	GetGameServer(context.Context, *Empty) (*GameServer, error)
 }
 
 func RegisterSDKServer(s *grpc.Server, srv SDKServer) {
@@ -229,6 +612,24 @@ func (x *sDKHealthServer) Recv() (*Empty, error) {
 	return m, nil
 }
 
+func _SDK_GetGameServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SDKServer).GetGameServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/stable.agones.dev.sdk.SDK/GetGameServer",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SDKServer).GetGameServer(ctx, req.(*Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _SDK_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "stable.agones.dev.sdk.SDK",
 	HandlerType: (*SDKServer)(nil),
@@ -241,6 +642,10 @@ var _SDK_serviceDesc = grpc.ServiceDesc{
 			MethodName: "Shutdown",
 			Handler:    _SDK_Shutdown_Handler,
 		},
+		{
+			MethodName: "GetGameServer",
+			Handler:    _SDK_GetGameServer_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -252,21 +657,52 @@ var _SDK_serviceDesc = grpc.ServiceDesc{
 	Metadata: "sdk.proto",
 }
 
-func init() { proto.RegisterFile("sdk.proto", fileDescriptor_sdk_6230b133a8116e3a) }
+func init() { proto.RegisterFile("sdk.proto", fileDescriptor_sdk_39d49c489951ac60) }
 
-var fileDescriptor_sdk_6230b133a8116e3a = []byte{
-	// 205 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x2c, 0x4e, 0xc9, 0xd6,
-	0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x2d, 0x2e, 0x49, 0x4c, 0xca, 0x49, 0xd5, 0x4b, 0x4c,
-	0xcf, 0xcf, 0x4b, 0x2d, 0xd6, 0x4b, 0x49, 0x2d, 0xd3, 0x2b, 0x4e, 0xc9, 0x96, 0x92, 0x49, 0xcf,
-	0xcf, 0x4f, 0xcf, 0x49, 0xd5, 0x4f, 0x2c, 0xc8, 0xd4, 0x4f, 0xcc, 0xcb, 0xcb, 0x2f, 0x49, 0x2c,
-	0xc9, 0xcc, 0xcf, 0x2b, 0x86, 0x68, 0x52, 0x62, 0xe7, 0x62, 0x75, 0xcd, 0x2d, 0x28, 0xa9, 0x34,
-	0x9a, 0xce, 0xc4, 0xc5, 0x1c, 0xec, 0xe2, 0x2d, 0x14, 0xc6, 0xc5, 0x1a, 0x94, 0x9a, 0x98, 0x52,
-	0x29, 0x24, 0xa3, 0x87, 0xd5, 0x3c, 0x3d, 0xb0, 0x72, 0x29, 0xbc, 0xb2, 0x4a, 0x82, 0x4d, 0x97,
-	0x9f, 0x4c, 0x66, 0xe2, 0x56, 0x62, 0xd3, 0x2f, 0x02, 0x99, 0x65, 0xc5, 0xa8, 0x25, 0x14, 0xc3,
-	0xc5, 0x11, 0x9c, 0x51, 0x5a, 0x92, 0x92, 0x5f, 0x9e, 0x47, 0x91, 0xd1, 0x22, 0x60, 0xa3, 0xf9,
-	0x94, 0x38, 0xf5, 0x8b, 0xa1, 0xc6, 0x81, 0x4c, 0x8f, 0xe2, 0x62, 0xf3, 0x48, 0x4d, 0xcc, 0x29,
-	0xc9, 0xa0, 0xc8, 0x6c, 0x21, 0xb0, 0xd9, 0x3c, 0x4a, 0xec, 0xfa, 0x19, 0x60, 0xc3, 0xac, 0x18,
-	0xb5, 0x34, 0x18, 0x9d, 0x58, 0xa3, 0x98, 0x8b, 0x53, 0xb2, 0x93, 0xd8, 0xc0, 0x01, 0x66, 0x0c,
-	0x08, 0x00, 0x00, 0xff, 0xff, 0x64, 0x8a, 0x6c, 0xf3, 0x72, 0x01, 0x00, 0x00,
+var fileDescriptor_sdk_39d49c489951ac60 = []byte{
+	// 699 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x95, 0xdd, 0x6e, 0xd3, 0x4a,
+	0x10, 0xc7, 0xe5, 0xc4, 0x76, 0xe2, 0xc9, 0xe9, 0x39, 0xe9, 0xb6, 0x47, 0xb2, 0xac, 0x0a, 0x95,
+	0x08, 0xa1, 0x50, 0x51, 0x07, 0x95, 0x9b, 0x12, 0x09, 0xc4, 0x47, 0x4b, 0x41, 0x50, 0x51, 0x39,
+	0x55, 0x2f, 0x2a, 0xa4, 0x68, 0x13, 0x8f, 0x12, 0x13, 0xc7, 0x6b, 0xed, 0x6e, 0x82, 0x72, 0xcb,
+	0x2b, 0xf0, 0x10, 0x70, 0x03, 0x2f, 0xc3, 0x2b, 0xf0, 0x10, 0x5c, 0x21, 0xb4, 0x6b, 0xbb, 0x09,
+	0xa5, 0xf4, 0x43, 0xbd, 0xca, 0xec, 0xcc, 0xfc, 0x7f, 0xb3, 0xd9, 0x99, 0x5d, 0x83, 0x23, 0xc2,
+	0x91, 0x9f, 0x72, 0x26, 0x19, 0xf9, 0x5f, 0x48, 0xda, 0x8b, 0xd1, 0xa7, 0x03, 0x96, 0xa0, 0xf0,
+	0x43, 0x9c, 0xfa, 0x22, 0x1c, 0x79, 0x6b, 0x03, 0xc6, 0x06, 0x31, 0xb6, 0x68, 0x1a, 0xb5, 0x68,
+	0x92, 0x30, 0x49, 0x65, 0xc4, 0x12, 0x91, 0x89, 0x1a, 0x15, 0xb0, 0x76, 0xc7, 0xa9, 0x9c, 0x35,
+	0xbe, 0x3a, 0x00, 0x7b, 0x74, 0x8c, 0x1d, 0xe4, 0x53, 0xe4, 0x64, 0x1f, 0x6a, 0xac, 0xf7, 0x0e,
+	0xfb, 0xb2, 0x3b, 0x46, 0x49, 0x5d, 0x63, 0xdd, 0x68, 0xd6, 0xb6, 0xee, 0xfa, 0x67, 0x96, 0xf0,
+	0xe7, 0x3a, 0xff, 0x8d, 0x16, 0xed, 0xa3, 0xa4, 0x01, 0xb0, 0x13, 0x9b, 0xb4, 0xc1, 0x14, 0x29,
+	0xf6, 0xdd, 0x92, 0xe6, 0xdc, 0xbe, 0x98, 0xd3, 0x49, 0xb1, 0x1f, 0x68, 0x0d, 0x79, 0x0c, 0xb6,
+	0x90, 0x54, 0x4e, 0x84, 0x5b, 0xd6, 0xea, 0xe6, 0x25, 0xd4, 0x3a, 0x3f, 0xc8, 0x75, 0xde, 0x27,
+	0x13, 0x60, 0xbe, 0x31, 0x42, 0xc0, 0x4c, 0xe8, 0x18, 0xf5, 0x9f, 0x72, 0x02, 0x6d, 0x93, 0x35,
+	0x70, 0xd4, 0xaf, 0x48, 0x69, 0x1f, 0xf5, 0x2e, 0x9d, 0x60, 0xee, 0x20, 0x75, 0x28, 0x4f, 0xa2,
+	0x50, 0xd7, 0x77, 0x02, 0x65, 0x92, 0x3b, 0x50, 0xe7, 0x28, 0xd8, 0x84, 0xf7, 0xb1, 0x3b, 0x45,
+	0x2e, 0x22, 0x96, 0xb8, 0xa6, 0x0e, 0xff, 0x57, 0xf8, 0x8f, 0x32, 0x37, 0xb9, 0x01, 0x30, 0xc0,
+	0x04, 0xb9, 0x3e, 0x77, 0xd7, 0x5a, 0x37, 0x9a, 0xe5, 0x60, 0xc1, 0x43, 0x36, 0x81, 0xf4, 0x39,
+	0x6a, 0xbb, 0x2b, 0xa3, 0x31, 0x0a, 0x49, 0xc7, 0xa9, 0x6b, 0xeb, 0xbc, 0xe5, 0x22, 0x72, 0x58,
+	0x04, 0x54, 0x7a, 0x88, 0x31, 0x9e, 0x4a, 0xaf, 0x64, 0xe9, 0x45, 0x64, 0x9e, 0xde, 0x85, 0xda,
+	0x42, 0xd7, 0xdd, 0xea, 0x7a, 0xb9, 0x59, 0xdb, 0x7a, 0x78, 0x95, 0x46, 0xfa, 0x4f, 0xe6, 0xfa,
+	0xdd, 0x44, 0xf2, 0x59, 0xb0, 0x48, 0x24, 0x07, 0x60, 0xc7, 0xb4, 0x87, 0xb1, 0x70, 0x1d, 0xcd,
+	0xde, 0xbe, 0x12, 0xfb, 0xb5, 0x96, 0x66, 0xd8, 0x9c, 0xe3, 0x3d, 0x82, 0xfa, 0xe9, 0x92, 0xaa,
+	0x03, 0x23, 0x9c, 0xe5, 0x2d, 0x53, 0x26, 0x59, 0x05, 0x6b, 0x4a, 0xe3, 0x49, 0xd1, 0xad, 0x6c,
+	0xd1, 0x2e, 0x6d, 0x1b, 0xde, 0x03, 0xa8, 0x2d, 0x60, 0xaf, 0x24, 0xfd, 0x61, 0x80, 0xa9, 0x46,
+	0x8f, 0xec, 0x82, 0x3d, 0x44, 0x1a, 0xcb, 0x61, 0x3e, 0xfa, 0x9b, 0x97, 0x1b, 0x59, 0xff, 0x85,
+	0x16, 0x05, 0xb9, 0xd8, 0xfb, 0x6c, 0x80, 0x9d, 0xb9, 0x88, 0x07, 0xd5, 0x9d, 0x48, 0x28, 0x46,
+	0xa8, 0x99, 0xd5, 0xe0, 0x64, 0x4d, 0x6e, 0xc1, 0xd2, 0x01, 0xf2, 0x88, 0x85, 0x1d, 0xec, 0xb3,
+	0x24, 0x14, 0x7a, 0x63, 0x56, 0xf0, 0xbb, 0x93, 0x6c, 0x40, 0xfd, 0x39, 0x8d, 0xe2, 0x09, 0xc7,
+	0xc3, 0x21, 0x47, 0x31, 0x64, 0x71, 0x36, 0x92, 0x56, 0xf0, 0x87, 0x9f, 0xdc, 0x83, 0x95, 0x97,
+	0x49, 0x24, 0x23, 0x1a, 0xef, 0x60, 0x4c, 0x67, 0x05, 0xd7, 0xd4, 0xe9, 0x67, 0x85, 0xbc, 0x2f,
+	0x06, 0xd8, 0xd9, 0xbd, 0x51, 0xe7, 0xa3, 0x6e, 0x4e, 0x71, 0x43, 0xb2, 0x05, 0x71, 0xa1, 0x42,
+	0xc3, 0x90, 0xa3, 0x10, 0xf9, 0xb9, 0x15, 0x4b, 0xf2, 0x0c, 0xac, 0x94, 0x71, 0xa9, 0x2e, 0x68,
+	0xf9, 0x92, 0x67, 0xa5, 0x0b, 0xf9, 0x07, 0x8c, 0xcb, 0x20, 0xd3, 0x7a, 0x3e, 0x98, 0x6a, 0x79,
+	0xe6, 0xed, 0x24, 0x60, 0xaa, 0xa4, 0xfc, 0x58, 0xb4, 0xbd, 0xf5, 0xb3, 0x04, 0xe5, 0xce, 0xce,
+	0x2b, 0x72, 0x04, 0x56, 0x80, 0x34, 0x9c, 0x91, 0xb5, 0xbf, 0x94, 0xd5, 0xef, 0x9b, 0x77, 0x6e,
+	0xb4, 0xb1, 0xfc, 0xe1, 0xdb, 0xf7, 0x8f, 0xa5, 0x5a, 0xc3, 0x6e, 0x71, 0xc5, 0x6a, 0x1b, 0x1b,
+	0xe4, 0x2d, 0x54, 0x3b, 0xc3, 0x89, 0x0c, 0xd9, 0xfb, 0xe4, 0x5a, 0xe8, 0x55, 0x8d, 0xfe, 0xb7,
+	0xe1, 0xb4, 0x44, 0x8e, 0x53, 0xf4, 0xe3, 0x93, 0xb9, 0xb8, 0x0e, 0x9b, 0x68, 0xf6, 0x3f, 0x8d,
+	0x4a, 0x2b, 0x9b, 0xb7, 0xb6, 0xb1, 0xd1, 0x34, 0x08, 0xc2, 0xd2, 0x1e, 0xca, 0x85, 0xc7, 0xfc,
+	0xfc, 0x12, 0x37, 0x2f, 0x6c, 0x57, 0x63, 0x45, 0xd7, 0x59, 0x22, 0xb5, 0xd6, 0x40, 0xbd, 0x89,
+	0xda, 0xf9, 0xd4, 0x3a, 0x2e, 0x8b, 0x70, 0xd4, 0xb3, 0xf5, 0x87, 0xe4, 0xfe, 0xaf, 0x00, 0x00,
+	0x00, 0xff, 0xff, 0xc5, 0x0e, 0x54, 0x28, 0x8a, 0x06, 0x00, 0x00,
 }

--- a/pkg/sdk/sdk.pb.gw.go
+++ b/pkg/sdk/sdk.pb.gw.go
@@ -110,6 +110,15 @@ func request_SDK_Health_0(ctx context.Context, marshaler runtime.Marshaler, clie
 
 }
 
+func request_SDK_GetGameServer_0(ctx context.Context, marshaler runtime.Marshaler, client SDKClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq Empty
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.GetGameServer(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
 // RegisterSDKHandlerFromEndpoint is same as RegisterSDKHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterSDKHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
@@ -235,6 +244,35 @@ func RegisterSDKHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 
 	})
 
+	mux.Handle("GET", pattern_SDK_GetGameServer_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		if cn, ok := w.(http.CloseNotifier); ok {
+			go func(done <-chan struct{}, closed <-chan bool) {
+				select {
+				case <-done:
+				case <-closed:
+					cancel()
+				}
+			}(ctx.Done(), cn.CloseNotify())
+		}
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_SDK_GetGameServer_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_SDK_GetGameServer_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -244,6 +282,8 @@ var (
 	pattern_SDK_Shutdown_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"shutdown"}, ""))
 
 	pattern_SDK_Health_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"health"}, ""))
+
+	pattern_SDK_GetGameServer_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"gameserver"}, ""))
 )
 
 var (
@@ -252,4 +292,6 @@ var (
 	forward_SDK_Shutdown_0 = runtime.ForwardResponseMessage
 
 	forward_SDK_Health_0 = runtime.ForwardResponseMessage
+
+	forward_SDK_GetGameServer_0 = runtime.ForwardResponseMessage
 )

--- a/sdk.proto
+++ b/sdk.proto
@@ -42,7 +42,59 @@ service SDK {
 			body: "*"
 		};
     }
+    // Retrieve the current GameServer data
+    rpc GetGameServer (Empty) returns (GameServer) {
+        option (google.api.http) = {
+            get: "/gameserver"
+        };
+    }
 }
 
 message Empty {
+}
+
+// A GameServer Custom Resource Definition object
+// We will only export those resources that make the most
+// sense. Can always expand to more as needed.
+message GameServer {
+    ObjectMeta object_meta = 1;
+    Spec spec = 2;
+    Status status = 3;
+
+    // representation of the K8s ObjectMeta resource
+    message ObjectMeta {
+        string name = 1;
+        string namespace = 2;
+        string uid = 3;
+        string resource_version = 4;
+        int64 generation = 5;
+        // timestamp is in Epoch format, unit: seconds
+        int64 creation_timestamp = 6;
+        // optional deletion timestamp in Epoch format, unit: seconds
+        int64 deletion_timestamp = 7;
+        map<string, string> annotations = 8;
+        map<string, string> labels = 9;
+    }
+
+    message Spec {
+        Health health = 1;
+
+        message Health {
+            bool Disabled = 1;
+            int32 PeriodSeconds = 2;
+            int32 FailureThreshold = 3;
+            int32 InitialDelaySeconds = 4;
+        }
+    }
+
+    message Status {
+        message Port {
+            string name = 1;
+            int32 port = 2;
+        }
+
+        string state = 1;
+        string address = 2;
+        repeated Port ports = 3;
+    }
 }

--- a/sdk.swagger.json
+++ b/sdk.swagger.json
@@ -14,6 +14,23 @@
     "application/json"
   ],
   "paths": {
+    "/gameserver": {
+      "get": {
+        "summary": "Retrieve the current GameServer data",
+        "operationId": "GetGameServer",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/sdkGameServer"
+            }
+          }
+        },
+        "tags": [
+          "SDK"
+        ]
+      }
+    },
     "/health": {
       "post": {
         "summary": "Send a Empty every d Duration to declare that this GameSever is healthy",
@@ -98,8 +115,125 @@
     }
   },
   "definitions": {
+    "GameServerObjectMeta": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "resource_version": {
+          "type": "string"
+        },
+        "generation": {
+          "type": "string",
+          "format": "int64"
+        },
+        "creation_timestamp": {
+          "type": "string",
+          "format": "int64",
+          "title": "timestamp is in Epoch format, unit: seconds"
+        },
+        "deletion_timestamp": {
+          "type": "string",
+          "format": "int64",
+          "title": "optional deletion timestamp in Epoch format, unit: seconds"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "representation of the K8s ObjectMeta resource"
+    },
+    "GameServerSpec": {
+      "type": "object",
+      "properties": {
+        "health": {
+          "$ref": "#/definitions/SpecHealth"
+        }
+      }
+    },
+    "GameServerStatus": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "address": {
+          "type": "string"
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StatusPort"
+          }
+        }
+      }
+    },
+    "SpecHealth": {
+      "type": "object",
+      "properties": {
+        "Disabled": {
+          "type": "boolean",
+          "format": "boolean"
+        },
+        "PeriodSeconds": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "FailureThreshold": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "InitialDelaySeconds": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "StatusPort": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
     "sdkEmpty": {
       "type": "object"
+    },
+    "sdkGameServer": {
+      "type": "object",
+      "properties": {
+        "object_meta": {
+          "$ref": "#/definitions/GameServerObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/GameServerSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/GameServerStatus"
+        }
+      },
+      "description": "A GameServer Custom Resource Definition object\nWe will only export those resources that make the most\nsense. Can always expand to more as needed."
     }
   }
 }

--- a/sdks/README.md
+++ b/sdks/README.md
@@ -46,6 +46,23 @@ This tells Agones to shut down the currently running game server.
 The GameServer state will be set `Shutdown` and the 
 backing Pod will be deleted, if they have not shut themselves down already. 
 
+### GameServer()
+⚠️⚠️⚠️ **This is currently a development feature and has not been released** ⚠️⚠️⚠️
+
+This returns most of the backing GameServer configuration and Status. This can be useful
+for instances where you may want to know Health check configuration, or the IP and Port
+the GameServer is currently allocated to.
+
+Since the GameServer contains an entire [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#pod-templates)
+the returned object is limited to that configuration that was deemed useful. If there are
+areas that you feel are missing, please [file an issue](https://github.com/GoogleCloudPlatform/agones/issues) or pull request.
+
+The easiest way to see what is exposed, is to check the [`sdk.proto`](https://github.com/GoogleCloudPlatform/agones/blob/master/sdk.proto),
+specifically at the `message GameServer`.
+
+For language specific documentation, have a look at the respective source (linked above), 
+and the [examples](../examples).
+
 ## Local Development
 
 When the game server is running on Agones, the SDK communicates over TCP to a small

--- a/sdks/cpp/Makefile
+++ b/sdks/cpp/Makefile
@@ -48,10 +48,12 @@ install:
 	cp $(build_path)/bin/libagonessdk.* /usr/local/lib
 	-mkdir -p /usr/local/include/agones
 	cp $(build_path)/*.h /usr/local/include/agones/
+	-mkdir -p /usr/local/include/google/api
+	cp -r $(build_path)/google/api/*.h /usr/local/include/google/api/
 	ldconfig
 
 # make the .so build
-libagonessdk: sdk.grpc.pb.o sdk.pb.o sdk.o
+libagonessdk: google/api/annotations.pb.o google/api/http.pb.o sdk.grpc.pb.o sdk.pb.o sdk.o
 	$(CXX) $^ $(LDFLAGS) -shared -o $(build_path)/bin/$@.so
 	ar rcs $(build_path)/bin/$@.a $^
 
@@ -76,4 +78,4 @@ archive:
 
 clean:
 	-rm -r $(build_path)/bin
-	-rm *.o
+	-find -name '*.o' -delete

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -59,6 +59,23 @@ if (!status.ok()) { ... }
 For more information, you can also read the [SDK Overview](../), check out [sdk.h](sdk.h) and also look at the
 [C++ example](../../examples/cpp-simple).
 
+⚠️⚠️⚠️ **sdk->GameServer(&gameserver) is currently a development feature and has not been released** ⚠️⚠️⚠️
+    
+To get the details on the [backing `GameServer`](../README.md#gameserver) call `sdk->GameServer(&gameserver)`,
+passing in a `stable::agones::dev::sdk::GameServer*` to push the results of the `GameServer` configuration into.
+
+This function will return a grpc::Status object, from which we can call `status.ok()` to determine
+if the function completed successfully.
+
+```cpp
+stable::agones::dev::sdk::GameServer gameserver;
+grpc::Status status = sdk->GameServer(&gameserver);
+if (!status.ok()) {...}
+```
+
+For more information, you can also read the [SDK Overview](../), check out [sdk.h](sdk.h) and also look at the
+[C++ example](../../examples/cpp-simple).
+
 ### Failure
 When running on Agones, the above functions should only fail under exceptional circumstances, so please 
 file a bug if it occurs.

--- a/sdks/cpp/sdk.cc
+++ b/sdks/cpp/sdk.cc
@@ -51,6 +51,14 @@ namespace agones {
         return health->Write(request);
     }
 
+    grpc::Status SDK::GameServer(stable::agones::dev::sdk::GameServer* response) {
+        grpc::ClientContext *context = new grpc::ClientContext();
+        context->set_deadline(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), gpr_time_from_seconds(30, GPR_TIMESPAN)));
+        stable::agones::dev::sdk::Empty request;
+
+        return stub->GetGameServer(context, request, response);
+    }
+
     grpc::Status SDK::Shutdown() {
         grpc::ClientContext *context = new grpc::ClientContext();
         context->set_deadline(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), gpr_time_from_seconds(30, GPR_TIMESPAN)));

--- a/sdks/cpp/sdk.grpc.pb.cc
+++ b/sdks/cpp/sdk.grpc.pb.cc
@@ -37,6 +37,7 @@ static const char* SDK_method_names[] = {
   "/stable.agones.dev.sdk.SDK/Ready",
   "/stable.agones.dev.sdk.SDK/Shutdown",
   "/stable.agones.dev.sdk.SDK/Health",
+  "/stable.agones.dev.sdk.SDK/GetGameServer",
 };
 
 std::unique_ptr< SDK::Stub> SDK::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -49,6 +50,7 @@ SDK::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   : channel_(channel), rpcmethod_Ready_(SDK_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Shutdown_(SDK_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Health_(SDK_method_names[2], ::grpc::internal::RpcMethod::CLIENT_STREAMING, channel)
+  , rpcmethod_GetGameServer_(SDK_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status SDK::Stub::Ready(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::stable::agones::dev::sdk::Empty* response) {
@@ -87,6 +89,18 @@ SDK::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
   return ::grpc::internal::ClientAsyncWriterFactory< ::stable::agones::dev::sdk::Empty>::Create(channel_.get(), cq, rpcmethod_Health_, context, response, false, nullptr);
 }
 
+::grpc::Status SDK::Stub::GetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::stable::agones::dev::sdk::GameServer* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetGameServer_, context, request, response);
+}
+
+::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>* SDK::Stub::AsyncGetGameServerRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::stable::agones::dev::sdk::GameServer>::Create(channel_.get(), cq, rpcmethod_GetGameServer_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>* SDK::Stub::PrepareAsyncGetGameServerRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::stable::agones::dev::sdk::GameServer>::Create(channel_.get(), cq, rpcmethod_GetGameServer_, context, request, false);
+}
+
 SDK::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       SDK_method_names[0],
@@ -103,6 +117,11 @@ SDK::Service::Service() {
       ::grpc::internal::RpcMethod::CLIENT_STREAMING,
       new ::grpc::internal::ClientStreamingHandler< SDK::Service, ::stable::agones::dev::sdk::Empty, ::stable::agones::dev::sdk::Empty>(
           std::mem_fn(&SDK::Service::Health), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      SDK_method_names[3],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< SDK::Service, ::stable::agones::dev::sdk::Empty, ::stable::agones::dev::sdk::GameServer>(
+          std::mem_fn(&SDK::Service::GetGameServer), this)));
 }
 
 SDK::Service::~Service() {
@@ -125,6 +144,13 @@ SDK::Service::~Service() {
 ::grpc::Status SDK::Service::Health(::grpc::ServerContext* context, ::grpc::ServerReader< ::stable::agones::dev::sdk::Empty>* reader, ::stable::agones::dev::sdk::Empty* response) {
   (void) context;
   (void) reader;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status SDK::Service::GetGameServer(::grpc::ServerContext* context, const ::stable::agones::dev::sdk::Empty* request, ::stable::agones::dev::sdk::GameServer* response) {
+  (void) context;
+  (void) request;
   (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }

--- a/sdks/cpp/sdk.grpc.pb.h
+++ b/sdks/cpp/sdk.grpc.pb.h
@@ -78,6 +78,14 @@ class SDK final {
     std::unique_ptr< ::grpc::ClientAsyncWriterInterface< ::stable::agones::dev::sdk::Empty>> PrepareAsyncHealth(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncWriterInterface< ::stable::agones::dev::sdk::Empty>>(PrepareAsyncHealthRaw(context, response, cq));
     }
+    // Retrieve the current GameServer data
+    virtual ::grpc::Status GetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::stable::agones::dev::sdk::GameServer* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::GameServer>> AsyncGetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::GameServer>>(AsyncGetGameServerRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::GameServer>> PrepareAsyncGetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::GameServer>>(PrepareAsyncGetGameServerRaw(context, request, cq));
+    }
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::Empty>* AsyncReadyRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::Empty>* PrepareAsyncReadyRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) = 0;
@@ -86,6 +94,8 @@ class SDK final {
     virtual ::grpc::ClientWriterInterface< ::stable::agones::dev::sdk::Empty>* HealthRaw(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response) = 0;
     virtual ::grpc::ClientAsyncWriterInterface< ::stable::agones::dev::sdk::Empty>* AsyncHealthRaw(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response, ::grpc::CompletionQueue* cq, void* tag) = 0;
     virtual ::grpc::ClientAsyncWriterInterface< ::stable::agones::dev::sdk::Empty>* PrepareAsyncHealthRaw(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::GameServer>* AsyncGetGameServerRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::stable::agones::dev::sdk::GameServer>* PrepareAsyncGetGameServerRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -113,6 +123,13 @@ class SDK final {
     std::unique_ptr< ::grpc::ClientAsyncWriter< ::stable::agones::dev::sdk::Empty>> PrepareAsyncHealth(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncWriter< ::stable::agones::dev::sdk::Empty>>(PrepareAsyncHealthRaw(context, response, cq));
     }
+    ::grpc::Status GetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::stable::agones::dev::sdk::GameServer* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>> AsyncGetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>>(AsyncGetGameServerRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>> PrepareAsyncGetGameServer(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>>(PrepareAsyncGetGameServerRaw(context, request, cq));
+    }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
@@ -123,9 +140,12 @@ class SDK final {
     ::grpc::ClientWriter< ::stable::agones::dev::sdk::Empty>* HealthRaw(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response) override;
     ::grpc::ClientAsyncWriter< ::stable::agones::dev::sdk::Empty>* AsyncHealthRaw(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response, ::grpc::CompletionQueue* cq, void* tag) override;
     ::grpc::ClientAsyncWriter< ::stable::agones::dev::sdk::Empty>* PrepareAsyncHealthRaw(::grpc::ClientContext* context, ::stable::agones::dev::sdk::Empty* response, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>* AsyncGetGameServerRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::stable::agones::dev::sdk::GameServer>* PrepareAsyncGetGameServerRaw(::grpc::ClientContext* context, const ::stable::agones::dev::sdk::Empty& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_Ready_;
     const ::grpc::internal::RpcMethod rpcmethod_Shutdown_;
     const ::grpc::internal::RpcMethod rpcmethod_Health_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetGameServer_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -139,6 +159,8 @@ class SDK final {
     virtual ::grpc::Status Shutdown(::grpc::ServerContext* context, const ::stable::agones::dev::sdk::Empty* request, ::stable::agones::dev::sdk::Empty* response);
     // Send a Empty every d Duration to declare that this GameSever is healthy
     virtual ::grpc::Status Health(::grpc::ServerContext* context, ::grpc::ServerReader< ::stable::agones::dev::sdk::Empty>* reader, ::stable::agones::dev::sdk::Empty* response);
+    // Retrieve the current GameServer data
+    virtual ::grpc::Status GetGameServer(::grpc::ServerContext* context, const ::stable::agones::dev::sdk::Empty* request, ::stable::agones::dev::sdk::GameServer* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_Ready : public BaseClass {
@@ -200,7 +222,27 @@ class SDK final {
       ::grpc::Service::RequestAsyncClientStreaming(2, context, reader, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Ready<WithAsyncMethod_Shutdown<WithAsyncMethod_Health<Service > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_GetGameServer : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_GetGameServer() {
+      ::grpc::Service::MarkMethodAsync(3);
+    }
+    ~WithAsyncMethod_GetGameServer() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGameServer(::grpc::ServerContext* context, const ::stable::agones::dev::sdk::Empty* request, ::stable::agones::dev::sdk::GameServer* response) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestGetGameServer(::grpc::ServerContext* context, ::stable::agones::dev::sdk::Empty* request, ::grpc::ServerAsyncResponseWriter< ::stable::agones::dev::sdk::GameServer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_Ready<WithAsyncMethod_Shutdown<WithAsyncMethod_Health<WithAsyncMethod_GetGameServer<Service > > > > AsyncService;
   template <class BaseClass>
   class WithGenericMethod_Ready : public BaseClass {
    private:
@@ -253,6 +295,23 @@ class SDK final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_GetGameServer : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_GetGameServer() {
+      ::grpc::Service::MarkMethodGeneric(3);
+    }
+    ~WithGenericMethod_GetGameServer() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status GetGameServer(::grpc::ServerContext* context, const ::stable::agones::dev::sdk::Empty* request, ::stable::agones::dev::sdk::GameServer* response) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_Ready : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
@@ -292,9 +351,29 @@ class SDK final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedShutdown(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::stable::agones::dev::sdk::Empty,::stable::agones::dev::sdk::Empty>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Ready<WithStreamedUnaryMethod_Shutdown<Service > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_GetGameServer : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_GetGameServer() {
+      ::grpc::Service::MarkMethodStreamed(3,
+        new ::grpc::internal::StreamedUnaryHandler< ::stable::agones::dev::sdk::Empty, ::stable::agones::dev::sdk::GameServer>(std::bind(&WithStreamedUnaryMethod_GetGameServer<BaseClass>::StreamedGetGameServer, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_GetGameServer() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status GetGameServer(::grpc::ServerContext* context, const ::stable::agones::dev::sdk::Empty* request, ::stable::agones::dev::sdk::GameServer* response) final override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedGetGameServer(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::stable::agones::dev::sdk::Empty,::stable::agones::dev::sdk::GameServer>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_Ready<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_GetGameServer<Service > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Ready<WithStreamedUnaryMethod_Shutdown<Service > > StreamedService;
+  typedef WithStreamedUnaryMethod_Ready<WithStreamedUnaryMethod_Shutdown<WithStreamedUnaryMethod_GetGameServer<Service > > > StreamedService;
 };
 
 }  // namespace sdk

--- a/sdks/cpp/sdk.h
+++ b/sdks/cpp/sdk.h
@@ -36,6 +36,9 @@ namespace agones {
             // Send Health ping. This is a synchronous request.
             bool Health();
 
+            // Retrieve the current GameServer data
+            grpc::Status GameServer(stable::agones::dev::sdk::GameServer* response);
+
             // Marks the Game Server as ready to shutdown
             grpc::Status Shutdown();
 

--- a/sdks/cpp/sdk.pb.cc
+++ b/sdks/cpp/sdk.pb.cc
@@ -43,6 +43,46 @@ class EmptyDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<Empty>
       _instance;
 } _Empty_default_instance_;
+class GameServer_ObjectMeta_AnnotationsEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse>
+      _instance;
+} _GameServer_ObjectMeta_AnnotationsEntry_DoNotUse_default_instance_;
+class GameServer_ObjectMeta_LabelsEntry_DoNotUseDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_ObjectMeta_LabelsEntry_DoNotUse>
+      _instance;
+} _GameServer_ObjectMeta_LabelsEntry_DoNotUse_default_instance_;
+class GameServer_ObjectMetaDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_ObjectMeta>
+      _instance;
+} _GameServer_ObjectMeta_default_instance_;
+class GameServer_Spec_HealthDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_Spec_Health>
+      _instance;
+} _GameServer_Spec_Health_default_instance_;
+class GameServer_SpecDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_Spec>
+      _instance;
+} _GameServer_Spec_default_instance_;
+class GameServer_Status_PortDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_Status_Port>
+      _instance;
+} _GameServer_Status_Port_default_instance_;
+class GameServer_StatusDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer_Status>
+      _instance;
+} _GameServer_Status_default_instance_;
+class GameServerDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<GameServer>
+      _instance;
+} _GameServer_default_instance_;
 }  // namespace sdk
 }  // namespace dev
 }  // namespace agones
@@ -69,7 +109,180 @@ void InitDefaultsEmpty() {
   ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsEmptyImpl);
 }
 
-::google::protobuf::Metadata file_level_metadata[1];
+void InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUseImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_ObjectMeta_AnnotationsEntry_DoNotUse_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse();
+  }
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUse() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUseImpl);
+}
+
+void InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUseImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_ObjectMeta_LabelsEntry_DoNotUse_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse();
+  }
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUse() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUseImpl);
+}
+
+void InitDefaultsGameServer_ObjectMetaImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  protobuf_sdk_2eproto::InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUse();
+  protobuf_sdk_2eproto::InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUse();
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_ObjectMeta_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_ObjectMeta();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_ObjectMeta() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_ObjectMetaImpl);
+}
+
+void InitDefaultsGameServer_Spec_HealthImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_Spec_Health_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_Spec_Health();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::stable::agones::dev::sdk::GameServer_Spec_Health::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_Spec_Health() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_Spec_HealthImpl);
+}
+
+void InitDefaultsGameServer_SpecImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  protobuf_sdk_2eproto::InitDefaultsGameServer_Spec_Health();
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_Spec_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_Spec();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::stable::agones::dev::sdk::GameServer_Spec::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_Spec() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_SpecImpl);
+}
+
+void InitDefaultsGameServer_Status_PortImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_Status_Port_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_Status_Port();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::stable::agones::dev::sdk::GameServer_Status_Port::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_Status_Port() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_Status_PortImpl);
+}
+
+void InitDefaultsGameServer_StatusImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  protobuf_sdk_2eproto::InitDefaultsGameServer_Status_Port();
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_Status_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer_Status();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::stable::agones::dev::sdk::GameServer_Status::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer_Status() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServer_StatusImpl);
+}
+
+void InitDefaultsGameServerImpl() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+#ifdef GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  ::google::protobuf::internal::InitProtobufDefaultsForceUnique();
+#else
+  ::google::protobuf::internal::InitProtobufDefaults();
+#endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
+  protobuf_sdk_2eproto::InitDefaultsGameServer_ObjectMeta();
+  protobuf_sdk_2eproto::InitDefaultsGameServer_Spec();
+  protobuf_sdk_2eproto::InitDefaultsGameServer_Status();
+  {
+    void* ptr = &::stable::agones::dev::sdk::_GameServer_default_instance_;
+    new (ptr) ::stable::agones::dev::sdk::GameServer();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::stable::agones::dev::sdk::GameServer::InitAsDefaultInstance();
+}
+
+void InitDefaultsGameServer() {
+  static GOOGLE_PROTOBUF_DECLARE_ONCE(once);
+  ::google::protobuf::GoogleOnceInit(&once, &InitDefaultsGameServerImpl);
+}
+
+::google::protobuf::Metadata file_level_metadata[9];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
@@ -77,13 +290,99 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse, value_),
+  0,
+  1,
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse, value_),
+  0,
+  1,
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, namespace__),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, uid_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, resource_version_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, generation_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, creation_timestamp_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, deletion_timestamp_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, annotations_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_ObjectMeta, labels_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec_Health, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec_Health, disabled_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec_Health, periodseconds_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec_Health, failurethreshold_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec_Health, initialdelayseconds_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Spec, health_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status_Port, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status_Port, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status_Port, port_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status, state_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status, address_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer_Status, ports_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer, object_meta_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer, spec_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::stable::agones::dev::sdk::GameServer, status_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::stable::agones::dev::sdk::Empty)},
+  { 5, 12, sizeof(::stable::agones::dev::sdk::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse)},
+  { 14, 21, sizeof(::stable::agones::dev::sdk::GameServer_ObjectMeta_LabelsEntry_DoNotUse)},
+  { 23, -1, sizeof(::stable::agones::dev::sdk::GameServer_ObjectMeta)},
+  { 37, -1, sizeof(::stable::agones::dev::sdk::GameServer_Spec_Health)},
+  { 46, -1, sizeof(::stable::agones::dev::sdk::GameServer_Spec)},
+  { 52, -1, sizeof(::stable::agones::dev::sdk::GameServer_Status_Port)},
+  { 59, -1, sizeof(::stable::agones::dev::sdk::GameServer_Status)},
+  { 67, -1, sizeof(::stable::agones::dev::sdk::GameServer)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_Empty_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_ObjectMeta_AnnotationsEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_ObjectMeta_LabelsEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_ObjectMeta_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_Spec_Health_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_Spec_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_Status_Port_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_Status_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::stable::agones::dev::sdk::_GameServer_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -102,25 +401,51 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 1);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 9);
 }
 
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
       "\n\tsdk.proto\022\025stable.agones.dev.sdk\032\034goog"
-      "le/api/annotations.proto\"\007\n\005Empty2\227\002\n\003SD"
-      "K\022V\n\005Ready\022\034.stable.agones.dev.sdk.Empty"
-      "\032\034.stable.agones.dev.sdk.Empty\"\021\202\323\344\223\002\013\"\006"
-      "/ready:\001*\022\\\n\010Shutdown\022\034.stable.agones.de"
-      "v.sdk.Empty\032\034.stable.agones.dev.sdk.Empt"
-      "y\"\024\202\323\344\223\002\016\"\t/shutdown:\001*\022Z\n\006Health\022\034.stab"
-      "le.agones.dev.sdk.Empty\032\034.stable.agones."
-      "dev.sdk.Empty\"\022\202\323\344\223\002\014\"\007/health:\001*(\001B\005Z\003s"
-      "dkb\006proto3"
+      "le/api/annotations.proto\"\007\n\005Empty\"\242\007\n\nGa"
+      "meServer\022A\n\013object_meta\030\001 \001(\0132,.stable.a"
+      "gones.dev.sdk.GameServer.ObjectMeta\0224\n\004s"
+      "pec\030\002 \001(\0132&.stable.agones.dev.sdk.GameSe"
+      "rver.Spec\0228\n\006status\030\003 \001(\0132(.stable.agone"
+      "s.dev.sdk.GameServer.Status\032\241\003\n\nObjectMe"
+      "ta\022\014\n\004name\030\001 \001(\t\022\021\n\tnamespace\030\002 \001(\t\022\013\n\003u"
+      "id\030\003 \001(\t\022\030\n\020resource_version\030\004 \001(\t\022\022\n\nge"
+      "neration\030\005 \001(\003\022\032\n\022creation_timestamp\030\006 \001"
+      "(\003\022\032\n\022deletion_timestamp\030\007 \001(\003\022R\n\013annota"
+      "tions\030\010 \003(\0132=.stable.agones.dev.sdk.Game"
+      "Server.ObjectMeta.AnnotationsEntry\022H\n\006la"
+      "bels\030\t \003(\01328.stable.agones.dev.sdk.GameS"
+      "erver.ObjectMeta.LabelsEntry\0322\n\020Annotati"
+      "onsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001"
+      "\032-\n\013LabelsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 "
+      "\001(\t:\0028\001\032\257\001\n\004Spec\022=\n\006health\030\001 \001(\0132-.stabl"
+      "e.agones.dev.sdk.GameServer.Spec.Health\032"
+      "h\n\006Health\022\020\n\010Disabled\030\001 \001(\010\022\025\n\rPeriodSec"
+      "onds\030\002 \001(\005\022\030\n\020FailureThreshold\030\003 \001(\005\022\033\n\023"
+      "InitialDelaySeconds\030\004 \001(\005\032\212\001\n\006Status\022\r\n\005"
+      "state\030\001 \001(\t\022\017\n\007address\030\002 \001(\t\022<\n\005ports\030\003 "
+      "\003(\0132-.stable.agones.dev.sdk.GameServer.S"
+      "tatus.Port\032\"\n\004Port\022\014\n\004name\030\001 \001(\t\022\014\n\004port"
+      "\030\002 \001(\0052\376\002\n\003SDK\022V\n\005Ready\022\034.stable.agones."
+      "dev.sdk.Empty\032\034.stable.agones.dev.sdk.Em"
+      "pty\"\021\202\323\344\223\002\013\"\006/ready:\001*\022\\\n\010Shutdown\022\034.sta"
+      "ble.agones.dev.sdk.Empty\032\034.stable.agones"
+      ".dev.sdk.Empty\"\024\202\323\344\223\002\016\"\t/shutdown:\001*\022Z\n\006"
+      "Health\022\034.stable.agones.dev.sdk.Empty\032\034.s"
+      "table.agones.dev.sdk.Empty\"\022\202\323\344\223\002\014\"\007/hea"
+      "lth:\001*(\001\022e\n\rGetGameServer\022\034.stable.agone"
+      "s.dev.sdk.Empty\032!.stable.agones.dev.sdk."
+      "GameServer\"\023\202\323\344\223\002\r\022\013/gameserverB\005Z\003sdkb\006"
+      "proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 370);
+      descriptor, 1406);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "sdk.proto", &protobuf_RegisterTypes);
   ::protobuf_google_2fapi_2fannotations_2eproto::AddDescriptors();
@@ -331,6 +656,2494 @@ void Empty::InternalSwap(Empty* other) {
 }
 
 ::google::protobuf::Metadata Empty::GetMetadata() const {
+  protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse() {}
+GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::GameServer_ObjectMeta_AnnotationsEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::MergeFrom(const GameServer_ObjectMeta_AnnotationsEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[1];
+}
+void GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+GameServer_ObjectMeta_LabelsEntry_DoNotUse::GameServer_ObjectMeta_LabelsEntry_DoNotUse() {}
+GameServer_ObjectMeta_LabelsEntry_DoNotUse::GameServer_ObjectMeta_LabelsEntry_DoNotUse(::google::protobuf::Arena* arena) : SuperType(arena) {}
+void GameServer_ObjectMeta_LabelsEntry_DoNotUse::MergeFrom(const GameServer_ObjectMeta_LabelsEntry_DoNotUse& other) {
+  MergeFromInternal(other);
+}
+::google::protobuf::Metadata GameServer_ObjectMeta_LabelsEntry_DoNotUse::GetMetadata() const {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[2];
+}
+void GameServer_ObjectMeta_LabelsEntry_DoNotUse::MergeFrom(
+    const ::google::protobuf::Message& other) {
+  ::google::protobuf::Message::MergeFrom(other);
+}
+
+
+// ===================================================================
+
+void GameServer_ObjectMeta::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GameServer_ObjectMeta::kNameFieldNumber;
+const int GameServer_ObjectMeta::kNamespaceFieldNumber;
+const int GameServer_ObjectMeta::kUidFieldNumber;
+const int GameServer_ObjectMeta::kResourceVersionFieldNumber;
+const int GameServer_ObjectMeta::kGenerationFieldNumber;
+const int GameServer_ObjectMeta::kCreationTimestampFieldNumber;
+const int GameServer_ObjectMeta::kDeletionTimestampFieldNumber;
+const int GameServer_ObjectMeta::kAnnotationsFieldNumber;
+const int GameServer_ObjectMeta::kLabelsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GameServer_ObjectMeta::GameServer_ObjectMeta()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_sdk_2eproto::InitDefaultsGameServer_ObjectMeta();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:stable.agones.dev.sdk.GameServer.ObjectMeta)
+}
+GameServer_ObjectMeta::GameServer_ObjectMeta(const GameServer_ObjectMeta& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  annotations_.MergeFrom(from.annotations_);
+  labels_.MergeFrom(from.labels_);
+  name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.name().size() > 0) {
+    name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
+  }
+  namespace__.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.namespace_().size() > 0) {
+    namespace__.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.namespace__);
+  }
+  uid_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.uid().size() > 0) {
+    uid_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.uid_);
+  }
+  resource_version_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.resource_version().size() > 0) {
+    resource_version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.resource_version_);
+  }
+  ::memcpy(&generation_, &from.generation_,
+    static_cast<size_t>(reinterpret_cast<char*>(&deletion_timestamp_) -
+    reinterpret_cast<char*>(&generation_)) + sizeof(deletion_timestamp_));
+  // @@protoc_insertion_point(copy_constructor:stable.agones.dev.sdk.GameServer.ObjectMeta)
+}
+
+void GameServer_ObjectMeta::SharedCtor() {
+  name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  namespace__.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  uid_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  resource_version_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(&generation_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&deletion_timestamp_) -
+      reinterpret_cast<char*>(&generation_)) + sizeof(deletion_timestamp_));
+  _cached_size_ = 0;
+}
+
+GameServer_ObjectMeta::~GameServer_ObjectMeta() {
+  // @@protoc_insertion_point(destructor:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  SharedDtor();
+}
+
+void GameServer_ObjectMeta::SharedDtor() {
+  name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  namespace__.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  uid_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  resource_version_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void GameServer_ObjectMeta::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GameServer_ObjectMeta::descriptor() {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GameServer_ObjectMeta& GameServer_ObjectMeta::default_instance() {
+  ::protobuf_sdk_2eproto::InitDefaultsGameServer_ObjectMeta();
+  return *internal_default_instance();
+}
+
+GameServer_ObjectMeta* GameServer_ObjectMeta::New(::google::protobuf::Arena* arena) const {
+  GameServer_ObjectMeta* n = new GameServer_ObjectMeta;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void GameServer_ObjectMeta::Clear() {
+// @@protoc_insertion_point(message_clear_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  annotations_.Clear();
+  labels_.Clear();
+  name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  namespace__.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  uid_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  resource_version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  ::memset(&generation_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&deletion_timestamp_) -
+      reinterpret_cast<char*>(&generation_)) + sizeof(deletion_timestamp_));
+  _internal_metadata_.Clear();
+}
+
+bool GameServer_ObjectMeta::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->name().data(), static_cast<int>(this->name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string namespace = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_namespace_()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->namespace_().data(), static_cast<int>(this->namespace_().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.namespace"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string uid = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_uid()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->uid().data(), static_cast<int>(this->uid().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.uid"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string resource_version = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_resource_version()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->resource_version().data(), static_cast<int>(this->resource_version().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int64 generation = 5;
+      case 5: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(40u /* 40 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &generation_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int64 creation_timestamp = 6;
+      case 6: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(48u /* 48 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &creation_timestamp_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int64 deletion_timestamp = 7;
+      case 7: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(56u /* 56 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int64, ::google::protobuf::internal::WireFormatLite::TYPE_INT64>(
+                 input, &deletion_timestamp_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> annotations = 8;
+      case 8: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
+          GameServer_ObjectMeta_AnnotationsEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              GameServer_ObjectMeta_AnnotationsEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&annotations_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // map<string, string> labels = 9;
+      case 9: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(74u /* 74 & 0xFF */)) {
+          GameServer_ObjectMeta_LabelsEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
+              GameServer_ObjectMeta_LabelsEntry_DoNotUse,
+              ::std::string, ::std::string,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+              0 >,
+            ::google::protobuf::Map< ::std::string, ::std::string > > parser(&labels_);
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+              input, &parser));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.key().data(), static_cast<int>(parser.key().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry.key"));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            parser.value().data(), static_cast<int>(parser.value().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry.value"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  return false;
+#undef DO_
+}
+
+void GameServer_ObjectMeta::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->name().data(), static_cast<int>(this->name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->name(), output);
+  }
+
+  // string namespace = 2;
+  if (this->namespace_().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->namespace_().data(), static_cast<int>(this->namespace_().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.namespace");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->namespace_(), output);
+  }
+
+  // string uid = 3;
+  if (this->uid().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->uid().data(), static_cast<int>(this->uid().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.uid");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      3, this->uid(), output);
+  }
+
+  // string resource_version = 4;
+  if (this->resource_version().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->resource_version().data(), static_cast<int>(this->resource_version().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      4, this->resource_version(), output);
+  }
+
+  // int64 generation = 5;
+  if (this->generation() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(5, this->generation(), output);
+  }
+
+  // int64 creation_timestamp = 6;
+  if (this->creation_timestamp() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->creation_timestamp(), output);
+  }
+
+  // int64 deletion_timestamp = 7;
+  if (this->deletion_timestamp() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt64(7, this->deletion_timestamp(), output);
+  }
+
+  // map<string, string> annotations = 8;
+  if (!this->annotations().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->annotations().size() > 1) {
+      ::google::protobuf::scoped_array<SortItem> items(
+          new SortItem[this->annotations().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->annotations().begin();
+          it != this->annotations().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(annotations_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            8, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->annotations().begin();
+          it != this->annotations().end(); ++it) {
+        entry.reset(annotations_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            8, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  // map<string, string> labels = 9;
+  if (!this->labels().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry.value");
+      }
+    };
+
+    if (output->IsSerializationDeterministic() &&
+        this->labels().size() > 1) {
+      ::google::protobuf::scoped_array<SortItem> items(
+          new SortItem[this->labels().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->labels().begin();
+          it != this->labels().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_LabelsEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(labels_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            9, *entry, output);
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_LabelsEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->labels().begin();
+          it != this->labels().end(); ++it) {
+        entry.reset(labels_.NewEntryWrapper(
+            it->first, it->second));
+        ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+            9, *entry, output);
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:stable.agones.dev.sdk.GameServer.ObjectMeta)
+}
+
+::google::protobuf::uint8* GameServer_ObjectMeta::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->name().data(), static_cast<int>(this->name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->name(), target);
+  }
+
+  // string namespace = 2;
+  if (this->namespace_().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->namespace_().data(), static_cast<int>(this->namespace_().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.namespace");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->namespace_(), target);
+  }
+
+  // string uid = 3;
+  if (this->uid().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->uid().data(), static_cast<int>(this->uid().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.uid");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        3, this->uid(), target);
+  }
+
+  // string resource_version = 4;
+  if (this->resource_version().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->resource_version().data(), static_cast<int>(this->resource_version().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        4, this->resource_version(), target);
+  }
+
+  // int64 generation = 5;
+  if (this->generation() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(5, this->generation(), target);
+  }
+
+  // int64 creation_timestamp = 6;
+  if (this->creation_timestamp() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->creation_timestamp(), target);
+  }
+
+  // int64 deletion_timestamp = 7;
+  if (this->deletion_timestamp() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(7, this->deletion_timestamp(), target);
+  }
+
+  // map<string, string> annotations = 8;
+  if (!this->annotations().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->annotations().size() > 1) {
+      ::google::protobuf::scoped_array<SortItem> items(
+          new SortItem[this->annotations().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->annotations().begin();
+          it != this->annotations().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(annotations_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       8, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->annotations().begin();
+          it != this->annotations().end(); ++it) {
+        entry.reset(annotations_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       8, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  // map<string, string> labels = 9;
+  if (!this->labels().empty()) {
+    typedef ::google::protobuf::Map< ::std::string, ::std::string >::const_pointer
+        ConstPtr;
+    typedef ConstPtr SortItem;
+    typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
+    struct Utf8Check {
+      static void Check(ConstPtr p) {
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->first.data(), static_cast<int>(p->first.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry.key");
+        ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          p->second.data(), static_cast<int>(p->second.length()),
+          ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+          "stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry.value");
+      }
+    };
+
+    if (deterministic &&
+        this->labels().size() > 1) {
+      ::google::protobuf::scoped_array<SortItem> items(
+          new SortItem[this->labels().size()]);
+      typedef ::google::protobuf::Map< ::std::string, ::std::string >::size_type size_type;
+      size_type n = 0;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->labels().begin();
+          it != this->labels().end(); ++it, ++n) {
+        items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
+      }
+      ::std::sort(&items[0], &items[static_cast<ptrdiff_t>(n)], Less());
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_LabelsEntry_DoNotUse> entry;
+      for (size_type i = 0; i < n; i++) {
+        entry.reset(labels_.NewEntryWrapper(
+            items[static_cast<ptrdiff_t>(i)]->first, items[static_cast<ptrdiff_t>(i)]->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       9, *entry, deterministic, target);
+;
+        Utf8Check::Check(items[static_cast<ptrdiff_t>(i)]);
+      }
+    } else {
+      ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_LabelsEntry_DoNotUse> entry;
+      for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+          it = this->labels().begin();
+          it != this->labels().end(); ++it) {
+        entry.reset(labels_.NewEntryWrapper(
+            it->first, it->second));
+        target = ::google::protobuf::internal::WireFormatLite::
+                   InternalWriteMessageNoVirtualToArray(
+                       9, *entry, deterministic, target);
+;
+        Utf8Check::Check(&*it);
+      }
+    }
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  return target;
+}
+
+size_t GameServer_ObjectMeta::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // map<string, string> annotations = 8;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->annotations_size());
+  {
+    ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->annotations().begin();
+        it != this->annotations().end(); ++it) {
+      entry.reset(annotations_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // map<string, string> labels = 9;
+  total_size += 1 *
+      ::google::protobuf::internal::FromIntSize(this->labels_size());
+  {
+    ::google::protobuf::scoped_ptr<GameServer_ObjectMeta_LabelsEntry_DoNotUse> entry;
+    for (::google::protobuf::Map< ::std::string, ::std::string >::const_iterator
+        it = this->labels().begin();
+        it != this->labels().end(); ++it) {
+      entry.reset(labels_.NewEntryWrapper(it->first, it->second));
+      total_size += ::google::protobuf::internal::WireFormatLite::
+          MessageSizeNoVirtual(*entry);
+    }
+  }
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->name());
+  }
+
+  // string namespace = 2;
+  if (this->namespace_().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->namespace_());
+  }
+
+  // string uid = 3;
+  if (this->uid().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->uid());
+  }
+
+  // string resource_version = 4;
+  if (this->resource_version().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->resource_version());
+  }
+
+  // int64 generation = 5;
+  if (this->generation() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->generation());
+  }
+
+  // int64 creation_timestamp = 6;
+  if (this->creation_timestamp() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->creation_timestamp());
+  }
+
+  // int64 deletion_timestamp = 7;
+  if (this->deletion_timestamp() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int64Size(
+        this->deletion_timestamp());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GameServer_ObjectMeta::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GameServer_ObjectMeta* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GameServer_ObjectMeta>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:stable.agones.dev.sdk.GameServer.ObjectMeta)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:stable.agones.dev.sdk.GameServer.ObjectMeta)
+    MergeFrom(*source);
+  }
+}
+
+void GameServer_ObjectMeta::MergeFrom(const GameServer_ObjectMeta& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  annotations_.MergeFrom(from.annotations_);
+  labels_.MergeFrom(from.labels_);
+  if (from.name().size() > 0) {
+
+    name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
+  }
+  if (from.namespace_().size() > 0) {
+
+    namespace__.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.namespace__);
+  }
+  if (from.uid().size() > 0) {
+
+    uid_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.uid_);
+  }
+  if (from.resource_version().size() > 0) {
+
+    resource_version_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.resource_version_);
+  }
+  if (from.generation() != 0) {
+    set_generation(from.generation());
+  }
+  if (from.creation_timestamp() != 0) {
+    set_creation_timestamp(from.creation_timestamp());
+  }
+  if (from.deletion_timestamp() != 0) {
+    set_deletion_timestamp(from.deletion_timestamp());
+  }
+}
+
+void GameServer_ObjectMeta::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GameServer_ObjectMeta::CopyFrom(const GameServer_ObjectMeta& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:stable.agones.dev.sdk.GameServer.ObjectMeta)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GameServer_ObjectMeta::IsInitialized() const {
+  return true;
+}
+
+void GameServer_ObjectMeta::Swap(GameServer_ObjectMeta* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GameServer_ObjectMeta::InternalSwap(GameServer_ObjectMeta* other) {
+  using std::swap;
+  annotations_.Swap(&other->annotations_);
+  labels_.Swap(&other->labels_);
+  name_.Swap(&other->name_);
+  namespace__.Swap(&other->namespace__);
+  uid_.Swap(&other->uid_);
+  resource_version_.Swap(&other->resource_version_);
+  swap(generation_, other->generation_);
+  swap(creation_timestamp_, other->creation_timestamp_);
+  swap(deletion_timestamp_, other->deletion_timestamp_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata GameServer_ObjectMeta::GetMetadata() const {
+  protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void GameServer_Spec_Health::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GameServer_Spec_Health::kDisabledFieldNumber;
+const int GameServer_Spec_Health::kPeriodSecondsFieldNumber;
+const int GameServer_Spec_Health::kFailureThresholdFieldNumber;
+const int GameServer_Spec_Health::kInitialDelaySecondsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GameServer_Spec_Health::GameServer_Spec_Health()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_sdk_2eproto::InitDefaultsGameServer_Spec_Health();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:stable.agones.dev.sdk.GameServer.Spec.Health)
+}
+GameServer_Spec_Health::GameServer_Spec_Health(const GameServer_Spec_Health& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::memcpy(&disabled_, &from.disabled_,
+    static_cast<size_t>(reinterpret_cast<char*>(&initialdelayseconds_) -
+    reinterpret_cast<char*>(&disabled_)) + sizeof(initialdelayseconds_));
+  // @@protoc_insertion_point(copy_constructor:stable.agones.dev.sdk.GameServer.Spec.Health)
+}
+
+void GameServer_Spec_Health::SharedCtor() {
+  ::memset(&disabled_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&initialdelayseconds_) -
+      reinterpret_cast<char*>(&disabled_)) + sizeof(initialdelayseconds_));
+  _cached_size_ = 0;
+}
+
+GameServer_Spec_Health::~GameServer_Spec_Health() {
+  // @@protoc_insertion_point(destructor:stable.agones.dev.sdk.GameServer.Spec.Health)
+  SharedDtor();
+}
+
+void GameServer_Spec_Health::SharedDtor() {
+}
+
+void GameServer_Spec_Health::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GameServer_Spec_Health::descriptor() {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GameServer_Spec_Health& GameServer_Spec_Health::default_instance() {
+  ::protobuf_sdk_2eproto::InitDefaultsGameServer_Spec_Health();
+  return *internal_default_instance();
+}
+
+GameServer_Spec_Health* GameServer_Spec_Health::New(::google::protobuf::Arena* arena) const {
+  GameServer_Spec_Health* n = new GameServer_Spec_Health;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void GameServer_Spec_Health::Clear() {
+// @@protoc_insertion_point(message_clear_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&disabled_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&initialdelayseconds_) -
+      reinterpret_cast<char*>(&disabled_)) + sizeof(initialdelayseconds_));
+  _internal_metadata_.Clear();
+}
+
+bool GameServer_Spec_Health::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // bool Disabled = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &disabled_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int32 PeriodSeconds = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(16u /* 16 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &periodseconds_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int32 FailureThreshold = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(24u /* 24 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &failurethreshold_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int32 InitialDelaySeconds = 4;
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(32u /* 32 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &initialdelayseconds_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:stable.agones.dev.sdk.GameServer.Spec.Health)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:stable.agones.dev.sdk.GameServer.Spec.Health)
+  return false;
+#undef DO_
+}
+
+void GameServer_Spec_Health::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool Disabled = 1;
+  if (this->disabled() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->disabled(), output);
+  }
+
+  // int32 PeriodSeconds = 2;
+  if (this->periodseconds() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->periodseconds(), output);
+  }
+
+  // int32 FailureThreshold = 3;
+  if (this->failurethreshold() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->failurethreshold(), output);
+  }
+
+  // int32 InitialDelaySeconds = 4;
+  if (this->initialdelayseconds() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(4, this->initialdelayseconds(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:stable.agones.dev.sdk.GameServer.Spec.Health)
+}
+
+::google::protobuf::uint8* GameServer_Spec_Health::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool Disabled = 1;
+  if (this->disabled() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->disabled(), target);
+  }
+
+  // int32 PeriodSeconds = 2;
+  if (this->periodseconds() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->periodseconds(), target);
+  }
+
+  // int32 FailureThreshold = 3;
+  if (this->failurethreshold() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->failurethreshold(), target);
+  }
+
+  // int32 InitialDelaySeconds = 4;
+  if (this->initialdelayseconds() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(4, this->initialdelayseconds(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:stable.agones.dev.sdk.GameServer.Spec.Health)
+  return target;
+}
+
+size_t GameServer_Spec_Health::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // bool Disabled = 1;
+  if (this->disabled() != 0) {
+    total_size += 1 + 1;
+  }
+
+  // int32 PeriodSeconds = 2;
+  if (this->periodseconds() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int32Size(
+        this->periodseconds());
+  }
+
+  // int32 FailureThreshold = 3;
+  if (this->failurethreshold() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int32Size(
+        this->failurethreshold());
+  }
+
+  // int32 InitialDelaySeconds = 4;
+  if (this->initialdelayseconds() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int32Size(
+        this->initialdelayseconds());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GameServer_Spec_Health::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GameServer_Spec_Health* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GameServer_Spec_Health>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:stable.agones.dev.sdk.GameServer.Spec.Health)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:stable.agones.dev.sdk.GameServer.Spec.Health)
+    MergeFrom(*source);
+  }
+}
+
+void GameServer_Spec_Health::MergeFrom(const GameServer_Spec_Health& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.disabled() != 0) {
+    set_disabled(from.disabled());
+  }
+  if (from.periodseconds() != 0) {
+    set_periodseconds(from.periodseconds());
+  }
+  if (from.failurethreshold() != 0) {
+    set_failurethreshold(from.failurethreshold());
+  }
+  if (from.initialdelayseconds() != 0) {
+    set_initialdelayseconds(from.initialdelayseconds());
+  }
+}
+
+void GameServer_Spec_Health::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GameServer_Spec_Health::CopyFrom(const GameServer_Spec_Health& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:stable.agones.dev.sdk.GameServer.Spec.Health)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GameServer_Spec_Health::IsInitialized() const {
+  return true;
+}
+
+void GameServer_Spec_Health::Swap(GameServer_Spec_Health* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GameServer_Spec_Health::InternalSwap(GameServer_Spec_Health* other) {
+  using std::swap;
+  swap(disabled_, other->disabled_);
+  swap(periodseconds_, other->periodseconds_);
+  swap(failurethreshold_, other->failurethreshold_);
+  swap(initialdelayseconds_, other->initialdelayseconds_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata GameServer_Spec_Health::GetMetadata() const {
+  protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void GameServer_Spec::InitAsDefaultInstance() {
+  ::stable::agones::dev::sdk::_GameServer_Spec_default_instance_._instance.get_mutable()->health_ = const_cast< ::stable::agones::dev::sdk::GameServer_Spec_Health*>(
+      ::stable::agones::dev::sdk::GameServer_Spec_Health::internal_default_instance());
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GameServer_Spec::kHealthFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GameServer_Spec::GameServer_Spec()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_sdk_2eproto::InitDefaultsGameServer_Spec();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:stable.agones.dev.sdk.GameServer.Spec)
+}
+GameServer_Spec::GameServer_Spec(const GameServer_Spec& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  if (from.has_health()) {
+    health_ = new ::stable::agones::dev::sdk::GameServer_Spec_Health(*from.health_);
+  } else {
+    health_ = NULL;
+  }
+  // @@protoc_insertion_point(copy_constructor:stable.agones.dev.sdk.GameServer.Spec)
+}
+
+void GameServer_Spec::SharedCtor() {
+  health_ = NULL;
+  _cached_size_ = 0;
+}
+
+GameServer_Spec::~GameServer_Spec() {
+  // @@protoc_insertion_point(destructor:stable.agones.dev.sdk.GameServer.Spec)
+  SharedDtor();
+}
+
+void GameServer_Spec::SharedDtor() {
+  if (this != internal_default_instance()) delete health_;
+}
+
+void GameServer_Spec::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GameServer_Spec::descriptor() {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GameServer_Spec& GameServer_Spec::default_instance() {
+  ::protobuf_sdk_2eproto::InitDefaultsGameServer_Spec();
+  return *internal_default_instance();
+}
+
+GameServer_Spec* GameServer_Spec::New(::google::protobuf::Arena* arena) const {
+  GameServer_Spec* n = new GameServer_Spec;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void GameServer_Spec::Clear() {
+// @@protoc_insertion_point(message_clear_start:stable.agones.dev.sdk.GameServer.Spec)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaNoVirtual() == NULL && health_ != NULL) {
+    delete health_;
+  }
+  health_ = NULL;
+  _internal_metadata_.Clear();
+}
+
+bool GameServer_Spec::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:stable.agones.dev.sdk.GameServer.Spec)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_health()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:stable.agones.dev.sdk.GameServer.Spec)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:stable.agones.dev.sdk.GameServer.Spec)
+  return false;
+#undef DO_
+}
+
+void GameServer_Spec::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:stable.agones.dev.sdk.GameServer.Spec)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+  if (this->has_health()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->health_, output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:stable.agones.dev.sdk.GameServer.Spec)
+}
+
+::google::protobuf::uint8* GameServer_Spec::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:stable.agones.dev.sdk.GameServer.Spec)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+  if (this->has_health()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, *this->health_, deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:stable.agones.dev.sdk.GameServer.Spec)
+  return target;
+}
+
+size_t GameServer_Spec::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:stable.agones.dev.sdk.GameServer.Spec)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+  if (this->has_health()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *this->health_);
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GameServer_Spec::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:stable.agones.dev.sdk.GameServer.Spec)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GameServer_Spec* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GameServer_Spec>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:stable.agones.dev.sdk.GameServer.Spec)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:stable.agones.dev.sdk.GameServer.Spec)
+    MergeFrom(*source);
+  }
+}
+
+void GameServer_Spec::MergeFrom(const GameServer_Spec& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:stable.agones.dev.sdk.GameServer.Spec)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_health()) {
+    mutable_health()->::stable::agones::dev::sdk::GameServer_Spec_Health::MergeFrom(from.health());
+  }
+}
+
+void GameServer_Spec::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:stable.agones.dev.sdk.GameServer.Spec)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GameServer_Spec::CopyFrom(const GameServer_Spec& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:stable.agones.dev.sdk.GameServer.Spec)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GameServer_Spec::IsInitialized() const {
+  return true;
+}
+
+void GameServer_Spec::Swap(GameServer_Spec* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GameServer_Spec::InternalSwap(GameServer_Spec* other) {
+  using std::swap;
+  swap(health_, other->health_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata GameServer_Spec::GetMetadata() const {
+  protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void GameServer_Status_Port::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GameServer_Status_Port::kNameFieldNumber;
+const int GameServer_Status_Port::kPortFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GameServer_Status_Port::GameServer_Status_Port()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_sdk_2eproto::InitDefaultsGameServer_Status_Port();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:stable.agones.dev.sdk.GameServer.Status.Port)
+}
+GameServer_Status_Port::GameServer_Status_Port(const GameServer_Status_Port& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.name().size() > 0) {
+    name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
+  }
+  port_ = from.port_;
+  // @@protoc_insertion_point(copy_constructor:stable.agones.dev.sdk.GameServer.Status.Port)
+}
+
+void GameServer_Status_Port::SharedCtor() {
+  name_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  port_ = 0;
+  _cached_size_ = 0;
+}
+
+GameServer_Status_Port::~GameServer_Status_Port() {
+  // @@protoc_insertion_point(destructor:stable.agones.dev.sdk.GameServer.Status.Port)
+  SharedDtor();
+}
+
+void GameServer_Status_Port::SharedDtor() {
+  name_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void GameServer_Status_Port::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GameServer_Status_Port::descriptor() {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GameServer_Status_Port& GameServer_Status_Port::default_instance() {
+  ::protobuf_sdk_2eproto::InitDefaultsGameServer_Status_Port();
+  return *internal_default_instance();
+}
+
+GameServer_Status_Port* GameServer_Status_Port::New(::google::protobuf::Arena* arena) const {
+  GameServer_Status_Port* n = new GameServer_Status_Port;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void GameServer_Status_Port::Clear() {
+// @@protoc_insertion_point(message_clear_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  port_ = 0;
+  _internal_metadata_.Clear();
+}
+
+bool GameServer_Status_Port::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string name = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_name()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->name().data(), static_cast<int>(this->name().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.Status.Port.name"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // int32 port = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(16u /* 16 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, &port_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:stable.agones.dev.sdk.GameServer.Status.Port)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:stable.agones.dev.sdk.GameServer.Status.Port)
+  return false;
+#undef DO_
+}
+
+void GameServer_Status_Port::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->name().data(), static_cast<int>(this->name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.Status.Port.name");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->name(), output);
+  }
+
+  // int32 port = 2;
+  if (this->port() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32(2, this->port(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:stable.agones.dev.sdk.GameServer.Status.Port)
+}
+
+::google::protobuf::uint8* GameServer_Status_Port::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string name = 1;
+  if (this->name().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->name().data(), static_cast<int>(this->name().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.Status.Port.name");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->name(), target);
+  }
+
+  // int32 port = 2;
+  if (this->port() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(2, this->port(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:stable.agones.dev.sdk.GameServer.Status.Port)
+  return target;
+}
+
+size_t GameServer_Status_Port::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string name = 1;
+  if (this->name().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->name());
+  }
+
+  // int32 port = 2;
+  if (this->port() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::Int32Size(
+        this->port());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GameServer_Status_Port::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GameServer_Status_Port* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GameServer_Status_Port>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:stable.agones.dev.sdk.GameServer.Status.Port)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:stable.agones.dev.sdk.GameServer.Status.Port)
+    MergeFrom(*source);
+  }
+}
+
+void GameServer_Status_Port::MergeFrom(const GameServer_Status_Port& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.name().size() > 0) {
+
+    name_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name_);
+  }
+  if (from.port() != 0) {
+    set_port(from.port());
+  }
+}
+
+void GameServer_Status_Port::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GameServer_Status_Port::CopyFrom(const GameServer_Status_Port& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:stable.agones.dev.sdk.GameServer.Status.Port)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GameServer_Status_Port::IsInitialized() const {
+  return true;
+}
+
+void GameServer_Status_Port::Swap(GameServer_Status_Port* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GameServer_Status_Port::InternalSwap(GameServer_Status_Port* other) {
+  using std::swap;
+  name_.Swap(&other->name_);
+  swap(port_, other->port_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata GameServer_Status_Port::GetMetadata() const {
+  protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void GameServer_Status::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GameServer_Status::kStateFieldNumber;
+const int GameServer_Status::kAddressFieldNumber;
+const int GameServer_Status::kPortsFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GameServer_Status::GameServer_Status()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_sdk_2eproto::InitDefaultsGameServer_Status();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:stable.agones.dev.sdk.GameServer.Status)
+}
+GameServer_Status::GameServer_Status(const GameServer_Status& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      ports_(from.ports_),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  state_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.state().size() > 0) {
+    state_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.state_);
+  }
+  address_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.address().size() > 0) {
+    address_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.address_);
+  }
+  // @@protoc_insertion_point(copy_constructor:stable.agones.dev.sdk.GameServer.Status)
+}
+
+void GameServer_Status::SharedCtor() {
+  state_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  address_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _cached_size_ = 0;
+}
+
+GameServer_Status::~GameServer_Status() {
+  // @@protoc_insertion_point(destructor:stable.agones.dev.sdk.GameServer.Status)
+  SharedDtor();
+}
+
+void GameServer_Status::SharedDtor() {
+  state_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  address_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void GameServer_Status::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GameServer_Status::descriptor() {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GameServer_Status& GameServer_Status::default_instance() {
+  ::protobuf_sdk_2eproto::InitDefaultsGameServer_Status();
+  return *internal_default_instance();
+}
+
+GameServer_Status* GameServer_Status::New(::google::protobuf::Arena* arena) const {
+  GameServer_Status* n = new GameServer_Status;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void GameServer_Status::Clear() {
+// @@protoc_insertion_point(message_clear_start:stable.agones.dev.sdk.GameServer.Status)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ports_.Clear();
+  state_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  address_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool GameServer_Status::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:stable.agones.dev.sdk.GameServer.Status)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string state = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_state()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->state().data(), static_cast<int>(this->state().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.Status.state"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string address = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_address()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->address().data(), static_cast<int>(this->address().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "stable.agones.dev.sdk.GameServer.Status.address"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(input, add_ports()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:stable.agones.dev.sdk.GameServer.Status)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:stable.agones.dev.sdk.GameServer.Status)
+  return false;
+#undef DO_
+}
+
+void GameServer_Status::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:stable.agones.dev.sdk.GameServer.Status)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string state = 1;
+  if (this->state().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->state().data(), static_cast<int>(this->state().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.Status.state");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->state(), output);
+  }
+
+  // string address = 2;
+  if (this->address().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->address().data(), static_cast<int>(this->address().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.Status.address");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->address(), output);
+  }
+
+  // repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->ports_size()); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, this->ports(static_cast<int>(i)), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:stable.agones.dev.sdk.GameServer.Status)
+}
+
+::google::protobuf::uint8* GameServer_Status::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:stable.agones.dev.sdk.GameServer.Status)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string state = 1;
+  if (this->state().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->state().data(), static_cast<int>(this->state().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.Status.state");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->state(), target);
+  }
+
+  // string address = 2;
+  if (this->address().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->address().data(), static_cast<int>(this->address().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "stable.agones.dev.sdk.GameServer.Status.address");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->address(), target);
+  }
+
+  // repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->ports_size()); i < n; i++) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        3, this->ports(static_cast<int>(i)), deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:stable.agones.dev.sdk.GameServer.Status)
+  return target;
+}
+
+size_t GameServer_Status::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:stable.agones.dev.sdk.GameServer.Status)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+  {
+    unsigned int count = static_cast<unsigned int>(this->ports_size());
+    total_size += 1UL * count;
+    for (unsigned int i = 0; i < count; i++) {
+      total_size +=
+        ::google::protobuf::internal::WireFormatLite::MessageSize(
+          this->ports(static_cast<int>(i)));
+    }
+  }
+
+  // string state = 1;
+  if (this->state().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->state());
+  }
+
+  // string address = 2;
+  if (this->address().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->address());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GameServer_Status::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:stable.agones.dev.sdk.GameServer.Status)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GameServer_Status* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GameServer_Status>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:stable.agones.dev.sdk.GameServer.Status)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:stable.agones.dev.sdk.GameServer.Status)
+    MergeFrom(*source);
+  }
+}
+
+void GameServer_Status::MergeFrom(const GameServer_Status& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:stable.agones.dev.sdk.GameServer.Status)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  ports_.MergeFrom(from.ports_);
+  if (from.state().size() > 0) {
+
+    state_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.state_);
+  }
+  if (from.address().size() > 0) {
+
+    address_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.address_);
+  }
+}
+
+void GameServer_Status::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:stable.agones.dev.sdk.GameServer.Status)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GameServer_Status::CopyFrom(const GameServer_Status& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:stable.agones.dev.sdk.GameServer.Status)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GameServer_Status::IsInitialized() const {
+  return true;
+}
+
+void GameServer_Status::Swap(GameServer_Status* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GameServer_Status::InternalSwap(GameServer_Status* other) {
+  using std::swap;
+  ports_.InternalSwap(&other->ports_);
+  state_.Swap(&other->state_);
+  address_.Swap(&other->address_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata GameServer_Status::GetMetadata() const {
+  protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void GameServer::InitAsDefaultInstance() {
+  ::stable::agones::dev::sdk::_GameServer_default_instance_._instance.get_mutable()->object_meta_ = const_cast< ::stable::agones::dev::sdk::GameServer_ObjectMeta*>(
+      ::stable::agones::dev::sdk::GameServer_ObjectMeta::internal_default_instance());
+  ::stable::agones::dev::sdk::_GameServer_default_instance_._instance.get_mutable()->spec_ = const_cast< ::stable::agones::dev::sdk::GameServer_Spec*>(
+      ::stable::agones::dev::sdk::GameServer_Spec::internal_default_instance());
+  ::stable::agones::dev::sdk::_GameServer_default_instance_._instance.get_mutable()->status_ = const_cast< ::stable::agones::dev::sdk::GameServer_Status*>(
+      ::stable::agones::dev::sdk::GameServer_Status::internal_default_instance());
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int GameServer::kObjectMetaFieldNumber;
+const int GameServer::kSpecFieldNumber;
+const int GameServer::kStatusFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+GameServer::GameServer()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  if (GOOGLE_PREDICT_TRUE(this != internal_default_instance())) {
+    ::protobuf_sdk_2eproto::InitDefaultsGameServer();
+  }
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:stable.agones.dev.sdk.GameServer)
+}
+GameServer::GameServer(const GameServer& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL),
+      _cached_size_(0) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  if (from.has_object_meta()) {
+    object_meta_ = new ::stable::agones::dev::sdk::GameServer_ObjectMeta(*from.object_meta_);
+  } else {
+    object_meta_ = NULL;
+  }
+  if (from.has_spec()) {
+    spec_ = new ::stable::agones::dev::sdk::GameServer_Spec(*from.spec_);
+  } else {
+    spec_ = NULL;
+  }
+  if (from.has_status()) {
+    status_ = new ::stable::agones::dev::sdk::GameServer_Status(*from.status_);
+  } else {
+    status_ = NULL;
+  }
+  // @@protoc_insertion_point(copy_constructor:stable.agones.dev.sdk.GameServer)
+}
+
+void GameServer::SharedCtor() {
+  ::memset(&object_meta_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&status_) -
+      reinterpret_cast<char*>(&object_meta_)) + sizeof(status_));
+  _cached_size_ = 0;
+}
+
+GameServer::~GameServer() {
+  // @@protoc_insertion_point(destructor:stable.agones.dev.sdk.GameServer)
+  SharedDtor();
+}
+
+void GameServer::SharedDtor() {
+  if (this != internal_default_instance()) delete object_meta_;
+  if (this != internal_default_instance()) delete spec_;
+  if (this != internal_default_instance()) delete status_;
+}
+
+void GameServer::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* GameServer::descriptor() {
+  ::protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const GameServer& GameServer::default_instance() {
+  ::protobuf_sdk_2eproto::InitDefaultsGameServer();
+  return *internal_default_instance();
+}
+
+GameServer* GameServer::New(::google::protobuf::Arena* arena) const {
+  GameServer* n = new GameServer;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void GameServer::Clear() {
+// @@protoc_insertion_point(message_clear_start:stable.agones.dev.sdk.GameServer)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaNoVirtual() == NULL && object_meta_ != NULL) {
+    delete object_meta_;
+  }
+  object_meta_ = NULL;
+  if (GetArenaNoVirtual() == NULL && spec_ != NULL) {
+    delete spec_;
+  }
+  spec_ = NULL;
+  if (GetArenaNoVirtual() == NULL && status_ != NULL) {
+    delete status_;
+  }
+  status_ = NULL;
+  _internal_metadata_.Clear();
+}
+
+bool GameServer::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:stable.agones.dev.sdk.GameServer)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_object_meta()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_spec()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // .stable.agones.dev.sdk.GameServer.Status status = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessage(
+               input, mutable_status()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:stable.agones.dev.sdk.GameServer)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:stable.agones.dev.sdk.GameServer)
+  return false;
+#undef DO_
+}
+
+void GameServer::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:stable.agones.dev.sdk.GameServer)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+  if (this->has_object_meta()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      1, *this->object_meta_, output);
+  }
+
+  // .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+  if (this->has_spec()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      2, *this->spec_, output);
+  }
+
+  // .stable.agones.dev.sdk.GameServer.Status status = 3;
+  if (this->has_status()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      3, *this->status_, output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:stable.agones.dev.sdk.GameServer)
+}
+
+::google::protobuf::uint8* GameServer::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:stable.agones.dev.sdk.GameServer)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+  if (this->has_object_meta()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        1, *this->object_meta_, deterministic, target);
+  }
+
+  // .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+  if (this->has_spec()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        2, *this->spec_, deterministic, target);
+  }
+
+  // .stable.agones.dev.sdk.GameServer.Status status = 3;
+  if (this->has_status()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      InternalWriteMessageToArray(
+        3, *this->status_, deterministic, target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:stable.agones.dev.sdk.GameServer)
+  return target;
+}
+
+size_t GameServer::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:stable.agones.dev.sdk.GameServer)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+  if (this->has_object_meta()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *this->object_meta_);
+  }
+
+  // .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+  if (this->has_spec()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *this->spec_);
+  }
+
+  // .stable.agones.dev.sdk.GameServer.Status status = 3;
+  if (this->has_status()) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::MessageSize(
+        *this->status_);
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = cached_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void GameServer::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:stable.agones.dev.sdk.GameServer)
+  GOOGLE_DCHECK_NE(&from, this);
+  const GameServer* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const GameServer>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:stable.agones.dev.sdk.GameServer)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:stable.agones.dev.sdk.GameServer)
+    MergeFrom(*source);
+  }
+}
+
+void GameServer::MergeFrom(const GameServer& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:stable.agones.dev.sdk.GameServer)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_object_meta()) {
+    mutable_object_meta()->::stable::agones::dev::sdk::GameServer_ObjectMeta::MergeFrom(from.object_meta());
+  }
+  if (from.has_spec()) {
+    mutable_spec()->::stable::agones::dev::sdk::GameServer_Spec::MergeFrom(from.spec());
+  }
+  if (from.has_status()) {
+    mutable_status()->::stable::agones::dev::sdk::GameServer_Status::MergeFrom(from.status());
+  }
+}
+
+void GameServer::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:stable.agones.dev.sdk.GameServer)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void GameServer::CopyFrom(const GameServer& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:stable.agones.dev.sdk.GameServer)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool GameServer::IsInitialized() const {
+  return true;
+}
+
+void GameServer::Swap(GameServer* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void GameServer::InternalSwap(GameServer* other) {
+  using std::swap;
+  swap(object_meta_, other->object_meta_);
+  swap(spec_, other->spec_);
+  swap(status_, other->status_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata GameServer::GetMetadata() const {
   protobuf_sdk_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_sdk_2eproto::file_level_metadata[kIndexInFileMessages];
 }

--- a/sdks/cpp/sdk.pb.h
+++ b/sdks/cpp/sdk.pb.h
@@ -43,6 +43,9 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>  // IWYU pragma: export
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
+#include <google/protobuf/map.h>  // IWYU pragma: export
+#include <google/protobuf/map_entry.h>
+#include <google/protobuf/map_field_inl.h>
 #include <google/protobuf/unknown_field_set.h>
 #include "google/api/annotations.pb.h"
 // @@protoc_insertion_point(includes)
@@ -52,7 +55,7 @@ namespace protobuf_sdk_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[1];
+  static const ::google::protobuf::internal::ParseTable schema[9];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -60,8 +63,32 @@ struct TableStruct {
 void AddDescriptors();
 void InitDefaultsEmptyImpl();
 void InitDefaultsEmpty();
+void InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUseImpl();
+void InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUse();
+void InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUseImpl();
+void InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUse();
+void InitDefaultsGameServer_ObjectMetaImpl();
+void InitDefaultsGameServer_ObjectMeta();
+void InitDefaultsGameServer_Spec_HealthImpl();
+void InitDefaultsGameServer_Spec_Health();
+void InitDefaultsGameServer_SpecImpl();
+void InitDefaultsGameServer_Spec();
+void InitDefaultsGameServer_Status_PortImpl();
+void InitDefaultsGameServer_Status_Port();
+void InitDefaultsGameServer_StatusImpl();
+void InitDefaultsGameServer_Status();
+void InitDefaultsGameServerImpl();
+void InitDefaultsGameServer();
 inline void InitDefaults() {
   InitDefaultsEmpty();
+  InitDefaultsGameServer_ObjectMeta_AnnotationsEntry_DoNotUse();
+  InitDefaultsGameServer_ObjectMeta_LabelsEntry_DoNotUse();
+  InitDefaultsGameServer_ObjectMeta();
+  InitDefaultsGameServer_Spec_Health();
+  InitDefaultsGameServer_Spec();
+  InitDefaultsGameServer_Status_Port();
+  InitDefaultsGameServer_Status();
+  InitDefaultsGameServer();
 }
 }  // namespace protobuf_sdk_2eproto
 namespace stable {
@@ -71,6 +98,30 @@ namespace sdk {
 class Empty;
 class EmptyDefaultTypeInternal;
 extern EmptyDefaultTypeInternal _Empty_default_instance_;
+class GameServer;
+class GameServerDefaultTypeInternal;
+extern GameServerDefaultTypeInternal _GameServer_default_instance_;
+class GameServer_ObjectMeta;
+class GameServer_ObjectMetaDefaultTypeInternal;
+extern GameServer_ObjectMetaDefaultTypeInternal _GameServer_ObjectMeta_default_instance_;
+class GameServer_ObjectMeta_AnnotationsEntry_DoNotUse;
+class GameServer_ObjectMeta_AnnotationsEntry_DoNotUseDefaultTypeInternal;
+extern GameServer_ObjectMeta_AnnotationsEntry_DoNotUseDefaultTypeInternal _GameServer_ObjectMeta_AnnotationsEntry_DoNotUse_default_instance_;
+class GameServer_ObjectMeta_LabelsEntry_DoNotUse;
+class GameServer_ObjectMeta_LabelsEntry_DoNotUseDefaultTypeInternal;
+extern GameServer_ObjectMeta_LabelsEntry_DoNotUseDefaultTypeInternal _GameServer_ObjectMeta_LabelsEntry_DoNotUse_default_instance_;
+class GameServer_Spec;
+class GameServer_SpecDefaultTypeInternal;
+extern GameServer_SpecDefaultTypeInternal _GameServer_Spec_default_instance_;
+class GameServer_Spec_Health;
+class GameServer_Spec_HealthDefaultTypeInternal;
+extern GameServer_Spec_HealthDefaultTypeInternal _GameServer_Spec_Health_default_instance_;
+class GameServer_Status;
+class GameServer_StatusDefaultTypeInternal;
+extern GameServer_StatusDefaultTypeInternal _GameServer_Status_default_instance_;
+class GameServer_Status_Port;
+class GameServer_Status_PortDefaultTypeInternal;
+extern GameServer_Status_PortDefaultTypeInternal _GameServer_Status_Port_default_instance_;
 }  // namespace sdk
 }  // namespace dev
 }  // namespace agones
@@ -172,6 +223,853 @@ class Empty : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
   friend struct ::protobuf_sdk_2eproto::TableStruct;
   friend void ::protobuf_sdk_2eproto::InitDefaultsEmptyImpl();
 };
+// -------------------------------------------------------------------
+
+class GameServer_ObjectMeta_AnnotationsEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GameServer_ObjectMeta_AnnotationsEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  GameServer_ObjectMeta_AnnotationsEntry_DoNotUse();
+  GameServer_ObjectMeta_AnnotationsEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const GameServer_ObjectMeta_AnnotationsEntry_DoNotUse& other);
+  static const GameServer_ObjectMeta_AnnotationsEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GameServer_ObjectMeta_AnnotationsEntry_DoNotUse*>(&_GameServer_ObjectMeta_AnnotationsEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) PROTOBUF_FINAL;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class GameServer_ObjectMeta_LabelsEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<GameServer_ObjectMeta_LabelsEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > {
+public:
+  typedef ::google::protobuf::internal::MapEntry<GameServer_ObjectMeta_LabelsEntry_DoNotUse, 
+    ::std::string, ::std::string,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+    0 > SuperType;
+  GameServer_ObjectMeta_LabelsEntry_DoNotUse();
+  GameServer_ObjectMeta_LabelsEntry_DoNotUse(::google::protobuf::Arena* arena);
+  void MergeFrom(const GameServer_ObjectMeta_LabelsEntry_DoNotUse& other);
+  static const GameServer_ObjectMeta_LabelsEntry_DoNotUse* internal_default_instance() { return reinterpret_cast<const GameServer_ObjectMeta_LabelsEntry_DoNotUse*>(&_GameServer_ObjectMeta_LabelsEntry_DoNotUse_default_instance_); }
+  void MergeFrom(const ::google::protobuf::Message& other) PROTOBUF_FINAL;
+  ::google::protobuf::Metadata GetMetadata() const;
+};
+
+// -------------------------------------------------------------------
+
+class GameServer_ObjectMeta : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:stable.agones.dev.sdk.GameServer.ObjectMeta) */ {
+ public:
+  GameServer_ObjectMeta();
+  virtual ~GameServer_ObjectMeta();
+
+  GameServer_ObjectMeta(const GameServer_ObjectMeta& from);
+
+  inline GameServer_ObjectMeta& operator=(const GameServer_ObjectMeta& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GameServer_ObjectMeta(GameServer_ObjectMeta&& from) noexcept
+    : GameServer_ObjectMeta() {
+    *this = ::std::move(from);
+  }
+
+  inline GameServer_ObjectMeta& operator=(GameServer_ObjectMeta&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GameServer_ObjectMeta& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GameServer_ObjectMeta* internal_default_instance() {
+    return reinterpret_cast<const GameServer_ObjectMeta*>(
+               &_GameServer_ObjectMeta_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    3;
+
+  void Swap(GameServer_ObjectMeta* other);
+  friend void swap(GameServer_ObjectMeta& a, GameServer_ObjectMeta& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GameServer_ObjectMeta* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  GameServer_ObjectMeta* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const GameServer_ObjectMeta& from);
+  void MergeFrom(const GameServer_ObjectMeta& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(GameServer_ObjectMeta* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+
+  // accessors -------------------------------------------------------
+
+  // map<string, string> annotations = 8;
+  int annotations_size() const;
+  void clear_annotations();
+  static const int kAnnotationsFieldNumber = 8;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      annotations() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_annotations();
+
+  // map<string, string> labels = 9;
+  int labels_size() const;
+  void clear_labels();
+  static const int kLabelsFieldNumber = 9;
+  const ::google::protobuf::Map< ::std::string, ::std::string >&
+      labels() const;
+  ::google::protobuf::Map< ::std::string, ::std::string >*
+      mutable_labels();
+
+  // string name = 1;
+  void clear_name();
+  static const int kNameFieldNumber = 1;
+  const ::std::string& name() const;
+  void set_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_name(::std::string&& value);
+  #endif
+  void set_name(const char* value);
+  void set_name(const char* value, size_t size);
+  ::std::string* mutable_name();
+  ::std::string* release_name();
+  void set_allocated_name(::std::string* name);
+
+  // string namespace = 2;
+  void clear_namespace_();
+  static const int kNamespaceFieldNumber = 2;
+  const ::std::string& namespace_() const;
+  void set_namespace_(const ::std::string& value);
+  #if LANG_CXX11
+  void set_namespace_(::std::string&& value);
+  #endif
+  void set_namespace_(const char* value);
+  void set_namespace_(const char* value, size_t size);
+  ::std::string* mutable_namespace_();
+  ::std::string* release_namespace_();
+  void set_allocated_namespace_(::std::string* namespace_);
+
+  // string uid = 3;
+  void clear_uid();
+  static const int kUidFieldNumber = 3;
+  const ::std::string& uid() const;
+  void set_uid(const ::std::string& value);
+  #if LANG_CXX11
+  void set_uid(::std::string&& value);
+  #endif
+  void set_uid(const char* value);
+  void set_uid(const char* value, size_t size);
+  ::std::string* mutable_uid();
+  ::std::string* release_uid();
+  void set_allocated_uid(::std::string* uid);
+
+  // string resource_version = 4;
+  void clear_resource_version();
+  static const int kResourceVersionFieldNumber = 4;
+  const ::std::string& resource_version() const;
+  void set_resource_version(const ::std::string& value);
+  #if LANG_CXX11
+  void set_resource_version(::std::string&& value);
+  #endif
+  void set_resource_version(const char* value);
+  void set_resource_version(const char* value, size_t size);
+  ::std::string* mutable_resource_version();
+  ::std::string* release_resource_version();
+  void set_allocated_resource_version(::std::string* resource_version);
+
+  // int64 generation = 5;
+  void clear_generation();
+  static const int kGenerationFieldNumber = 5;
+  ::google::protobuf::int64 generation() const;
+  void set_generation(::google::protobuf::int64 value);
+
+  // int64 creation_timestamp = 6;
+  void clear_creation_timestamp();
+  static const int kCreationTimestampFieldNumber = 6;
+  ::google::protobuf::int64 creation_timestamp() const;
+  void set_creation_timestamp(::google::protobuf::int64 value);
+
+  // int64 deletion_timestamp = 7;
+  void clear_deletion_timestamp();
+  static const int kDeletionTimestampFieldNumber = 7;
+  ::google::protobuf::int64 deletion_timestamp() const;
+  void set_deletion_timestamp(::google::protobuf::int64 value);
+
+  // @@protoc_insertion_point(class_scope:stable.agones.dev.sdk.GameServer.ObjectMeta)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::MapField<
+      GameServer_ObjectMeta_AnnotationsEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > annotations_;
+  ::google::protobuf::internal::MapField<
+      GameServer_ObjectMeta_LabelsEntry_DoNotUse,
+      ::std::string, ::std::string,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
+      0 > labels_;
+  ::google::protobuf::internal::ArenaStringPtr name_;
+  ::google::protobuf::internal::ArenaStringPtr namespace__;
+  ::google::protobuf::internal::ArenaStringPtr uid_;
+  ::google::protobuf::internal::ArenaStringPtr resource_version_;
+  ::google::protobuf::int64 generation_;
+  ::google::protobuf::int64 creation_timestamp_;
+  ::google::protobuf::int64 deletion_timestamp_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_sdk_2eproto::TableStruct;
+  friend void ::protobuf_sdk_2eproto::InitDefaultsGameServer_ObjectMetaImpl();
+};
+// -------------------------------------------------------------------
+
+class GameServer_Spec_Health : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:stable.agones.dev.sdk.GameServer.Spec.Health) */ {
+ public:
+  GameServer_Spec_Health();
+  virtual ~GameServer_Spec_Health();
+
+  GameServer_Spec_Health(const GameServer_Spec_Health& from);
+
+  inline GameServer_Spec_Health& operator=(const GameServer_Spec_Health& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GameServer_Spec_Health(GameServer_Spec_Health&& from) noexcept
+    : GameServer_Spec_Health() {
+    *this = ::std::move(from);
+  }
+
+  inline GameServer_Spec_Health& operator=(GameServer_Spec_Health&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GameServer_Spec_Health& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GameServer_Spec_Health* internal_default_instance() {
+    return reinterpret_cast<const GameServer_Spec_Health*>(
+               &_GameServer_Spec_Health_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    4;
+
+  void Swap(GameServer_Spec_Health* other);
+  friend void swap(GameServer_Spec_Health& a, GameServer_Spec_Health& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GameServer_Spec_Health* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  GameServer_Spec_Health* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const GameServer_Spec_Health& from);
+  void MergeFrom(const GameServer_Spec_Health& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(GameServer_Spec_Health* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // bool Disabled = 1;
+  void clear_disabled();
+  static const int kDisabledFieldNumber = 1;
+  bool disabled() const;
+  void set_disabled(bool value);
+
+  // int32 PeriodSeconds = 2;
+  void clear_periodseconds();
+  static const int kPeriodSecondsFieldNumber = 2;
+  ::google::protobuf::int32 periodseconds() const;
+  void set_periodseconds(::google::protobuf::int32 value);
+
+  // int32 FailureThreshold = 3;
+  void clear_failurethreshold();
+  static const int kFailureThresholdFieldNumber = 3;
+  ::google::protobuf::int32 failurethreshold() const;
+  void set_failurethreshold(::google::protobuf::int32 value);
+
+  // int32 InitialDelaySeconds = 4;
+  void clear_initialdelayseconds();
+  static const int kInitialDelaySecondsFieldNumber = 4;
+  ::google::protobuf::int32 initialdelayseconds() const;
+  void set_initialdelayseconds(::google::protobuf::int32 value);
+
+  // @@protoc_insertion_point(class_scope:stable.agones.dev.sdk.GameServer.Spec.Health)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  bool disabled_;
+  ::google::protobuf::int32 periodseconds_;
+  ::google::protobuf::int32 failurethreshold_;
+  ::google::protobuf::int32 initialdelayseconds_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_sdk_2eproto::TableStruct;
+  friend void ::protobuf_sdk_2eproto::InitDefaultsGameServer_Spec_HealthImpl();
+};
+// -------------------------------------------------------------------
+
+class GameServer_Spec : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:stable.agones.dev.sdk.GameServer.Spec) */ {
+ public:
+  GameServer_Spec();
+  virtual ~GameServer_Spec();
+
+  GameServer_Spec(const GameServer_Spec& from);
+
+  inline GameServer_Spec& operator=(const GameServer_Spec& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GameServer_Spec(GameServer_Spec&& from) noexcept
+    : GameServer_Spec() {
+    *this = ::std::move(from);
+  }
+
+  inline GameServer_Spec& operator=(GameServer_Spec&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GameServer_Spec& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GameServer_Spec* internal_default_instance() {
+    return reinterpret_cast<const GameServer_Spec*>(
+               &_GameServer_Spec_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    5;
+
+  void Swap(GameServer_Spec* other);
+  friend void swap(GameServer_Spec& a, GameServer_Spec& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GameServer_Spec* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  GameServer_Spec* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const GameServer_Spec& from);
+  void MergeFrom(const GameServer_Spec& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(GameServer_Spec* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  typedef GameServer_Spec_Health Health;
+
+  // accessors -------------------------------------------------------
+
+  // .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+  bool has_health() const;
+  void clear_health();
+  static const int kHealthFieldNumber = 1;
+  const ::stable::agones::dev::sdk::GameServer_Spec_Health& health() const;
+  ::stable::agones::dev::sdk::GameServer_Spec_Health* release_health();
+  ::stable::agones::dev::sdk::GameServer_Spec_Health* mutable_health();
+  void set_allocated_health(::stable::agones::dev::sdk::GameServer_Spec_Health* health);
+
+  // @@protoc_insertion_point(class_scope:stable.agones.dev.sdk.GameServer.Spec)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::stable::agones::dev::sdk::GameServer_Spec_Health* health_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_sdk_2eproto::TableStruct;
+  friend void ::protobuf_sdk_2eproto::InitDefaultsGameServer_SpecImpl();
+};
+// -------------------------------------------------------------------
+
+class GameServer_Status_Port : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:stable.agones.dev.sdk.GameServer.Status.Port) */ {
+ public:
+  GameServer_Status_Port();
+  virtual ~GameServer_Status_Port();
+
+  GameServer_Status_Port(const GameServer_Status_Port& from);
+
+  inline GameServer_Status_Port& operator=(const GameServer_Status_Port& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GameServer_Status_Port(GameServer_Status_Port&& from) noexcept
+    : GameServer_Status_Port() {
+    *this = ::std::move(from);
+  }
+
+  inline GameServer_Status_Port& operator=(GameServer_Status_Port&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GameServer_Status_Port& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GameServer_Status_Port* internal_default_instance() {
+    return reinterpret_cast<const GameServer_Status_Port*>(
+               &_GameServer_Status_Port_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    6;
+
+  void Swap(GameServer_Status_Port* other);
+  friend void swap(GameServer_Status_Port& a, GameServer_Status_Port& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GameServer_Status_Port* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  GameServer_Status_Port* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const GameServer_Status_Port& from);
+  void MergeFrom(const GameServer_Status_Port& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(GameServer_Status_Port* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string name = 1;
+  void clear_name();
+  static const int kNameFieldNumber = 1;
+  const ::std::string& name() const;
+  void set_name(const ::std::string& value);
+  #if LANG_CXX11
+  void set_name(::std::string&& value);
+  #endif
+  void set_name(const char* value);
+  void set_name(const char* value, size_t size);
+  ::std::string* mutable_name();
+  ::std::string* release_name();
+  void set_allocated_name(::std::string* name);
+
+  // int32 port = 2;
+  void clear_port();
+  static const int kPortFieldNumber = 2;
+  ::google::protobuf::int32 port() const;
+  void set_port(::google::protobuf::int32 value);
+
+  // @@protoc_insertion_point(class_scope:stable.agones.dev.sdk.GameServer.Status.Port)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr name_;
+  ::google::protobuf::int32 port_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_sdk_2eproto::TableStruct;
+  friend void ::protobuf_sdk_2eproto::InitDefaultsGameServer_Status_PortImpl();
+};
+// -------------------------------------------------------------------
+
+class GameServer_Status : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:stable.agones.dev.sdk.GameServer.Status) */ {
+ public:
+  GameServer_Status();
+  virtual ~GameServer_Status();
+
+  GameServer_Status(const GameServer_Status& from);
+
+  inline GameServer_Status& operator=(const GameServer_Status& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GameServer_Status(GameServer_Status&& from) noexcept
+    : GameServer_Status() {
+    *this = ::std::move(from);
+  }
+
+  inline GameServer_Status& operator=(GameServer_Status&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GameServer_Status& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GameServer_Status* internal_default_instance() {
+    return reinterpret_cast<const GameServer_Status*>(
+               &_GameServer_Status_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    7;
+
+  void Swap(GameServer_Status* other);
+  friend void swap(GameServer_Status& a, GameServer_Status& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GameServer_Status* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  GameServer_Status* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const GameServer_Status& from);
+  void MergeFrom(const GameServer_Status& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(GameServer_Status* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  typedef GameServer_Status_Port Port;
+
+  // accessors -------------------------------------------------------
+
+  // repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+  int ports_size() const;
+  void clear_ports();
+  static const int kPortsFieldNumber = 3;
+  const ::stable::agones::dev::sdk::GameServer_Status_Port& ports(int index) const;
+  ::stable::agones::dev::sdk::GameServer_Status_Port* mutable_ports(int index);
+  ::stable::agones::dev::sdk::GameServer_Status_Port* add_ports();
+  ::google::protobuf::RepeatedPtrField< ::stable::agones::dev::sdk::GameServer_Status_Port >*
+      mutable_ports();
+  const ::google::protobuf::RepeatedPtrField< ::stable::agones::dev::sdk::GameServer_Status_Port >&
+      ports() const;
+
+  // string state = 1;
+  void clear_state();
+  static const int kStateFieldNumber = 1;
+  const ::std::string& state() const;
+  void set_state(const ::std::string& value);
+  #if LANG_CXX11
+  void set_state(::std::string&& value);
+  #endif
+  void set_state(const char* value);
+  void set_state(const char* value, size_t size);
+  ::std::string* mutable_state();
+  ::std::string* release_state();
+  void set_allocated_state(::std::string* state);
+
+  // string address = 2;
+  void clear_address();
+  static const int kAddressFieldNumber = 2;
+  const ::std::string& address() const;
+  void set_address(const ::std::string& value);
+  #if LANG_CXX11
+  void set_address(::std::string&& value);
+  #endif
+  void set_address(const char* value);
+  void set_address(const char* value, size_t size);
+  ::std::string* mutable_address();
+  ::std::string* release_address();
+  void set_allocated_address(::std::string* address);
+
+  // @@protoc_insertion_point(class_scope:stable.agones.dev.sdk.GameServer.Status)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::RepeatedPtrField< ::stable::agones::dev::sdk::GameServer_Status_Port > ports_;
+  ::google::protobuf::internal::ArenaStringPtr state_;
+  ::google::protobuf::internal::ArenaStringPtr address_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_sdk_2eproto::TableStruct;
+  friend void ::protobuf_sdk_2eproto::InitDefaultsGameServer_StatusImpl();
+};
+// -------------------------------------------------------------------
+
+class GameServer : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:stable.agones.dev.sdk.GameServer) */ {
+ public:
+  GameServer();
+  virtual ~GameServer();
+
+  GameServer(const GameServer& from);
+
+  inline GameServer& operator=(const GameServer& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  GameServer(GameServer&& from) noexcept
+    : GameServer() {
+    *this = ::std::move(from);
+  }
+
+  inline GameServer& operator=(GameServer&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const GameServer& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const GameServer* internal_default_instance() {
+    return reinterpret_cast<const GameServer*>(
+               &_GameServer_default_instance_);
+  }
+  static PROTOBUF_CONSTEXPR int const kIndexInFileMessages =
+    8;
+
+  void Swap(GameServer* other);
+  friend void swap(GameServer& a, GameServer& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline GameServer* New() const PROTOBUF_FINAL { return New(NULL); }
+
+  GameServer* New(::google::protobuf::Arena* arena) const PROTOBUF_FINAL;
+  void CopyFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void MergeFrom(const ::google::protobuf::Message& from) PROTOBUF_FINAL;
+  void CopyFrom(const GameServer& from);
+  void MergeFrom(const GameServer& from);
+  void Clear() PROTOBUF_FINAL;
+  bool IsInitialized() const PROTOBUF_FINAL;
+
+  size_t ByteSizeLong() const PROTOBUF_FINAL;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) PROTOBUF_FINAL;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const PROTOBUF_FINAL;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const PROTOBUF_FINAL;
+  int GetCachedSize() const PROTOBUF_FINAL { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const PROTOBUF_FINAL;
+  void InternalSwap(GameServer* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const PROTOBUF_FINAL;
+
+  // nested types ----------------------------------------------------
+
+  typedef GameServer_ObjectMeta ObjectMeta;
+  typedef GameServer_Spec Spec;
+  typedef GameServer_Status Status;
+
+  // accessors -------------------------------------------------------
+
+  // .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+  bool has_object_meta() const;
+  void clear_object_meta();
+  static const int kObjectMetaFieldNumber = 1;
+  const ::stable::agones::dev::sdk::GameServer_ObjectMeta& object_meta() const;
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta* release_object_meta();
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta* mutable_object_meta();
+  void set_allocated_object_meta(::stable::agones::dev::sdk::GameServer_ObjectMeta* object_meta);
+
+  // .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+  bool has_spec() const;
+  void clear_spec();
+  static const int kSpecFieldNumber = 2;
+  const ::stable::agones::dev::sdk::GameServer_Spec& spec() const;
+  ::stable::agones::dev::sdk::GameServer_Spec* release_spec();
+  ::stable::agones::dev::sdk::GameServer_Spec* mutable_spec();
+  void set_allocated_spec(::stable::agones::dev::sdk::GameServer_Spec* spec);
+
+  // .stable.agones.dev.sdk.GameServer.Status status = 3;
+  bool has_status() const;
+  void clear_status();
+  static const int kStatusFieldNumber = 3;
+  const ::stable::agones::dev::sdk::GameServer_Status& status() const;
+  ::stable::agones::dev::sdk::GameServer_Status* release_status();
+  ::stable::agones::dev::sdk::GameServer_Status* mutable_status();
+  void set_allocated_status(::stable::agones::dev::sdk::GameServer_Status* status);
+
+  // @@protoc_insertion_point(class_scope:stable.agones.dev.sdk.GameServer)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta* object_meta_;
+  ::stable::agones::dev::sdk::GameServer_Spec* spec_;
+  ::stable::agones::dev::sdk::GameServer_Status* status_;
+  mutable int _cached_size_;
+  friend struct ::protobuf_sdk_2eproto::TableStruct;
+  friend void ::protobuf_sdk_2eproto::InitDefaultsGameServerImpl();
+};
 // ===================================================================
 
 
@@ -183,9 +1081,802 @@ class Empty : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
 #endif  // __GNUC__
 // Empty
 
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// GameServer_ObjectMeta
+
+// string name = 1;
+inline void GameServer_ObjectMeta::clear_name() {
+  name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_ObjectMeta::name() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+  return name_.GetNoArena();
+}
+inline void GameServer_ObjectMeta::set_name(const ::std::string& value) {
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+}
+#if LANG_CXX11
+inline void GameServer_ObjectMeta::set_name(::std::string&& value) {
+  
+  name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+}
+#endif
+inline void GameServer_ObjectMeta::set_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+}
+inline void GameServer_ObjectMeta::set_name(const char* value, size_t size) {
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+}
+inline ::std::string* GameServer_ObjectMeta::mutable_name() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+  return name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_ObjectMeta::release_name() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+  
+  return name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_ObjectMeta::set_allocated_name(::std::string* name) {
+  if (name != NULL) {
+    
+  } else {
+    
+  }
+  name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.ObjectMeta.name)
+}
+
+// string namespace = 2;
+inline void GameServer_ObjectMeta::clear_namespace_() {
+  namespace__.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_ObjectMeta::namespace_() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+  return namespace__.GetNoArena();
+}
+inline void GameServer_ObjectMeta::set_namespace_(const ::std::string& value) {
+  
+  namespace__.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+}
+#if LANG_CXX11
+inline void GameServer_ObjectMeta::set_namespace_(::std::string&& value) {
+  
+  namespace__.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+}
+#endif
+inline void GameServer_ObjectMeta::set_namespace_(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  namespace__.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+}
+inline void GameServer_ObjectMeta::set_namespace_(const char* value, size_t size) {
+  
+  namespace__.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+}
+inline ::std::string* GameServer_ObjectMeta::mutable_namespace_() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+  return namespace__.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_ObjectMeta::release_namespace_() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+  
+  return namespace__.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_ObjectMeta::set_allocated_namespace_(::std::string* namespace_) {
+  if (namespace_ != NULL) {
+    
+  } else {
+    
+  }
+  namespace__.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), namespace_);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.ObjectMeta.namespace)
+}
+
+// string uid = 3;
+inline void GameServer_ObjectMeta::clear_uid() {
+  uid_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_ObjectMeta::uid() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+  return uid_.GetNoArena();
+}
+inline void GameServer_ObjectMeta::set_uid(const ::std::string& value) {
+  
+  uid_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+}
+#if LANG_CXX11
+inline void GameServer_ObjectMeta::set_uid(::std::string&& value) {
+  
+  uid_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+}
+#endif
+inline void GameServer_ObjectMeta::set_uid(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  uid_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+}
+inline void GameServer_ObjectMeta::set_uid(const char* value, size_t size) {
+  
+  uid_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+}
+inline ::std::string* GameServer_ObjectMeta::mutable_uid() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+  return uid_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_ObjectMeta::release_uid() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+  
+  return uid_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_ObjectMeta::set_allocated_uid(::std::string* uid) {
+  if (uid != NULL) {
+    
+  } else {
+    
+  }
+  uid_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), uid);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.ObjectMeta.uid)
+}
+
+// string resource_version = 4;
+inline void GameServer_ObjectMeta::clear_resource_version() {
+  resource_version_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_ObjectMeta::resource_version() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+  return resource_version_.GetNoArena();
+}
+inline void GameServer_ObjectMeta::set_resource_version(const ::std::string& value) {
+  
+  resource_version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+}
+#if LANG_CXX11
+inline void GameServer_ObjectMeta::set_resource_version(::std::string&& value) {
+  
+  resource_version_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+}
+#endif
+inline void GameServer_ObjectMeta::set_resource_version(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  resource_version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+}
+inline void GameServer_ObjectMeta::set_resource_version(const char* value, size_t size) {
+  
+  resource_version_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+}
+inline ::std::string* GameServer_ObjectMeta::mutable_resource_version() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+  return resource_version_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_ObjectMeta::release_resource_version() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+  
+  return resource_version_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_ObjectMeta::set_allocated_resource_version(::std::string* resource_version) {
+  if (resource_version != NULL) {
+    
+  } else {
+    
+  }
+  resource_version_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), resource_version);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.ObjectMeta.resource_version)
+}
+
+// int64 generation = 5;
+inline void GameServer_ObjectMeta::clear_generation() {
+  generation_ = GOOGLE_LONGLONG(0);
+}
+inline ::google::protobuf::int64 GameServer_ObjectMeta::generation() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.generation)
+  return generation_;
+}
+inline void GameServer_ObjectMeta::set_generation(::google::protobuf::int64 value) {
+  
+  generation_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.generation)
+}
+
+// int64 creation_timestamp = 6;
+inline void GameServer_ObjectMeta::clear_creation_timestamp() {
+  creation_timestamp_ = GOOGLE_LONGLONG(0);
+}
+inline ::google::protobuf::int64 GameServer_ObjectMeta::creation_timestamp() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.creation_timestamp)
+  return creation_timestamp_;
+}
+inline void GameServer_ObjectMeta::set_creation_timestamp(::google::protobuf::int64 value) {
+  
+  creation_timestamp_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.creation_timestamp)
+}
+
+// int64 deletion_timestamp = 7;
+inline void GameServer_ObjectMeta::clear_deletion_timestamp() {
+  deletion_timestamp_ = GOOGLE_LONGLONG(0);
+}
+inline ::google::protobuf::int64 GameServer_ObjectMeta::deletion_timestamp() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.ObjectMeta.deletion_timestamp)
+  return deletion_timestamp_;
+}
+inline void GameServer_ObjectMeta::set_deletion_timestamp(::google::protobuf::int64 value) {
+  
+  deletion_timestamp_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.ObjectMeta.deletion_timestamp)
+}
+
+// map<string, string> annotations = 8;
+inline int GameServer_ObjectMeta::annotations_size() const {
+  return annotations_.size();
+}
+inline void GameServer_ObjectMeta::clear_annotations() {
+  annotations_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+GameServer_ObjectMeta::annotations() const {
+  // @@protoc_insertion_point(field_map:stable.agones.dev.sdk.GameServer.ObjectMeta.annotations)
+  return annotations_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+GameServer_ObjectMeta::mutable_annotations() {
+  // @@protoc_insertion_point(field_mutable_map:stable.agones.dev.sdk.GameServer.ObjectMeta.annotations)
+  return annotations_.MutableMap();
+}
+
+// map<string, string> labels = 9;
+inline int GameServer_ObjectMeta::labels_size() const {
+  return labels_.size();
+}
+inline void GameServer_ObjectMeta::clear_labels() {
+  labels_.Clear();
+}
+inline const ::google::protobuf::Map< ::std::string, ::std::string >&
+GameServer_ObjectMeta::labels() const {
+  // @@protoc_insertion_point(field_map:stable.agones.dev.sdk.GameServer.ObjectMeta.labels)
+  return labels_.GetMap();
+}
+inline ::google::protobuf::Map< ::std::string, ::std::string >*
+GameServer_ObjectMeta::mutable_labels() {
+  // @@protoc_insertion_point(field_mutable_map:stable.agones.dev.sdk.GameServer.ObjectMeta.labels)
+  return labels_.MutableMap();
+}
+
+// -------------------------------------------------------------------
+
+// GameServer_Spec_Health
+
+// bool Disabled = 1;
+inline void GameServer_Spec_Health::clear_disabled() {
+  disabled_ = false;
+}
+inline bool GameServer_Spec_Health::disabled() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Spec.Health.Disabled)
+  return disabled_;
+}
+inline void GameServer_Spec_Health::set_disabled(bool value) {
+  
+  disabled_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Spec.Health.Disabled)
+}
+
+// int32 PeriodSeconds = 2;
+inline void GameServer_Spec_Health::clear_periodseconds() {
+  periodseconds_ = 0;
+}
+inline ::google::protobuf::int32 GameServer_Spec_Health::periodseconds() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Spec.Health.PeriodSeconds)
+  return periodseconds_;
+}
+inline void GameServer_Spec_Health::set_periodseconds(::google::protobuf::int32 value) {
+  
+  periodseconds_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Spec.Health.PeriodSeconds)
+}
+
+// int32 FailureThreshold = 3;
+inline void GameServer_Spec_Health::clear_failurethreshold() {
+  failurethreshold_ = 0;
+}
+inline ::google::protobuf::int32 GameServer_Spec_Health::failurethreshold() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Spec.Health.FailureThreshold)
+  return failurethreshold_;
+}
+inline void GameServer_Spec_Health::set_failurethreshold(::google::protobuf::int32 value) {
+  
+  failurethreshold_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Spec.Health.FailureThreshold)
+}
+
+// int32 InitialDelaySeconds = 4;
+inline void GameServer_Spec_Health::clear_initialdelayseconds() {
+  initialdelayseconds_ = 0;
+}
+inline ::google::protobuf::int32 GameServer_Spec_Health::initialdelayseconds() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Spec.Health.InitialDelaySeconds)
+  return initialdelayseconds_;
+}
+inline void GameServer_Spec_Health::set_initialdelayseconds(::google::protobuf::int32 value) {
+  
+  initialdelayseconds_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Spec.Health.InitialDelaySeconds)
+}
+
+// -------------------------------------------------------------------
+
+// GameServer_Spec
+
+// .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+inline bool GameServer_Spec::has_health() const {
+  return this != internal_default_instance() && health_ != NULL;
+}
+inline void GameServer_Spec::clear_health() {
+  if (GetArenaNoVirtual() == NULL && health_ != NULL) {
+    delete health_;
+  }
+  health_ = NULL;
+}
+inline const ::stable::agones::dev::sdk::GameServer_Spec_Health& GameServer_Spec::health() const {
+  const ::stable::agones::dev::sdk::GameServer_Spec_Health* p = health_;
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Spec.health)
+  return p != NULL ? *p : *reinterpret_cast<const ::stable::agones::dev::sdk::GameServer_Spec_Health*>(
+      &::stable::agones::dev::sdk::_GameServer_Spec_Health_default_instance_);
+}
+inline ::stable::agones::dev::sdk::GameServer_Spec_Health* GameServer_Spec::release_health() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.Spec.health)
+  
+  ::stable::agones::dev::sdk::GameServer_Spec_Health* temp = health_;
+  health_ = NULL;
+  return temp;
+}
+inline ::stable::agones::dev::sdk::GameServer_Spec_Health* GameServer_Spec::mutable_health() {
+  
+  if (health_ == NULL) {
+    health_ = new ::stable::agones::dev::sdk::GameServer_Spec_Health;
+  }
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.Spec.health)
+  return health_;
+}
+inline void GameServer_Spec::set_allocated_health(::stable::agones::dev::sdk::GameServer_Spec_Health* health) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete health_;
+  }
+  if (health) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      health = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, health, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  health_ = health;
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.Spec.health)
+}
+
+// -------------------------------------------------------------------
+
+// GameServer_Status_Port
+
+// string name = 1;
+inline void GameServer_Status_Port::clear_name() {
+  name_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_Status_Port::name() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Status.Port.name)
+  return name_.GetNoArena();
+}
+inline void GameServer_Status_Port::set_name(const ::std::string& value) {
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Status.Port.name)
+}
+#if LANG_CXX11
+inline void GameServer_Status_Port::set_name(::std::string&& value) {
+  
+  name_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.Status.Port.name)
+}
+#endif
+inline void GameServer_Status_Port::set_name(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.Status.Port.name)
+}
+inline void GameServer_Status_Port::set_name(const char* value, size_t size) {
+  
+  name_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.Status.Port.name)
+}
+inline ::std::string* GameServer_Status_Port::mutable_name() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.Status.Port.name)
+  return name_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_Status_Port::release_name() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.Status.Port.name)
+  
+  return name_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_Status_Port::set_allocated_name(::std::string* name) {
+  if (name != NULL) {
+    
+  } else {
+    
+  }
+  name_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.Status.Port.name)
+}
+
+// int32 port = 2;
+inline void GameServer_Status_Port::clear_port() {
+  port_ = 0;
+}
+inline ::google::protobuf::int32 GameServer_Status_Port::port() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Status.Port.port)
+  return port_;
+}
+inline void GameServer_Status_Port::set_port(::google::protobuf::int32 value) {
+  
+  port_ = value;
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Status.Port.port)
+}
+
+// -------------------------------------------------------------------
+
+// GameServer_Status
+
+// string state = 1;
+inline void GameServer_Status::clear_state() {
+  state_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_Status::state() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Status.state)
+  return state_.GetNoArena();
+}
+inline void GameServer_Status::set_state(const ::std::string& value) {
+  
+  state_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Status.state)
+}
+#if LANG_CXX11
+inline void GameServer_Status::set_state(::std::string&& value) {
+  
+  state_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.Status.state)
+}
+#endif
+inline void GameServer_Status::set_state(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  state_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.Status.state)
+}
+inline void GameServer_Status::set_state(const char* value, size_t size) {
+  
+  state_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.Status.state)
+}
+inline ::std::string* GameServer_Status::mutable_state() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.Status.state)
+  return state_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_Status::release_state() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.Status.state)
+  
+  return state_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_Status::set_allocated_state(::std::string* state) {
+  if (state != NULL) {
+    
+  } else {
+    
+  }
+  state_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), state);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.Status.state)
+}
+
+// string address = 2;
+inline void GameServer_Status::clear_address() {
+  address_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& GameServer_Status::address() const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Status.address)
+  return address_.GetNoArena();
+}
+inline void GameServer_Status::set_address(const ::std::string& value) {
+  
+  address_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:stable.agones.dev.sdk.GameServer.Status.address)
+}
+#if LANG_CXX11
+inline void GameServer_Status::set_address(::std::string&& value) {
+  
+  address_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:stable.agones.dev.sdk.GameServer.Status.address)
+}
+#endif
+inline void GameServer_Status::set_address(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  address_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:stable.agones.dev.sdk.GameServer.Status.address)
+}
+inline void GameServer_Status::set_address(const char* value, size_t size) {
+  
+  address_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:stable.agones.dev.sdk.GameServer.Status.address)
+}
+inline ::std::string* GameServer_Status::mutable_address() {
+  
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.Status.address)
+  return address_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* GameServer_Status::release_address() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.Status.address)
+  
+  return address_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void GameServer_Status::set_allocated_address(::std::string* address) {
+  if (address != NULL) {
+    
+  } else {
+    
+  }
+  address_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), address);
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.Status.address)
+}
+
+// repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+inline int GameServer_Status::ports_size() const {
+  return ports_.size();
+}
+inline void GameServer_Status::clear_ports() {
+  ports_.Clear();
+}
+inline const ::stable::agones::dev::sdk::GameServer_Status_Port& GameServer_Status::ports(int index) const {
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.Status.ports)
+  return ports_.Get(index);
+}
+inline ::stable::agones::dev::sdk::GameServer_Status_Port* GameServer_Status::mutable_ports(int index) {
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.Status.ports)
+  return ports_.Mutable(index);
+}
+inline ::stable::agones::dev::sdk::GameServer_Status_Port* GameServer_Status::add_ports() {
+  // @@protoc_insertion_point(field_add:stable.agones.dev.sdk.GameServer.Status.ports)
+  return ports_.Add();
+}
+inline ::google::protobuf::RepeatedPtrField< ::stable::agones::dev::sdk::GameServer_Status_Port >*
+GameServer_Status::mutable_ports() {
+  // @@protoc_insertion_point(field_mutable_list:stable.agones.dev.sdk.GameServer.Status.ports)
+  return &ports_;
+}
+inline const ::google::protobuf::RepeatedPtrField< ::stable::agones::dev::sdk::GameServer_Status_Port >&
+GameServer_Status::ports() const {
+  // @@protoc_insertion_point(field_list:stable.agones.dev.sdk.GameServer.Status.ports)
+  return ports_;
+}
+
+// -------------------------------------------------------------------
+
+// GameServer
+
+// .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+inline bool GameServer::has_object_meta() const {
+  return this != internal_default_instance() && object_meta_ != NULL;
+}
+inline void GameServer::clear_object_meta() {
+  if (GetArenaNoVirtual() == NULL && object_meta_ != NULL) {
+    delete object_meta_;
+  }
+  object_meta_ = NULL;
+}
+inline const ::stable::agones::dev::sdk::GameServer_ObjectMeta& GameServer::object_meta() const {
+  const ::stable::agones::dev::sdk::GameServer_ObjectMeta* p = object_meta_;
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.object_meta)
+  return p != NULL ? *p : *reinterpret_cast<const ::stable::agones::dev::sdk::GameServer_ObjectMeta*>(
+      &::stable::agones::dev::sdk::_GameServer_ObjectMeta_default_instance_);
+}
+inline ::stable::agones::dev::sdk::GameServer_ObjectMeta* GameServer::release_object_meta() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.object_meta)
+  
+  ::stable::agones::dev::sdk::GameServer_ObjectMeta* temp = object_meta_;
+  object_meta_ = NULL;
+  return temp;
+}
+inline ::stable::agones::dev::sdk::GameServer_ObjectMeta* GameServer::mutable_object_meta() {
+  
+  if (object_meta_ == NULL) {
+    object_meta_ = new ::stable::agones::dev::sdk::GameServer_ObjectMeta;
+  }
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.object_meta)
+  return object_meta_;
+}
+inline void GameServer::set_allocated_object_meta(::stable::agones::dev::sdk::GameServer_ObjectMeta* object_meta) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete object_meta_;
+  }
+  if (object_meta) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      object_meta = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, object_meta, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  object_meta_ = object_meta;
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.object_meta)
+}
+
+// .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+inline bool GameServer::has_spec() const {
+  return this != internal_default_instance() && spec_ != NULL;
+}
+inline void GameServer::clear_spec() {
+  if (GetArenaNoVirtual() == NULL && spec_ != NULL) {
+    delete spec_;
+  }
+  spec_ = NULL;
+}
+inline const ::stable::agones::dev::sdk::GameServer_Spec& GameServer::spec() const {
+  const ::stable::agones::dev::sdk::GameServer_Spec* p = spec_;
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.spec)
+  return p != NULL ? *p : *reinterpret_cast<const ::stable::agones::dev::sdk::GameServer_Spec*>(
+      &::stable::agones::dev::sdk::_GameServer_Spec_default_instance_);
+}
+inline ::stable::agones::dev::sdk::GameServer_Spec* GameServer::release_spec() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.spec)
+  
+  ::stable::agones::dev::sdk::GameServer_Spec* temp = spec_;
+  spec_ = NULL;
+  return temp;
+}
+inline ::stable::agones::dev::sdk::GameServer_Spec* GameServer::mutable_spec() {
+  
+  if (spec_ == NULL) {
+    spec_ = new ::stable::agones::dev::sdk::GameServer_Spec;
+  }
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.spec)
+  return spec_;
+}
+inline void GameServer::set_allocated_spec(::stable::agones::dev::sdk::GameServer_Spec* spec) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete spec_;
+  }
+  if (spec) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      spec = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, spec, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  spec_ = spec;
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.spec)
+}
+
+// .stable.agones.dev.sdk.GameServer.Status status = 3;
+inline bool GameServer::has_status() const {
+  return this != internal_default_instance() && status_ != NULL;
+}
+inline void GameServer::clear_status() {
+  if (GetArenaNoVirtual() == NULL && status_ != NULL) {
+    delete status_;
+  }
+  status_ = NULL;
+}
+inline const ::stable::agones::dev::sdk::GameServer_Status& GameServer::status() const {
+  const ::stable::agones::dev::sdk::GameServer_Status* p = status_;
+  // @@protoc_insertion_point(field_get:stable.agones.dev.sdk.GameServer.status)
+  return p != NULL ? *p : *reinterpret_cast<const ::stable::agones::dev::sdk::GameServer_Status*>(
+      &::stable::agones::dev::sdk::_GameServer_Status_default_instance_);
+}
+inline ::stable::agones::dev::sdk::GameServer_Status* GameServer::release_status() {
+  // @@protoc_insertion_point(field_release:stable.agones.dev.sdk.GameServer.status)
+  
+  ::stable::agones::dev::sdk::GameServer_Status* temp = status_;
+  status_ = NULL;
+  return temp;
+}
+inline ::stable::agones::dev::sdk::GameServer_Status* GameServer::mutable_status() {
+  
+  if (status_ == NULL) {
+    status_ = new ::stable::agones::dev::sdk::GameServer_Status;
+  }
+  // @@protoc_insertion_point(field_mutable:stable.agones.dev.sdk.GameServer.status)
+  return status_;
+}
+inline void GameServer::set_allocated_status(::stable::agones::dev::sdk::GameServer_Status* status) {
+  ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
+  if (message_arena == NULL) {
+    delete status_;
+  }
+  if (status) {
+    ::google::protobuf::Arena* submessage_arena = NULL;
+    if (message_arena != submessage_arena) {
+      status = ::google::protobuf::internal::GetOwnedMessage(
+          message_arena, status, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  status_ = status;
+  // @@protoc_insertion_point(field_set_allocated:stable.agones.dev.sdk.GameServer.status)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 
 // @@protoc_insertion_point(namespace_scope)
 

--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -71,3 +71,8 @@ func (s *SDK) Shutdown() error {
 func (s *SDK) Health() error {
 	return errors.Wrap(s.health.Send(&sdk.Empty{}), "could not send Health ping")
 }
+
+// GameServer retrieve the GameServer details
+func (s *SDK) GameServer() (*sdk.GameServer, error) {
+	return s.client.GetGameServer(s.ctx, &sdk.Empty{})
+}

--- a/sdks/go/sdk_test.go
+++ b/sdks/go/sdk_test.go
@@ -52,6 +52,10 @@ func TestSDK(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, sm.ready)
 	assert.True(t, sm.shutdown)
+
+	gs, err := s.GameServer()
+	assert.Nil(t, err)
+	assert.NotNil(t, gs)
 }
 
 var _ sdk.SDKClient = &sdkMock{}
@@ -61,6 +65,10 @@ type sdkMock struct {
 	ready    bool
 	shutdown bool
 	hm       *healthMock
+}
+
+func (m *sdkMock) GetGameServer(ctx context.Context, in *sdk.Empty, opts ...grpc.CallOption) (*sdk.GameServer, error) {
+	return &sdk.GameServer{}, nil
 }
 
 func (m *sdkMock) Ready(ctx context.Context, e *sdk.Empty, opts ...grpc.CallOption) (*sdk.Empty, error) {

--- a/sdks/rust/src/grpc/sdk.rs
+++ b/sdks/rust/src/grpc/sdk.rs
@@ -156,64 +156,1851 @@ impl ::protobuf::reflect::ProtobufValue for Empty {
     }
 }
 
+#[derive(PartialEq,Clone,Default)]
+pub struct GameServer {
+    // message fields
+    pub object_meta: ::protobuf::SingularPtrField<GameServer_ObjectMeta>,
+    pub spec: ::protobuf::SingularPtrField<GameServer_Spec>,
+    pub status: ::protobuf::SingularPtrField<GameServer_Status>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+impl GameServer {
+    pub fn new() -> GameServer {
+        ::std::default::Default::default()
+    }
+
+    // .stable.agones.dev.sdk.GameServer.ObjectMeta object_meta = 1;
+
+    pub fn clear_object_meta(&mut self) {
+        self.object_meta.clear();
+    }
+
+    pub fn has_object_meta(&self) -> bool {
+        self.object_meta.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_object_meta(&mut self, v: GameServer_ObjectMeta) {
+        self.object_meta = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_object_meta(&mut self) -> &mut GameServer_ObjectMeta {
+        if self.object_meta.is_none() {
+            self.object_meta.set_default();
+        }
+        self.object_meta.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_object_meta(&mut self) -> GameServer_ObjectMeta {
+        self.object_meta.take().unwrap_or_else(|| GameServer_ObjectMeta::new())
+    }
+
+    pub fn get_object_meta(&self) -> &GameServer_ObjectMeta {
+        self.object_meta.as_ref().unwrap_or_else(|| GameServer_ObjectMeta::default_instance())
+    }
+
+    // .stable.agones.dev.sdk.GameServer.Spec spec = 2;
+
+    pub fn clear_spec(&mut self) {
+        self.spec.clear();
+    }
+
+    pub fn has_spec(&self) -> bool {
+        self.spec.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_spec(&mut self, v: GameServer_Spec) {
+        self.spec = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_spec(&mut self) -> &mut GameServer_Spec {
+        if self.spec.is_none() {
+            self.spec.set_default();
+        }
+        self.spec.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_spec(&mut self) -> GameServer_Spec {
+        self.spec.take().unwrap_or_else(|| GameServer_Spec::new())
+    }
+
+    pub fn get_spec(&self) -> &GameServer_Spec {
+        self.spec.as_ref().unwrap_or_else(|| GameServer_Spec::default_instance())
+    }
+
+    // .stable.agones.dev.sdk.GameServer.Status status = 3;
+
+    pub fn clear_status(&mut self) {
+        self.status.clear();
+    }
+
+    pub fn has_status(&self) -> bool {
+        self.status.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_status(&mut self, v: GameServer_Status) {
+        self.status = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_status(&mut self) -> &mut GameServer_Status {
+        if self.status.is_none() {
+            self.status.set_default();
+        }
+        self.status.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_status(&mut self) -> GameServer_Status {
+        self.status.take().unwrap_or_else(|| GameServer_Status::new())
+    }
+
+    pub fn get_status(&self) -> &GameServer_Status {
+        self.status.as_ref().unwrap_or_else(|| GameServer_Status::default_instance())
+    }
+}
+
+impl ::protobuf::Message for GameServer {
+    fn is_initialized(&self) -> bool {
+        for v in &self.object_meta {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        for v in &self.spec {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        for v in &self.status {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.object_meta)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.spec)?;
+                },
+                3 => {
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.status)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(ref v) = self.object_meta.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        }
+        if let Some(ref v) = self.spec.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        }
+        if let Some(ref v) = self.status.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(ref v) = self.object_meta.as_ref() {
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        }
+        if let Some(ref v) = self.spec.as_ref() {
+            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        }
+        if let Some(ref v) = self.status.as_ref() {
+            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        }
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> GameServer {
+        GameServer::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<GameServer_ObjectMeta>>(
+                    "object_meta",
+                    |m: &GameServer| { &m.object_meta },
+                    |m: &mut GameServer| { &mut m.object_meta },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<GameServer_Spec>>(
+                    "spec",
+                    |m: &GameServer| { &m.spec },
+                    |m: &mut GameServer| { &mut m.spec },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<GameServer_Status>>(
+                    "status",
+                    |m: &GameServer| { &m.status },
+                    |m: &mut GameServer| { &mut m.status },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GameServer>(
+                    "GameServer",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static GameServer {
+        static mut instance: ::protobuf::lazy::Lazy<GameServer> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GameServer,
+        };
+        unsafe {
+            instance.get(GameServer::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for GameServer {
+    fn clear(&mut self) {
+        self.clear_object_meta();
+        self.clear_spec();
+        self.clear_status();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for GameServer {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GameServer {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct GameServer_ObjectMeta {
+    // message fields
+    pub name: ::std::string::String,
+    pub namespace: ::std::string::String,
+    pub uid: ::std::string::String,
+    pub resource_version: ::std::string::String,
+    pub generation: i64,
+    pub creation_timestamp: i64,
+    pub deletion_timestamp: i64,
+    pub annotations: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
+    pub labels: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+impl GameServer_ObjectMeta {
+    pub fn new() -> GameServer_ObjectMeta {
+        ::std::default::Default::default()
+    }
+
+    // string name = 1;
+
+    pub fn clear_name(&mut self) {
+        self.name.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.name = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        &mut self.name
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.name, ::std::string::String::new())
+    }
+
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    // string namespace = 2;
+
+    pub fn clear_namespace(&mut self) {
+        self.namespace.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_namespace(&mut self, v: ::std::string::String) {
+        self.namespace = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_namespace(&mut self) -> &mut ::std::string::String {
+        &mut self.namespace
+    }
+
+    // Take field
+    pub fn take_namespace(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.namespace, ::std::string::String::new())
+    }
+
+    pub fn get_namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    // string uid = 3;
+
+    pub fn clear_uid(&mut self) {
+        self.uid.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_uid(&mut self, v: ::std::string::String) {
+        self.uid = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_uid(&mut self) -> &mut ::std::string::String {
+        &mut self.uid
+    }
+
+    // Take field
+    pub fn take_uid(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.uid, ::std::string::String::new())
+    }
+
+    pub fn get_uid(&self) -> &str {
+        &self.uid
+    }
+
+    // string resource_version = 4;
+
+    pub fn clear_resource_version(&mut self) {
+        self.resource_version.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_resource_version(&mut self, v: ::std::string::String) {
+        self.resource_version = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_resource_version(&mut self) -> &mut ::std::string::String {
+        &mut self.resource_version
+    }
+
+    // Take field
+    pub fn take_resource_version(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.resource_version, ::std::string::String::new())
+    }
+
+    pub fn get_resource_version(&self) -> &str {
+        &self.resource_version
+    }
+
+    // int64 generation = 5;
+
+    pub fn clear_generation(&mut self) {
+        self.generation = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_generation(&mut self, v: i64) {
+        self.generation = v;
+    }
+
+    pub fn get_generation(&self) -> i64 {
+        self.generation
+    }
+
+    // int64 creation_timestamp = 6;
+
+    pub fn clear_creation_timestamp(&mut self) {
+        self.creation_timestamp = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_creation_timestamp(&mut self, v: i64) {
+        self.creation_timestamp = v;
+    }
+
+    pub fn get_creation_timestamp(&self) -> i64 {
+        self.creation_timestamp
+    }
+
+    // int64 deletion_timestamp = 7;
+
+    pub fn clear_deletion_timestamp(&mut self) {
+        self.deletion_timestamp = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_deletion_timestamp(&mut self, v: i64) {
+        self.deletion_timestamp = v;
+    }
+
+    pub fn get_deletion_timestamp(&self) -> i64 {
+        self.deletion_timestamp
+    }
+
+    // repeated .stable.agones.dev.sdk.GameServer.ObjectMeta.AnnotationsEntry annotations = 8;
+
+    pub fn clear_annotations(&mut self) {
+        self.annotations.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_annotations(&mut self, v: ::std::collections::HashMap<::std::string::String, ::std::string::String>) {
+        self.annotations = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_annotations(&mut self) -> &mut ::std::collections::HashMap<::std::string::String, ::std::string::String> {
+        &mut self.annotations
+    }
+
+    // Take field
+    pub fn take_annotations(&mut self) -> ::std::collections::HashMap<::std::string::String, ::std::string::String> {
+        ::std::mem::replace(&mut self.annotations, ::std::collections::HashMap::new())
+    }
+
+    pub fn get_annotations(&self) -> &::std::collections::HashMap<::std::string::String, ::std::string::String> {
+        &self.annotations
+    }
+
+    // repeated .stable.agones.dev.sdk.GameServer.ObjectMeta.LabelsEntry labels = 9;
+
+    pub fn clear_labels(&mut self) {
+        self.labels.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_labels(&mut self, v: ::std::collections::HashMap<::std::string::String, ::std::string::String>) {
+        self.labels = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_labels(&mut self) -> &mut ::std::collections::HashMap<::std::string::String, ::std::string::String> {
+        &mut self.labels
+    }
+
+    // Take field
+    pub fn take_labels(&mut self) -> ::std::collections::HashMap<::std::string::String, ::std::string::String> {
+        ::std::mem::replace(&mut self.labels, ::std::collections::HashMap::new())
+    }
+
+    pub fn get_labels(&self) -> &::std::collections::HashMap<::std::string::String, ::std::string::String> {
+        &self.labels
+    }
+}
+
+impl ::protobuf::Message for GameServer_ObjectMeta {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.name)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.namespace)?;
+                },
+                3 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.uid)?;
+                },
+                4 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.resource_version)?;
+                },
+                5 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int64()?;
+                    self.generation = tmp;
+                },
+                6 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int64()?;
+                    self.creation_timestamp = tmp;
+                },
+                7 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int64()?;
+                    self.deletion_timestamp = tmp;
+                },
+                8 => {
+                    ::protobuf::rt::read_map_into::<::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(wire_type, is, &mut self.annotations)?;
+                },
+                9 => {
+                    ::protobuf::rt::read_map_into::<::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(wire_type, is, &mut self.labels)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if !self.name.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.name);
+        }
+        if !self.namespace.is_empty() {
+            my_size += ::protobuf::rt::string_size(2, &self.namespace);
+        }
+        if !self.uid.is_empty() {
+            my_size += ::protobuf::rt::string_size(3, &self.uid);
+        }
+        if !self.resource_version.is_empty() {
+            my_size += ::protobuf::rt::string_size(4, &self.resource_version);
+        }
+        if self.generation != 0 {
+            my_size += ::protobuf::rt::value_size(5, self.generation, ::protobuf::wire_format::WireTypeVarint);
+        }
+        if self.creation_timestamp != 0 {
+            my_size += ::protobuf::rt::value_size(6, self.creation_timestamp, ::protobuf::wire_format::WireTypeVarint);
+        }
+        if self.deletion_timestamp != 0 {
+            my_size += ::protobuf::rt::value_size(7, self.deletion_timestamp, ::protobuf::wire_format::WireTypeVarint);
+        }
+        my_size += ::protobuf::rt::compute_map_size::<::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(8, &self.annotations);
+        my_size += ::protobuf::rt::compute_map_size::<::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(9, &self.labels);
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if !self.name.is_empty() {
+            os.write_string(1, &self.name)?;
+        }
+        if !self.namespace.is_empty() {
+            os.write_string(2, &self.namespace)?;
+        }
+        if !self.uid.is_empty() {
+            os.write_string(3, &self.uid)?;
+        }
+        if !self.resource_version.is_empty() {
+            os.write_string(4, &self.resource_version)?;
+        }
+        if self.generation != 0 {
+            os.write_int64(5, self.generation)?;
+        }
+        if self.creation_timestamp != 0 {
+            os.write_int64(6, self.creation_timestamp)?;
+        }
+        if self.deletion_timestamp != 0 {
+            os.write_int64(7, self.deletion_timestamp)?;
+        }
+        ::protobuf::rt::write_map_with_cached_sizes::<::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(8, &self.annotations, os)?;
+        ::protobuf::rt::write_map_with_cached_sizes::<::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(9, &self.labels, os)?;
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> GameServer_ObjectMeta {
+        GameServer_ObjectMeta::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "name",
+                    |m: &GameServer_ObjectMeta| { &m.name },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.name },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "namespace",
+                    |m: &GameServer_ObjectMeta| { &m.namespace },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.namespace },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "uid",
+                    |m: &GameServer_ObjectMeta| { &m.uid },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.uid },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "resource_version",
+                    |m: &GameServer_ObjectMeta| { &m.resource_version },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.resource_version },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                    "generation",
+                    |m: &GameServer_ObjectMeta| { &m.generation },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.generation },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                    "creation_timestamp",
+                    |m: &GameServer_ObjectMeta| { &m.creation_timestamp },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.creation_timestamp },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                    "deletion_timestamp",
+                    |m: &GameServer_ObjectMeta| { &m.deletion_timestamp },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.deletion_timestamp },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_map_accessor::<_, ::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(
+                    "annotations",
+                    |m: &GameServer_ObjectMeta| { &m.annotations },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.annotations },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_map_accessor::<_, ::protobuf::types::ProtobufTypeString, ::protobuf::types::ProtobufTypeString>(
+                    "labels",
+                    |m: &GameServer_ObjectMeta| { &m.labels },
+                    |m: &mut GameServer_ObjectMeta| { &mut m.labels },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GameServer_ObjectMeta>(
+                    "GameServer_ObjectMeta",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static GameServer_ObjectMeta {
+        static mut instance: ::protobuf::lazy::Lazy<GameServer_ObjectMeta> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GameServer_ObjectMeta,
+        };
+        unsafe {
+            instance.get(GameServer_ObjectMeta::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for GameServer_ObjectMeta {
+    fn clear(&mut self) {
+        self.clear_name();
+        self.clear_namespace();
+        self.clear_uid();
+        self.clear_resource_version();
+        self.clear_generation();
+        self.clear_creation_timestamp();
+        self.clear_deletion_timestamp();
+        self.clear_annotations();
+        self.clear_labels();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for GameServer_ObjectMeta {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GameServer_ObjectMeta {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct GameServer_Spec {
+    // message fields
+    pub health: ::protobuf::SingularPtrField<GameServer_Spec_Health>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+impl GameServer_Spec {
+    pub fn new() -> GameServer_Spec {
+        ::std::default::Default::default()
+    }
+
+    // .stable.agones.dev.sdk.GameServer.Spec.Health health = 1;
+
+    pub fn clear_health(&mut self) {
+        self.health.clear();
+    }
+
+    pub fn has_health(&self) -> bool {
+        self.health.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_health(&mut self, v: GameServer_Spec_Health) {
+        self.health = ::protobuf::SingularPtrField::some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_health(&mut self) -> &mut GameServer_Spec_Health {
+        if self.health.is_none() {
+            self.health.set_default();
+        }
+        self.health.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_health(&mut self) -> GameServer_Spec_Health {
+        self.health.take().unwrap_or_else(|| GameServer_Spec_Health::new())
+    }
+
+    pub fn get_health(&self) -> &GameServer_Spec_Health {
+        self.health.as_ref().unwrap_or_else(|| GameServer_Spec_Health::default_instance())
+    }
+}
+
+impl ::protobuf::Message for GameServer_Spec {
+    fn is_initialized(&self) -> bool {
+        for v in &self.health {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.health)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if let Some(ref v) = self.health.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if let Some(ref v) = self.health.as_ref() {
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        }
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> GameServer_Spec {
+        GameServer_Spec::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<GameServer_Spec_Health>>(
+                    "health",
+                    |m: &GameServer_Spec| { &m.health },
+                    |m: &mut GameServer_Spec| { &mut m.health },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GameServer_Spec>(
+                    "GameServer_Spec",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static GameServer_Spec {
+        static mut instance: ::protobuf::lazy::Lazy<GameServer_Spec> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GameServer_Spec,
+        };
+        unsafe {
+            instance.get(GameServer_Spec::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for GameServer_Spec {
+    fn clear(&mut self) {
+        self.clear_health();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for GameServer_Spec {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GameServer_Spec {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct GameServer_Spec_Health {
+    // message fields
+    pub Disabled: bool,
+    pub PeriodSeconds: i32,
+    pub FailureThreshold: i32,
+    pub InitialDelaySeconds: i32,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+impl GameServer_Spec_Health {
+    pub fn new() -> GameServer_Spec_Health {
+        ::std::default::Default::default()
+    }
+
+    // bool Disabled = 1;
+
+    pub fn clear_Disabled(&mut self) {
+        self.Disabled = false;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_Disabled(&mut self, v: bool) {
+        self.Disabled = v;
+    }
+
+    pub fn get_Disabled(&self) -> bool {
+        self.Disabled
+    }
+
+    // int32 PeriodSeconds = 2;
+
+    pub fn clear_PeriodSeconds(&mut self) {
+        self.PeriodSeconds = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_PeriodSeconds(&mut self, v: i32) {
+        self.PeriodSeconds = v;
+    }
+
+    pub fn get_PeriodSeconds(&self) -> i32 {
+        self.PeriodSeconds
+    }
+
+    // int32 FailureThreshold = 3;
+
+    pub fn clear_FailureThreshold(&mut self) {
+        self.FailureThreshold = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_FailureThreshold(&mut self, v: i32) {
+        self.FailureThreshold = v;
+    }
+
+    pub fn get_FailureThreshold(&self) -> i32 {
+        self.FailureThreshold
+    }
+
+    // int32 InitialDelaySeconds = 4;
+
+    pub fn clear_InitialDelaySeconds(&mut self) {
+        self.InitialDelaySeconds = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_InitialDelaySeconds(&mut self, v: i32) {
+        self.InitialDelaySeconds = v;
+    }
+
+    pub fn get_InitialDelaySeconds(&self) -> i32 {
+        self.InitialDelaySeconds
+    }
+}
+
+impl ::protobuf::Message for GameServer_Spec_Health {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_bool()?;
+                    self.Disabled = tmp;
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int32()?;
+                    self.PeriodSeconds = tmp;
+                },
+                3 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int32()?;
+                    self.FailureThreshold = tmp;
+                },
+                4 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int32()?;
+                    self.InitialDelaySeconds = tmp;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if self.Disabled != false {
+            my_size += 2;
+        }
+        if self.PeriodSeconds != 0 {
+            my_size += ::protobuf::rt::value_size(2, self.PeriodSeconds, ::protobuf::wire_format::WireTypeVarint);
+        }
+        if self.FailureThreshold != 0 {
+            my_size += ::protobuf::rt::value_size(3, self.FailureThreshold, ::protobuf::wire_format::WireTypeVarint);
+        }
+        if self.InitialDelaySeconds != 0 {
+            my_size += ::protobuf::rt::value_size(4, self.InitialDelaySeconds, ::protobuf::wire_format::WireTypeVarint);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if self.Disabled != false {
+            os.write_bool(1, self.Disabled)?;
+        }
+        if self.PeriodSeconds != 0 {
+            os.write_int32(2, self.PeriodSeconds)?;
+        }
+        if self.FailureThreshold != 0 {
+            os.write_int32(3, self.FailureThreshold)?;
+        }
+        if self.InitialDelaySeconds != 0 {
+            os.write_int32(4, self.InitialDelaySeconds)?;
+        }
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> GameServer_Spec_Health {
+        GameServer_Spec_Health::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                    "Disabled",
+                    |m: &GameServer_Spec_Health| { &m.Disabled },
+                    |m: &mut GameServer_Spec_Health| { &mut m.Disabled },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                    "PeriodSeconds",
+                    |m: &GameServer_Spec_Health| { &m.PeriodSeconds },
+                    |m: &mut GameServer_Spec_Health| { &mut m.PeriodSeconds },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                    "FailureThreshold",
+                    |m: &GameServer_Spec_Health| { &m.FailureThreshold },
+                    |m: &mut GameServer_Spec_Health| { &mut m.FailureThreshold },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                    "InitialDelaySeconds",
+                    |m: &GameServer_Spec_Health| { &m.InitialDelaySeconds },
+                    |m: &mut GameServer_Spec_Health| { &mut m.InitialDelaySeconds },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GameServer_Spec_Health>(
+                    "GameServer_Spec_Health",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static GameServer_Spec_Health {
+        static mut instance: ::protobuf::lazy::Lazy<GameServer_Spec_Health> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GameServer_Spec_Health,
+        };
+        unsafe {
+            instance.get(GameServer_Spec_Health::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for GameServer_Spec_Health {
+    fn clear(&mut self) {
+        self.clear_Disabled();
+        self.clear_PeriodSeconds();
+        self.clear_FailureThreshold();
+        self.clear_InitialDelaySeconds();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for GameServer_Spec_Health {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GameServer_Spec_Health {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct GameServer_Status {
+    // message fields
+    pub state: ::std::string::String,
+    pub address: ::std::string::String,
+    pub ports: ::protobuf::RepeatedField<GameServer_Status_Port>,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+impl GameServer_Status {
+    pub fn new() -> GameServer_Status {
+        ::std::default::Default::default()
+    }
+
+    // string state = 1;
+
+    pub fn clear_state(&mut self) {
+        self.state.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_state(&mut self, v: ::std::string::String) {
+        self.state = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_state(&mut self) -> &mut ::std::string::String {
+        &mut self.state
+    }
+
+    // Take field
+    pub fn take_state(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.state, ::std::string::String::new())
+    }
+
+    pub fn get_state(&self) -> &str {
+        &self.state
+    }
+
+    // string address = 2;
+
+    pub fn clear_address(&mut self) {
+        self.address.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_address(&mut self, v: ::std::string::String) {
+        self.address = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_address(&mut self) -> &mut ::std::string::String {
+        &mut self.address
+    }
+
+    // Take field
+    pub fn take_address(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.address, ::std::string::String::new())
+    }
+
+    pub fn get_address(&self) -> &str {
+        &self.address
+    }
+
+    // repeated .stable.agones.dev.sdk.GameServer.Status.Port ports = 3;
+
+    pub fn clear_ports(&mut self) {
+        self.ports.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ports(&mut self, v: ::protobuf::RepeatedField<GameServer_Status_Port>) {
+        self.ports = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_ports(&mut self) -> &mut ::protobuf::RepeatedField<GameServer_Status_Port> {
+        &mut self.ports
+    }
+
+    // Take field
+    pub fn take_ports(&mut self) -> ::protobuf::RepeatedField<GameServer_Status_Port> {
+        ::std::mem::replace(&mut self.ports, ::protobuf::RepeatedField::new())
+    }
+
+    pub fn get_ports(&self) -> &[GameServer_Status_Port] {
+        &self.ports
+    }
+}
+
+impl ::protobuf::Message for GameServer_Status {
+    fn is_initialized(&self) -> bool {
+        for v in &self.ports {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.state)?;
+                },
+                2 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.address)?;
+                },
+                3 => {
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.ports)?;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if !self.state.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.state);
+        }
+        if !self.address.is_empty() {
+            my_size += ::protobuf::rt::string_size(2, &self.address);
+        }
+        for value in &self.ports {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
+        };
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if !self.state.is_empty() {
+            os.write_string(1, &self.state)?;
+        }
+        if !self.address.is_empty() {
+            os.write_string(2, &self.address)?;
+        }
+        for v in &self.ports {
+            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_raw_varint32(v.get_cached_size())?;
+            v.write_to_with_cached_sizes(os)?;
+        };
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> GameServer_Status {
+        GameServer_Status::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "state",
+                    |m: &GameServer_Status| { &m.state },
+                    |m: &mut GameServer_Status| { &mut m.state },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "address",
+                    |m: &GameServer_Status| { &m.address },
+                    |m: &mut GameServer_Status| { &mut m.address },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<GameServer_Status_Port>>(
+                    "ports",
+                    |m: &GameServer_Status| { &m.ports },
+                    |m: &mut GameServer_Status| { &mut m.ports },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GameServer_Status>(
+                    "GameServer_Status",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static GameServer_Status {
+        static mut instance: ::protobuf::lazy::Lazy<GameServer_Status> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GameServer_Status,
+        };
+        unsafe {
+            instance.get(GameServer_Status::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for GameServer_Status {
+    fn clear(&mut self) {
+        self.clear_state();
+        self.clear_address();
+        self.clear_ports();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for GameServer_Status {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GameServer_Status {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
+#[derive(PartialEq,Clone,Default)]
+pub struct GameServer_Status_Port {
+    // message fields
+    pub name: ::std::string::String,
+    pub port: i32,
+    // special fields
+    unknown_fields: ::protobuf::UnknownFields,
+    cached_size: ::protobuf::CachedSize,
+}
+
+impl GameServer_Status_Port {
+    pub fn new() -> GameServer_Status_Port {
+        ::std::default::Default::default()
+    }
+
+    // string name = 1;
+
+    pub fn clear_name(&mut self) {
+        self.name.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.name = v;
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        &mut self.name
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        ::std::mem::replace(&mut self.name, ::std::string::String::new())
+    }
+
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    // int32 port = 2;
+
+    pub fn clear_port(&mut self) {
+        self.port = 0;
+    }
+
+    // Param is passed by value, moved
+    pub fn set_port(&mut self, v: i32) {
+        self.port = v;
+    }
+
+    pub fn get_port(&self) -> i32 {
+        self.port
+    }
+}
+
+impl ::protobuf::Message for GameServer_Status_Port {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+        while !is.eof()? {
+            let (field_number, wire_type) = is.read_tag_unpack()?;
+            match field_number {
+                1 => {
+                    ::protobuf::rt::read_singular_proto3_string_into(wire_type, is, &mut self.name)?;
+                },
+                2 => {
+                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                    }
+                    let tmp = is.read_int32()?;
+                    self.port = tmp;
+                },
+                _ => {
+                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u32 {
+        let mut my_size = 0;
+        if !self.name.is_empty() {
+            my_size += ::protobuf::rt::string_size(1, &self.name);
+        }
+        if self.port != 0 {
+            my_size += ::protobuf::rt::value_size(2, self.port, ::protobuf::wire_format::WireTypeVarint);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
+        self.cached_size.set(my_size);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+        if !self.name.is_empty() {
+            os.write_string(1, &self.name)?;
+        }
+        if self.port != 0 {
+            os.write_int32(2, self.port)?;
+        }
+        os.write_unknown_fields(self.get_unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn get_cached_size(&self) -> u32 {
+        self.cached_size.get()
+    }
+
+    fn get_unknown_fields(&self) -> &::protobuf::UnknownFields {
+        &self.unknown_fields
+    }
+
+    fn mut_unknown_fields(&mut self) -> &mut ::protobuf::UnknownFields {
+        &mut self.unknown_fields
+    }
+
+    fn as_any(&self) -> &::std::any::Any {
+        self as &::std::any::Any
+    }
+    fn as_any_mut(&mut self) -> &mut ::std::any::Any {
+        self as &mut ::std::any::Any
+    }
+    fn into_any(self: Box<Self>) -> ::std::boxed::Box<::std::any::Any> {
+        self
+    }
+
+    fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
+        Self::descriptor_static()
+    }
+
+    fn new() -> GameServer_Status_Port {
+        GameServer_Status_Port::new()
+    }
+
+    fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+        };
+        unsafe {
+            descriptor.get(|| {
+                let mut fields = ::std::vec::Vec::new();
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                    "name",
+                    |m: &GameServer_Status_Port| { &m.name },
+                    |m: &mut GameServer_Status_Port| { &mut m.name },
+                ));
+                fields.push(::protobuf::reflect::accessor::make_simple_field_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                    "port",
+                    |m: &GameServer_Status_Port| { &m.port },
+                    |m: &mut GameServer_Status_Port| { &mut m.port },
+                ));
+                ::protobuf::reflect::MessageDescriptor::new::<GameServer_Status_Port>(
+                    "GameServer_Status_Port",
+                    fields,
+                    file_descriptor_proto()
+                )
+            })
+        }
+    }
+
+    fn default_instance() -> &'static GameServer_Status_Port {
+        static mut instance: ::protobuf::lazy::Lazy<GameServer_Status_Port> = ::protobuf::lazy::Lazy {
+            lock: ::protobuf::lazy::ONCE_INIT,
+            ptr: 0 as *const GameServer_Status_Port,
+        };
+        unsafe {
+            instance.get(GameServer_Status_Port::new)
+        }
+    }
+}
+
+impl ::protobuf::Clear for GameServer_Status_Port {
+    fn clear(&mut self) {
+        self.clear_name();
+        self.clear_port();
+        self.unknown_fields.clear();
+    }
+}
+
+impl ::std::fmt::Debug for GameServer_Status_Port {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for GameServer_Status_Port {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+        ::protobuf::reflect::ProtobufValueRef::Message(self)
+    }
+}
+
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n\tsdk.proto\x12\x15stable.agones.dev.sdk\x1a\x1cgoogle/api/annotations\
-    .proto\"\x07\n\x05Empty2\x97\x02\n\x03SDK\x12V\n\x05Ready\x12\x1c.stable\
-    .agones.dev.sdk.Empty\x1a\x1c.stable.agones.dev.sdk.Empty\"\x11\x82\xd3\
-    \xe4\x93\x02\x0b\"\x06/ready:\x01*\x12\\\n\x08Shutdown\x12\x1c.stable.ag\
-    ones.dev.sdk.Empty\x1a\x1c.stable.agones.dev.sdk.Empty\"\x14\x82\xd3\xe4\
-    \x93\x02\x0e\"\t/shutdown:\x01*\x12Z\n\x06Health\x12\x1c.stable.agones.d\
-    ev.sdk.Empty\x1a\x1c.stable.agones.dev.sdk.Empty\"\x12\x82\xd3\xe4\x93\
-    \x02\x0c\"\x07/health:\x01*(\x01B\x05Z\x03sdkJ\xd1\x0b\n\x06\x12\x04\x0e\
-    \0/\x01\n\xd2\x04\n\x01\x0c\x12\x03\x0e\0\x122\xc7\x04\x20Copyright\x202\
-    017\x20Google\x20Inc.\x20All\x20Rights\x20Reserved.\n\n\x20Licensed\x20u\
-    nder\x20the\x20Apache\x20License,\x20Version\x202.0\x20(the\x20\"License\
-    \");\n\x20you\x20may\x20not\x20use\x20this\x20file\x20except\x20in\x20co\
-    mpliance\x20with\x20the\x20License.\n\x20You\x20may\x20obtain\x20a\x20co\
-    py\x20of\x20the\x20License\x20at\n\n\x20\x20\x20\x20\x20http://www.apach\
-    e.org/licenses/LICENSE-2.0\n\n\x20Unless\x20required\x20by\x20applicable\
-    \x20law\x20or\x20agreed\x20to\x20in\x20writing,\x20software\n\x20distrib\
-    uted\x20under\x20the\x20License\x20is\x20distributed\x20on\x20an\x20\"AS\
-    \x20IS\"\x20BASIS,\n\x20WITHOUT\x20WARRANTIES\x20OR\x20CONDITIONS\x20OF\
-    \x20ANY\x20KIND,\x20either\x20express\x20or\x20implied.\n\x20See\x20the\
-    \x20License\x20for\x20the\x20specific\x20language\x20governing\x20permis\
-    sions\x20and\n\x20limitations\x20under\x20the\x20License.\n\n\x08\n\x01\
-    \x02\x12\x03\x10\x08\x1d\n\x08\n\x01\x08\x12\x03\x11\0\x1a\n\x0b\n\x04\
-    \x08\xe7\x07\0\x12\x03\x11\0\x1a\n\x0c\n\x05\x08\xe7\x07\0\x02\x12\x03\
-    \x11\x07\x11\n\r\n\x06\x08\xe7\x07\0\x02\0\x12\x03\x11\x07\x11\n\x0e\n\
-    \x07\x08\xe7\x07\0\x02\0\x01\x12\x03\x11\x07\x11\n\x0c\n\x05\x08\xe7\x07\
-    \0\x07\x12\x03\x11\x14\x19\n\t\n\x02\x03\0\x12\x03\x13\x07%\nM\n\x02\x06\
-    \0\x12\x04\x16\0,\x01\x1aA\x20SDK\x20service\x20to\x20be\x20used\x20in\
-    \x20the\x20GameServer\x20SDK\x20to\x20the\x20Pod\x20Sidecar\n\n\n\n\x03\
-    \x06\0\x01\x12\x03\x16\x08\x0b\n1\n\x04\x06\0\x02\0\x12\x04\x18\x04\x1d\
-    \x05\x1a#\x20Call\x20when\x20the\x20GameServer\x20is\x20ready\n\n\x0c\n\
-    \x05\x06\0\x02\0\x01\x12\x03\x18\x08\r\n\x0c\n\x05\x06\0\x02\0\x02\x12\
-    \x03\x18\x0f\x14\n\x0c\n\x05\x06\0\x02\0\x03\x12\x03\x18\x1f$\n\r\n\x05\
-    \x06\0\x02\0\x04\x12\x04\x19\x08\x1c\n\n\x10\n\x08\x06\0\x02\0\x04\xe7\
-    \x07\0\x12\x04\x19\x08\x1c\n\n\x10\n\t\x06\0\x02\0\x04\xe7\x07\0\x02\x12\
-    \x03\x19\x0f\x20\n\x11\n\n\x06\0\x02\0\x04\xe7\x07\0\x02\0\x12\x03\x19\
-    \x0f\x20\n\x12\n\x0b\x06\0\x02\0\x04\xe7\x07\0\x02\0\x01\x12\x03\x19\x10\
-    \x1f\n\x11\n\t\x06\0\x02\0\x04\xe7\x07\0\x08\x12\x04\x19#\x1c\t\n9\n\x04\
-    \x06\0\x02\x01\x12\x04\x1f\x04$\x05\x1a+\x20Call\x20when\x20the\x20GameS\
-    erver\x20is\x20shutting\x20down\n\n\x0c\n\x05\x06\0\x02\x01\x01\x12\x03\
-    \x1f\x08\x10\n\x0c\n\x05\x06\0\x02\x01\x02\x12\x03\x1f\x12\x17\n\x0c\n\
-    \x05\x06\0\x02\x01\x03\x12\x03\x1f\"'\n\r\n\x05\x06\0\x02\x01\x04\x12\
-    \x04\x20\x08#\n\n\x10\n\x08\x06\0\x02\x01\x04\xe7\x07\0\x12\x04\x20\x08#\
-    \n\n\x10\n\t\x06\0\x02\x01\x04\xe7\x07\0\x02\x12\x03\x20\x0f\x20\n\x11\n\
-    \n\x06\0\x02\x01\x04\xe7\x07\0\x02\0\x12\x03\x20\x0f\x20\n\x12\n\x0b\x06\
-    \0\x02\x01\x04\xe7\x07\0\x02\0\x01\x12\x03\x20\x10\x1f\n\x11\n\t\x06\0\
-    \x02\x01\x04\xe7\x07\0\x08\x12\x04\x20##\t\nW\n\x04\x06\0\x02\x02\x12\
-    \x04&\x04+\x05\x1aI\x20Send\x20a\x20Empty\x20every\x20d\x20Duration\x20t\
-    o\x20declare\x20that\x20this\x20GameSever\x20is\x20healthy\n\n\x0c\n\x05\
-    \x06\0\x02\x02\x01\x12\x03&\x08\x0e\n\x0c\n\x05\x06\0\x02\x02\x05\x12\
-    \x03&\x10\x16\n\x0c\n\x05\x06\0\x02\x02\x02\x12\x03&\x17\x1c\n\x0c\n\x05\
-    \x06\0\x02\x02\x03\x12\x03&',\n\r\n\x05\x06\0\x02\x02\x04\x12\x04'\x08*\
-    \x12\n\x10\n\x08\x06\0\x02\x02\x04\xe7\x07\0\x12\x04'\x08*\x12\n\x10\n\t\
-    \x06\0\x02\x02\x04\xe7\x07\0\x02\x12\x03'\x0f\x20\n\x11\n\n\x06\0\x02\
-    \x02\x04\xe7\x07\0\x02\0\x12\x03'\x0f\x20\n\x12\n\x0b\x06\0\x02\x02\x04\
-    \xe7\x07\0\x02\0\x01\x12\x03'\x10\x1f\n\x11\n\t\x06\0\x02\x02\x04\xe7\
-    \x07\0\x08\x12\x04'#*\x11\n\n\n\x02\x04\0\x12\x04.\0/\x01\n\n\n\x03\x04\
-    \0\x01\x12\x03.\x08\rb\x06proto3\
+    .proto\"\x07\n\x05Empty\"\xae\t\n\nGameServer\x12M\n\x0bobject_meta\x18\
+    \x01\x20\x01(\x0b2,.stable.agones.dev.sdk.GameServer.ObjectMetaR\nobject\
+    Meta\x12:\n\x04spec\x18\x02\x20\x01(\x0b2&.stable.agones.dev.sdk.GameSer\
+    ver.SpecR\x04spec\x12@\n\x06status\x18\x03\x20\x01(\x0b2(.stable.agones.\
+    dev.sdk.GameServer.StatusR\x06status\x1a\xa7\x04\n\nObjectMeta\x12\x12\n\
+    \x04name\x18\x01\x20\x01(\tR\x04name\x12\x1c\n\tnamespace\x18\x02\x20\
+    \x01(\tR\tnamespace\x12\x10\n\x03uid\x18\x03\x20\x01(\tR\x03uid\x12)\n\
+    \x10resource_version\x18\x04\x20\x01(\tR\x0fresourceVersion\x12\x1e\n\ng\
+    eneration\x18\x05\x20\x01(\x03R\ngeneration\x12-\n\x12creation_timestamp\
+    \x18\x06\x20\x01(\x03R\x11creationTimestamp\x12-\n\x12deletion_timestamp\
+    \x18\x07\x20\x01(\x03R\x11deletionTimestamp\x12_\n\x0bannotations\x18\
+    \x08\x20\x03(\x0b2=.stable.agones.dev.sdk.GameServer.ObjectMeta.Annotati\
+    onsEntryR\x0bannotations\x12P\n\x06labels\x18\t\x20\x03(\x0b28.stable.ag\
+    ones.dev.sdk.GameServer.ObjectMeta.LabelsEntryR\x06labels\x1a>\n\x10Anno\
+    tationsEntry\x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x14\n\x05va\
+    lue\x18\x02\x20\x01(\tR\x05value:\x028\x01\x1a9\n\x0bLabelsEntry\x12\x10\
+    \n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\
+    \tR\x05value:\x028\x01\x1a\xf8\x01\n\x04Spec\x12E\n\x06health\x18\x01\
+    \x20\x01(\x0b2-.stable.agones.dev.sdk.GameServer.Spec.HealthR\x06health\
+    \x1a\xa8\x01\n\x06Health\x12\x1a\n\x08Disabled\x18\x01\x20\x01(\x08R\x08\
+    Disabled\x12$\n\rPeriodSeconds\x18\x02\x20\x01(\x05R\rPeriodSeconds\x12*\
+    \n\x10FailureThreshold\x18\x03\x20\x01(\x05R\x10FailureThreshold\x120\n\
+    \x13InitialDelaySeconds\x18\x04\x20\x01(\x05R\x13InitialDelaySeconds\x1a\
+    \xad\x01\n\x06Status\x12\x14\n\x05state\x18\x01\x20\x01(\tR\x05state\x12\
+    \x18\n\x07address\x18\x02\x20\x01(\tR\x07address\x12C\n\x05ports\x18\x03\
+    \x20\x03(\x0b2-.stable.agones.dev.sdk.GameServer.Status.PortR\x05ports\
+    \x1a.\n\x04Port\x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x12\n\
+    \x04port\x18\x02\x20\x01(\x05R\x04port2\xfe\x02\n\x03SDK\x12V\n\x05Ready\
+    \x12\x1c.stable.agones.dev.sdk.Empty\x1a\x1c.stable.agones.dev.sdk.Empty\
+    \"\x11\x82\xd3\xe4\x93\x02\x0b\"\x06/ready:\x01*\x12\\\n\x08Shutdown\x12\
+    \x1c.stable.agones.dev.sdk.Empty\x1a\x1c.stable.agones.dev.sdk.Empty\"\
+    \x14\x82\xd3\xe4\x93\x02\x0e\"\t/shutdown:\x01*\x12Z\n\x06Health\x12\x1c\
+    .stable.agones.dev.sdk.Empty\x1a\x1c.stable.agones.dev.sdk.Empty\"\x12\
+    \x82\xd3\xe4\x93\x02\x0c\"\x07/health:\x01*(\x01\x12e\n\rGetGameServer\
+    \x12\x1c.stable.agones.dev.sdk.Empty\x1a!.stable.agones.dev.sdk.GameServ\
+    er\"\x13\x82\xd3\xe4\x93\x02\r\x12\x0b/gameserverB\x05Z\x03sdkJ\xfe\x1e\
+    \n\x06\x12\x04\x0e\0c\x01\n\xd2\x04\n\x01\x0c\x12\x03\x0e\0\x122\xc7\x04\
+    \x20Copyright\x202017\x20Google\x20Inc.\x20All\x20Rights\x20Reserved.\n\
+    \n\x20Licensed\x20under\x20the\x20Apache\x20License,\x20Version\x202.0\
+    \x20(the\x20\"License\");\n\x20you\x20may\x20not\x20use\x20this\x20file\
+    \x20except\x20in\x20compliance\x20with\x20the\x20License.\n\x20You\x20ma\
+    y\x20obtain\x20a\x20copy\x20of\x20the\x20License\x20at\n\n\x20\x20\x20\
+    \x20\x20http://www.apache.org/licenses/LICENSE-2.0\n\n\x20Unless\x20requ\
+    ired\x20by\x20applicable\x20law\x20or\x20agreed\x20to\x20in\x20writing,\
+    \x20software\n\x20distributed\x20under\x20the\x20License\x20is\x20distri\
+    buted\x20on\x20an\x20\"AS\x20IS\"\x20BASIS,\n\x20WITHOUT\x20WARRANTIES\
+    \x20OR\x20CONDITIONS\x20OF\x20ANY\x20KIND,\x20either\x20express\x20or\
+    \x20implied.\n\x20See\x20the\x20License\x20for\x20the\x20specific\x20lan\
+    guage\x20governing\x20permissions\x20and\n\x20limitations\x20under\x20th\
+    e\x20License.\n\n\x08\n\x01\x02\x12\x03\x10\x08\x1d\n\x08\n\x01\x08\x12\
+    \x03\x11\0\x1a\n\x0b\n\x04\x08\xe7\x07\0\x12\x03\x11\0\x1a\n\x0c\n\x05\
+    \x08\xe7\x07\0\x02\x12\x03\x11\x07\x11\n\r\n\x06\x08\xe7\x07\0\x02\0\x12\
+    \x03\x11\x07\x11\n\x0e\n\x07\x08\xe7\x07\0\x02\0\x01\x12\x03\x11\x07\x11\
+    \n\x0c\n\x05\x08\xe7\x07\0\x07\x12\x03\x11\x14\x19\n\t\n\x02\x03\0\x12\
+    \x03\x13\x07%\nM\n\x02\x06\0\x12\x04\x16\02\x01\x1aA\x20SDK\x20service\
+    \x20to\x20be\x20used\x20in\x20the\x20GameServer\x20SDK\x20to\x20the\x20P\
+    od\x20Sidecar\n\n\n\n\x03\x06\0\x01\x12\x03\x16\x08\x0b\n1\n\x04\x06\0\
+    \x02\0\x12\x04\x18\x04\x1d\x05\x1a#\x20Call\x20when\x20the\x20GameServer\
+    \x20is\x20ready\n\n\x0c\n\x05\x06\0\x02\0\x01\x12\x03\x18\x08\r\n\x0c\n\
+    \x05\x06\0\x02\0\x02\x12\x03\x18\x0f\x14\n\x0c\n\x05\x06\0\x02\0\x03\x12\
+    \x03\x18\x1f$\n\r\n\x05\x06\0\x02\0\x04\x12\x04\x19\x08\x1c\n\n\x10\n\
+    \x08\x06\0\x02\0\x04\xe7\x07\0\x12\x04\x19\x08\x1c\n\n\x10\n\t\x06\0\x02\
+    \0\x04\xe7\x07\0\x02\x12\x03\x19\x0f\x20\n\x11\n\n\x06\0\x02\0\x04\xe7\
+    \x07\0\x02\0\x12\x03\x19\x0f\x20\n\x12\n\x0b\x06\0\x02\0\x04\xe7\x07\0\
+    \x02\0\x01\x12\x03\x19\x10\x1f\n\x11\n\t\x06\0\x02\0\x04\xe7\x07\0\x08\
+    \x12\x04\x19#\x1c\t\n9\n\x04\x06\0\x02\x01\x12\x04\x1f\x04$\x05\x1a+\x20\
+    Call\x20when\x20the\x20GameServer\x20is\x20shutting\x20down\n\n\x0c\n\
+    \x05\x06\0\x02\x01\x01\x12\x03\x1f\x08\x10\n\x0c\n\x05\x06\0\x02\x01\x02\
+    \x12\x03\x1f\x12\x17\n\x0c\n\x05\x06\0\x02\x01\x03\x12\x03\x1f\"'\n\r\n\
+    \x05\x06\0\x02\x01\x04\x12\x04\x20\x08#\n\n\x10\n\x08\x06\0\x02\x01\x04\
+    \xe7\x07\0\x12\x04\x20\x08#\n\n\x10\n\t\x06\0\x02\x01\x04\xe7\x07\0\x02\
+    \x12\x03\x20\x0f\x20\n\x11\n\n\x06\0\x02\x01\x04\xe7\x07\0\x02\0\x12\x03\
+    \x20\x0f\x20\n\x12\n\x0b\x06\0\x02\x01\x04\xe7\x07\0\x02\0\x01\x12\x03\
+    \x20\x10\x1f\n\x11\n\t\x06\0\x02\x01\x04\xe7\x07\0\x08\x12\x04\x20##\t\n\
+    W\n\x04\x06\0\x02\x02\x12\x04&\x04+\x05\x1aI\x20Send\x20a\x20Empty\x20ev\
+    ery\x20d\x20Duration\x20to\x20declare\x20that\x20this\x20GameSever\x20is\
+    \x20healthy\n\n\x0c\n\x05\x06\0\x02\x02\x01\x12\x03&\x08\x0e\n\x0c\n\x05\
+    \x06\0\x02\x02\x05\x12\x03&\x10\x16\n\x0c\n\x05\x06\0\x02\x02\x02\x12\
+    \x03&\x17\x1c\n\x0c\n\x05\x06\0\x02\x02\x03\x12\x03&',\n\r\n\x05\x06\0\
+    \x02\x02\x04\x12\x04'\x08*\x12\n\x10\n\x08\x06\0\x02\x02\x04\xe7\x07\0\
+    \x12\x04'\x08*\x12\n\x10\n\t\x06\0\x02\x02\x04\xe7\x07\0\x02\x12\x03'\
+    \x0f\x20\n\x11\n\n\x06\0\x02\x02\x04\xe7\x07\0\x02\0\x12\x03'\x0f\x20\n\
+    \x12\n\x0b\x06\0\x02\x02\x04\xe7\x07\0\x02\0\x01\x12\x03'\x10\x1f\n\x11\
+    \n\t\x06\0\x02\x02\x04\xe7\x07\0\x08\x12\x04'#*\x11\n4\n\x04\x06\0\x02\
+    \x03\x12\x04-\x041\x05\x1a&\x20Retrieve\x20the\x20current\x20GameServer\
+    \x20data\n\n\x0c\n\x05\x06\0\x02\x03\x01\x12\x03-\x08\x15\n\x0c\n\x05\
+    \x06\0\x02\x03\x02\x12\x03-\x17\x1c\n\x0c\n\x05\x06\0\x02\x03\x03\x12\
+    \x03-'1\n\r\n\x05\x06\0\x02\x03\x04\x12\x04.\x080\n\n\x10\n\x08\x06\0\
+    \x02\x03\x04\xe7\x07\0\x12\x04.\x080\n\n\x10\n\t\x06\0\x02\x03\x04\xe7\
+    \x07\0\x02\x12\x03.\x0f\x20\n\x11\n\n\x06\0\x02\x03\x04\xe7\x07\0\x02\0\
+    \x12\x03.\x0f\x20\n\x12\n\x0b\x06\0\x02\x03\x04\xe7\x07\0\x02\0\x01\x12\
+    \x03.\x10\x1f\n\x11\n\t\x06\0\x02\x03\x04\xe7\x07\0\x08\x12\x04.#0\t\n\n\
+    \n\x02\x04\0\x12\x044\05\x01\n\n\n\x03\x04\0\x01\x12\x034\x08\r\n\xa2\
+    \x01\n\x02\x04\x01\x12\x04:\0c\x01\x1a\x95\x01\x20A\x20GameServer\x20Cus\
+    tom\x20Resource\x20Definition\x20object\n\x20We\x20will\x20only\x20expor\
+    t\x20those\x20resources\x20that\x20make\x20the\x20most\n\x20sense.\x20Ca\
+    n\x20always\x20expand\x20to\x20more\x20as\x20needed.\n\n\n\n\x03\x04\x01\
+    \x01\x12\x03:\x08\x12\n\x0b\n\x04\x04\x01\x02\0\x12\x03;\x04\x1f\n\r\n\
+    \x05\x04\x01\x02\0\x04\x12\x04;\x04:\x14\n\x0c\n\x05\x04\x01\x02\0\x06\
+    \x12\x03;\x04\x0e\n\x0c\n\x05\x04\x01\x02\0\x01\x12\x03;\x0f\x1a\n\x0c\n\
+    \x05\x04\x01\x02\0\x03\x12\x03;\x1d\x1e\n\x0b\n\x04\x04\x01\x02\x01\x12\
+    \x03<\x04\x12\n\r\n\x05\x04\x01\x02\x01\x04\x12\x04<\x04;\x1f\n\x0c\n\
+    \x05\x04\x01\x02\x01\x06\x12\x03<\x04\x08\n\x0c\n\x05\x04\x01\x02\x01\
+    \x01\x12\x03<\t\r\n\x0c\n\x05\x04\x01\x02\x01\x03\x12\x03<\x10\x11\n\x0b\
+    \n\x04\x04\x01\x02\x02\x12\x03=\x04\x16\n\r\n\x05\x04\x01\x02\x02\x04\
+    \x12\x04=\x04<\x12\n\x0c\n\x05\x04\x01\x02\x02\x06\x12\x03=\x04\n\n\x0c\
+    \n\x05\x04\x01\x02\x02\x01\x12\x03=\x0b\x11\n\x0c\n\x05\x04\x01\x02\x02\
+    \x03\x12\x03=\x14\x15\n=\n\x04\x04\x01\x03\0\x12\x04@\x04L\x05\x1a/\x20r\
+    epresentation\x20of\x20the\x20K8s\x20ObjectMeta\x20resource\n\n\x0c\n\
+    \x05\x04\x01\x03\0\x01\x12\x03@\x0c\x16\n\r\n\x06\x04\x01\x03\0\x02\0\
+    \x12\x03A\x08\x18\n\x0f\n\x07\x04\x01\x03\0\x02\0\x04\x12\x04A\x08@\x18\
+    \n\x0e\n\x07\x04\x01\x03\0\x02\0\x05\x12\x03A\x08\x0e\n\x0e\n\x07\x04\
+    \x01\x03\0\x02\0\x01\x12\x03A\x0f\x13\n\x0e\n\x07\x04\x01\x03\0\x02\0\
+    \x03\x12\x03A\x16\x17\n\r\n\x06\x04\x01\x03\0\x02\x01\x12\x03B\x08\x1d\n\
+    \x0f\n\x07\x04\x01\x03\0\x02\x01\x04\x12\x04B\x08A\x18\n\x0e\n\x07\x04\
+    \x01\x03\0\x02\x01\x05\x12\x03B\x08\x0e\n\x0e\n\x07\x04\x01\x03\0\x02\
+    \x01\x01\x12\x03B\x0f\x18\n\x0e\n\x07\x04\x01\x03\0\x02\x01\x03\x12\x03B\
+    \x1b\x1c\n\r\n\x06\x04\x01\x03\0\x02\x02\x12\x03C\x08\x17\n\x0f\n\x07\
+    \x04\x01\x03\0\x02\x02\x04\x12\x04C\x08B\x1d\n\x0e\n\x07\x04\x01\x03\0\
+    \x02\x02\x05\x12\x03C\x08\x0e\n\x0e\n\x07\x04\x01\x03\0\x02\x02\x01\x12\
+    \x03C\x0f\x12\n\x0e\n\x07\x04\x01\x03\0\x02\x02\x03\x12\x03C\x15\x16\n\r\
+    \n\x06\x04\x01\x03\0\x02\x03\x12\x03D\x08$\n\x0f\n\x07\x04\x01\x03\0\x02\
+    \x03\x04\x12\x04D\x08C\x17\n\x0e\n\x07\x04\x01\x03\0\x02\x03\x05\x12\x03\
+    D\x08\x0e\n\x0e\n\x07\x04\x01\x03\0\x02\x03\x01\x12\x03D\x0f\x1f\n\x0e\n\
+    \x07\x04\x01\x03\0\x02\x03\x03\x12\x03D\"#\n\r\n\x06\x04\x01\x03\0\x02\
+    \x04\x12\x03E\x08\x1d\n\x0f\n\x07\x04\x01\x03\0\x02\x04\x04\x12\x04E\x08\
+    D$\n\x0e\n\x07\x04\x01\x03\0\x02\x04\x05\x12\x03E\x08\r\n\x0e\n\x07\x04\
+    \x01\x03\0\x02\x04\x01\x12\x03E\x0e\x18\n\x0e\n\x07\x04\x01\x03\0\x02\
+    \x04\x03\x12\x03E\x1b\x1c\n<\n\x06\x04\x01\x03\0\x02\x05\x12\x03G\x08%\
+    \x1a-\x20timestamp\x20is\x20in\x20Epoch\x20format,\x20unit:\x20seconds\n\
+    \n\x0f\n\x07\x04\x01\x03\0\x02\x05\x04\x12\x04G\x08E\x1d\n\x0e\n\x07\x04\
+    \x01\x03\0\x02\x05\x05\x12\x03G\x08\r\n\x0e\n\x07\x04\x01\x03\0\x02\x05\
+    \x01\x12\x03G\x0e\x20\n\x0e\n\x07\x04\x01\x03\0\x02\x05\x03\x12\x03G#$\n\
+    K\n\x06\x04\x01\x03\0\x02\x06\x12\x03I\x08%\x1a<\x20optional\x20deletion\
+    \x20timestamp\x20in\x20Epoch\x20format,\x20unit:\x20seconds\n\n\x0f\n\
+    \x07\x04\x01\x03\0\x02\x06\x04\x12\x04I\x08G%\n\x0e\n\x07\x04\x01\x03\0\
+    \x02\x06\x05\x12\x03I\x08\r\n\x0e\n\x07\x04\x01\x03\0\x02\x06\x01\x12\
+    \x03I\x0e\x20\n\x0e\n\x07\x04\x01\x03\0\x02\x06\x03\x12\x03I#$\n\r\n\x06\
+    \x04\x01\x03\0\x02\x07\x12\x03J\x08,\n\x0f\n\x07\x04\x01\x03\0\x02\x07\
+    \x04\x12\x04J\x08I%\n\x0e\n\x07\x04\x01\x03\0\x02\x07\x06\x12\x03J\x08\
+    \x1b\n\x0e\n\x07\x04\x01\x03\0\x02\x07\x01\x12\x03J\x1c'\n\x0e\n\x07\x04\
+    \x01\x03\0\x02\x07\x03\x12\x03J*+\n\r\n\x06\x04\x01\x03\0\x02\x08\x12\
+    \x03K\x08'\n\x0f\n\x07\x04\x01\x03\0\x02\x08\x04\x12\x04K\x08J,\n\x0e\n\
+    \x07\x04\x01\x03\0\x02\x08\x06\x12\x03K\x08\x1b\n\x0e\n\x07\x04\x01\x03\
+    \0\x02\x08\x01\x12\x03K\x1c\"\n\x0e\n\x07\x04\x01\x03\0\x02\x08\x03\x12\
+    \x03K%&\n\x0c\n\x04\x04\x01\x03\x01\x12\x04N\x04W\x05\n\x0c\n\x05\x04\
+    \x01\x03\x01\x01\x12\x03N\x0c\x10\n\r\n\x06\x04\x01\x03\x01\x02\0\x12\
+    \x03O\x08\x1a\n\x0f\n\x07\x04\x01\x03\x01\x02\0\x04\x12\x04O\x08N\x12\n\
+    \x0e\n\x07\x04\x01\x03\x01\x02\0\x06\x12\x03O\x08\x0e\n\x0e\n\x07\x04\
+    \x01\x03\x01\x02\0\x01\x12\x03O\x0f\x15\n\x0e\n\x07\x04\x01\x03\x01\x02\
+    \0\x03\x12\x03O\x18\x19\n\x0e\n\x06\x04\x01\x03\x01\x03\0\x12\x04Q\x08V\
+    \t\n\x0e\n\x07\x04\x01\x03\x01\x03\0\x01\x12\x03Q\x10\x16\n\x0f\n\x08\
+    \x04\x01\x03\x01\x03\0\x02\0\x12\x03R\x0c\x1e\n\x11\n\t\x04\x01\x03\x01\
+    \x03\0\x02\0\x04\x12\x04R\x0cQ\x18\n\x10\n\t\x04\x01\x03\x01\x03\0\x02\0\
+    \x05\x12\x03R\x0c\x10\n\x10\n\t\x04\x01\x03\x01\x03\0\x02\0\x01\x12\x03R\
+    \x11\x19\n\x10\n\t\x04\x01\x03\x01\x03\0\x02\0\x03\x12\x03R\x1c\x1d\n\
+    \x0f\n\x08\x04\x01\x03\x01\x03\0\x02\x01\x12\x03S\x0c$\n\x11\n\t\x04\x01\
+    \x03\x01\x03\0\x02\x01\x04\x12\x04S\x0cR\x1e\n\x10\n\t\x04\x01\x03\x01\
+    \x03\0\x02\x01\x05\x12\x03S\x0c\x11\n\x10\n\t\x04\x01\x03\x01\x03\0\x02\
+    \x01\x01\x12\x03S\x12\x1f\n\x10\n\t\x04\x01\x03\x01\x03\0\x02\x01\x03\
+    \x12\x03S\"#\n\x0f\n\x08\x04\x01\x03\x01\x03\0\x02\x02\x12\x03T\x0c'\n\
+    \x11\n\t\x04\x01\x03\x01\x03\0\x02\x02\x04\x12\x04T\x0cS$\n\x10\n\t\x04\
+    \x01\x03\x01\x03\0\x02\x02\x05\x12\x03T\x0c\x11\n\x10\n\t\x04\x01\x03\
+    \x01\x03\0\x02\x02\x01\x12\x03T\x12\"\n\x10\n\t\x04\x01\x03\x01\x03\0\
+    \x02\x02\x03\x12\x03T%&\n\x0f\n\x08\x04\x01\x03\x01\x03\0\x02\x03\x12\
+    \x03U\x0c*\n\x11\n\t\x04\x01\x03\x01\x03\0\x02\x03\x04\x12\x04U\x0cT'\n\
+    \x10\n\t\x04\x01\x03\x01\x03\0\x02\x03\x05\x12\x03U\x0c\x11\n\x10\n\t\
+    \x04\x01\x03\x01\x03\0\x02\x03\x01\x12\x03U\x12%\n\x10\n\t\x04\x01\x03\
+    \x01\x03\0\x02\x03\x03\x12\x03U()\n\x0c\n\x04\x04\x01\x03\x02\x12\x04Y\
+    \x04b\x05\n\x0c\n\x05\x04\x01\x03\x02\x01\x12\x03Y\x0c\x12\n\x0e\n\x06\
+    \x04\x01\x03\x02\x03\0\x12\x04Z\x08]\t\n\x0e\n\x07\x04\x01\x03\x02\x03\0\
+    \x01\x12\x03Z\x10\x14\n\x0f\n\x08\x04\x01\x03\x02\x03\0\x02\0\x12\x03[\
+    \x0c\x1c\n\x11\n\t\x04\x01\x03\x02\x03\0\x02\0\x04\x12\x04[\x0cZ\x16\n\
+    \x10\n\t\x04\x01\x03\x02\x03\0\x02\0\x05\x12\x03[\x0c\x12\n\x10\n\t\x04\
+    \x01\x03\x02\x03\0\x02\0\x01\x12\x03[\x13\x17\n\x10\n\t\x04\x01\x03\x02\
+    \x03\0\x02\0\x03\x12\x03[\x1a\x1b\n\x0f\n\x08\x04\x01\x03\x02\x03\0\x02\
+    \x01\x12\x03\\\x0c\x1b\n\x11\n\t\x04\x01\x03\x02\x03\0\x02\x01\x04\x12\
+    \x04\\\x0c[\x1c\n\x10\n\t\x04\x01\x03\x02\x03\0\x02\x01\x05\x12\x03\\\
+    \x0c\x11\n\x10\n\t\x04\x01\x03\x02\x03\0\x02\x01\x01\x12\x03\\\x12\x16\n\
+    \x10\n\t\x04\x01\x03\x02\x03\0\x02\x01\x03\x12\x03\\\x19\x1a\n\r\n\x06\
+    \x04\x01\x03\x02\x02\0\x12\x03_\x08\x19\n\x0f\n\x07\x04\x01\x03\x02\x02\
+    \0\x04\x12\x04_\x08]\t\n\x0e\n\x07\x04\x01\x03\x02\x02\0\x05\x12\x03_\
+    \x08\x0e\n\x0e\n\x07\x04\x01\x03\x02\x02\0\x01\x12\x03_\x0f\x14\n\x0e\n\
+    \x07\x04\x01\x03\x02\x02\0\x03\x12\x03_\x17\x18\n\r\n\x06\x04\x01\x03\
+    \x02\x02\x01\x12\x03`\x08\x1b\n\x0f\n\x07\x04\x01\x03\x02\x02\x01\x04\
+    \x12\x04`\x08_\x19\n\x0e\n\x07\x04\x01\x03\x02\x02\x01\x05\x12\x03`\x08\
+    \x0e\n\x0e\n\x07\x04\x01\x03\x02\x02\x01\x01\x12\x03`\x0f\x16\n\x0e\n\
+    \x07\x04\x01\x03\x02\x02\x01\x03\x12\x03`\x19\x1a\n\r\n\x06\x04\x01\x03\
+    \x02\x02\x02\x12\x03a\x08\x20\n\x0e\n\x07\x04\x01\x03\x02\x02\x02\x04\
+    \x12\x03a\x08\x10\n\x0e\n\x07\x04\x01\x03\x02\x02\x02\x06\x12\x03a\x11\
+    \x15\n\x0e\n\x07\x04\x01\x03\x02\x02\x02\x01\x12\x03a\x16\x1b\n\x0e\n\
+    \x07\x04\x01\x03\x02\x02\x02\x03\x12\x03a\x1e\x1fb\x06proto3\
 ";
 
 static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {

--- a/sdks/rust/src/grpc/sdk_grpc.rs
+++ b/sdks/rust/src/grpc/sdk_grpc.rs
@@ -54,6 +54,13 @@ const METHOD_SDK_HEALTH: ::grpcio::Method<super::sdk::Empty, super::sdk::Empty> 
     resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
 };
 
+const METHOD_SDK_GET_GAME_SERVER: ::grpcio::Method<super::sdk::Empty, super::sdk::GameServer> = ::grpcio::Method {
+    ty: ::grpcio::MethodType::Unary,
+    name: "/stable.agones.dev.sdk.SDK/GetGameServer",
+    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+};
+
 pub struct SdkClient {
     client: ::grpcio::Client,
 }
@@ -104,6 +111,22 @@ impl SdkClient {
     pub fn health(&self) -> ::grpcio::Result<(::grpcio::ClientCStreamSender<super::sdk::Empty>, ::grpcio::ClientCStreamReceiver<super::sdk::Empty>)> {
         self.health_opt(::grpcio::CallOption::default())
     }
+
+    pub fn get_game_server_opt(&self, req: &super::sdk::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::sdk::GameServer> {
+        self.client.unary_call(&METHOD_SDK_GET_GAME_SERVER, req, opt)
+    }
+
+    pub fn get_game_server(&self, req: &super::sdk::Empty) -> ::grpcio::Result<super::sdk::GameServer> {
+        self.get_game_server_opt(req, ::grpcio::CallOption::default())
+    }
+
+    pub fn get_game_server_async_opt(&self, req: &super::sdk::Empty, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::sdk::GameServer>> {
+        self.client.unary_call_async(&METHOD_SDK_GET_GAME_SERVER, req, opt)
+    }
+
+    pub fn get_game_server_async(&self, req: &super::sdk::Empty) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::sdk::GameServer>> {
+        self.get_game_server_async_opt(req, ::grpcio::CallOption::default())
+    }
     pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Item = (), Error = ()> + Send + 'static {
         self.client.spawn(f)
     }
@@ -113,6 +136,7 @@ pub trait Sdk {
     fn ready(&self, ctx: ::grpcio::RpcContext, req: super::sdk::Empty, sink: ::grpcio::UnarySink<super::sdk::Empty>);
     fn shutdown(&self, ctx: ::grpcio::RpcContext, req: super::sdk::Empty, sink: ::grpcio::UnarySink<super::sdk::Empty>);
     fn health(&self, ctx: ::grpcio::RpcContext, stream: ::grpcio::RequestStream<super::sdk::Empty>, sink: ::grpcio::ClientStreamingSink<super::sdk::Empty>);
+    fn get_game_server(&self, ctx: ::grpcio::RpcContext, req: super::sdk::Empty, sink: ::grpcio::UnarySink<super::sdk::GameServer>);
 }
 
 pub fn create_sdk<S: Sdk + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
@@ -128,6 +152,10 @@ pub fn create_sdk<S: Sdk + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
     let instance = s.clone();
     builder = builder.add_client_streaming_handler(&METHOD_SDK_HEALTH, move |ctx, req, resp| {
         instance.health(ctx, req, resp)
+    });
+    let instance = s.clone();
+    builder = builder.add_unary_handler(&METHOD_SDK_GET_GAME_SERVER, move |ctx, req, resp| {
+        instance.get_game_server(ctx, req, resp)
     });
     builder.build()
 }


### PR DESCRIPTION
Extended the gRPC SDK to include a `GameServer()` function for both Go, C++
and REST by extending the backing `sdk.proto` and implementing the functionality
in the sdk sidecar.

This is the start of work needed for #277.