### PR TITLE
Hotfix: Ensure multiple Pods don't get created for a GameServer

### DIFF
--- a/pkg/gameservers/localsdk_test.go
+++ b/pkg/gameservers/localsdk_test.go
@@ -85,7 +85,7 @@ func TestLocalSDKServerSetLabel(t *testing.T) {
 		},
 	}
 
-	for k,v := range fixtures {
+	for k, v := range fixtures {
 		t.Run(k, func(t *testing.T) {
 			ctx := context.Background()
 			e := &sdk.Empty{}


### PR DESCRIPTION
Since the cache is eventually consistent, there was a race condition in which a GameServer could create more than one Pod backing it, as the first one isn't found in the cache yet.

This sync's the cache before checking this value, so the cache is up to date.