### PR TITLE
Forces restart when using tls generation.

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -141,7 +141,7 @@ install: ALWAYS_PULL_SIDECAR := true
 install: IMAGE_PULL_POLICY := "Always"
 install: $(ensure-build-image)
 	$(DOCKER_RUN) \
-		helm upgrade --install --recreate-pods --wait --namespace=agones-system \
+		helm upgrade --install --wait --namespace=agones-system \
 		--set agones.image.tag=$(VERSION),agones.image.registry=$(REGISTRY),agones.image.controller.pullPolicy=$(IMAGE_PULL_POLICY),agones.image.sdk.alwaysPull=$(ALWAYS_PULL_SIDECAR) \
 		agones $(mount_path)/install/helm/agones/
 

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -124,6 +124,13 @@ $ helm install --name my-release --namespace agones-system -f values.yaml agones
 
 > **Tip**: You can use the default [values.yaml](agones/values.yaml)
 
+## TLS Certificates
+
+By default agones chart generates tls certificates used by the adminission controller, while this is handy, it requires the agones controller to restart on each `helm upgrade` command. 
+For most used cases the controller would have required a restart anyway (eg: controller image updated). However if you really need to avoid restarts we suggest that you turn off tls automatic generation (`agones.controller.generateTLS` to `false`) and provide your own certificates (`certs/server.crt`,`certs/server.key`).
+
+> **Tip**: You can use our script located at `cert/cert.sh` to generates them.
+
 ## Confirm Agones is running
 
 To confirm Agones is up and running, [go to the next section](../README.md#confirming-agones-started-successfully)

--- a/install/helm/agones/templates/NOTES.txt
+++ b/install/helm/agones/templates/NOTES.txt
@@ -4,7 +4,7 @@ You can watch the status by running 'kubectl --namespace {{ .Release.Namespace }
 
 Once ready you can create your first GameServer using our examples:
 
-'kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/master/examples/simple-udp/server/gameserver.yaml'
+'kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/master/examples/simple-udp/gameserver.yaml'
 
 An example GameServer that makes use of the controller:
 

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -35,6 +35,10 @@ spec:
     type: Recreate
   template:
     metadata:
+{{- if .Values.agones.controller.generateTLS }}
+      annotations:
+        revision/tls-cert: {{ .Release.Revision | quote }}
+{{- end }}
       labels:
         stable.agones.dev/role: controller
         app: {{ template "agones.name" . }}


### PR DESCRIPTION
Fixes #309.

This forces restart when using helm TLS certificates generation. I've also added some documentation to avoid restarts if required, and fixed a wrong URL found in the documentation.