### PR TITLE
Fix bug: Disabled health checking not implemented

### DIFF
--- a/install/helm/agones/templates/serviceaccounts/sdk.yaml
+++ b/install/helm/agones/templates/serviceaccounts/sdk.yaml
@@ -36,6 +36,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
   verbs: ["list", "update", "watch"]

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -111,6 +111,9 @@ metadata:
     release: agones-manual
     heritage: Tiller
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 - apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
   verbs: ["list", "update", "watch"]


### PR DESCRIPTION
This commit fixes actually two bugs:

1) While we documented that you could disabled health checking we never
actually implemented it! This fixes that. Thankfully, the work that has been
done to retrieve `GameServer` details through the SDK makes this relatively
easy.

2) SDK Server sidecar never had the necessary RBAC permissions to send events
to the `GameServer` CRD. This is now fixed as well.