### PR TITLE
Missing `watch` permission in rbac for agones-sdk

### DIFF
--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -38,7 +38,7 @@ metadata:
 rules:
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
-  verbs: ["list", "update"]
+  verbs: ["list", "update", "watch"]
 ---
   {{- range .Values.gameservers.namespaces }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -113,7 +113,7 @@ metadata:
 rules:
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
-  verbs: ["list", "update"]
+  verbs: ["list", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Getting the following error in the logs.
`{"level":"error","msg":"agones.dev/agones/pkg/client/informers/externalversions/factory.go:74: Failed to watch *v1alpha1.GameServer: unknown (get gameservers.stable.agones.dev)","time":"2018-07-19T21:52:23Z"}`

Needed the `watch` permission to make it go away.

We aren't watching for events right now, so it's just noise, but it's better with it gone.