### PR TITLE
Add allocator service, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ This software is currently alpha, and subject to change. Not to be used in produ
 - Client SDKs for integration with dedicated game servers to work with Agones.
 
 ## Why does this project exist?
-For more details on why this project was written, read the 
+For more details on why this project was written, read the
 [announcement blog post](https://cloudplatform.googleblog.com/2018/03/introducing-Agones-open-source-multiplayer-dedicated-game-server-hosting-built-on-Kubernetes.html).
 
 ## Requirements
 - Kubernetes cluster version 1.9+
     - [Minikube](https://github.com/kubernetes/minikube), [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) and [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) have been tested
     - If you are creating and managing your own Kubernetes cluster, the
-    [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook-beta-in-19), and 
+    [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook-beta-in-19), and
     [ValidatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#validatingadmissionwebhook-alpha-in-18-beta-in-19)
     admission controllers are required.
     We also recommend following the
@@ -45,6 +45,7 @@ Documentation and usage guides on how to develop and host dedicated game servers
  - [Create a Game Server](./docs/create_gameserver.md)
  - [Create a Game Server Fleet](./docs/create_fleet.md)
  - [Edit Your First Game Server (Go)](./docs/edit_first_game_server.md)
+ - [Create an Allocator Service (Go)](./docs/create_allocator_service.md)
 
 ### Guides
  - [Integrating the Game Server SDK](sdks)
@@ -62,6 +63,7 @@ Documentation and usage guides on how to develop and host dedicated game servers
 - [Simple UDP](./examples/simple-udp) (Go) - simple server and client that send UDP packets back and forth.
 - [CPP Simple](./examples/cpp-simple) (C++) - C++ example that starts up, stays healthy and then shuts down after 60 seconds.
 - [Xonotic](./examples/xonotic) - Wraps the SDK around the open source FPS game [Xonotic](http://www.xonotic.org) and hosts it on Agones.
+- [Allocator Service](./examples/allocator-service) (Go) - A service which allocates a Game Server from a Fleet using the Agones API.
 
 ## Get involved
 
@@ -79,7 +81,7 @@ Please read the [contributing](CONTRIBUTING.md) guide for directions on submitti
 
 See the [Developing, Testing and Building Agones](build/README.md) documentation for developing, testing and building Agones from source.
 
-The [Release Process](docs/governance/release_process.md) documentation displays the project's upcoming release calendar and release process. 
+The [Release Process](docs/governance/release_process.md) documentation displays the project's upcoming release calendar and release process.
 
 Agones is in active development - we would love your help in shaping its future!
 

--- a/docs/access_api.md
+++ b/docs/access_api.md
@@ -1,15 +1,15 @@
 # Accessing Agones via the Kubernetes API
 
 It's likely that we will want to programmatically interact with Agones. Everything that can be done
-via the `kubectl` and yaml configurations can also be done via 
+via the `kubectl` and yaml configurations can also be done via
 the [Kubernetes API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/).
 
 Installing Agones creates several [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources),
 which can be accessed and manipulated through the Kubernetes API.
 
-Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/client-libraries/), however, 
-at time of writing, only 
-the [Go](https://github.com/kubernetes/client-go) and 
+Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/client-libraries/), however,
+at time of writing, only
+the [Go](https://github.com/kubernetes/client-go) and
 [Python](https://github.com/kubernetes-client/python/) clients are documented to support accessing CRDs.
 
 This can be found in the [Accessing a custom resource](https://kubernetes.io/docs/concepts/api-extension/custom-resources/#accessing-a-custom-resource)
@@ -34,21 +34,21 @@ If you plan to run your code in the same cluster as the Agones install, have a l
 [in cluster configuration](https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration)
 example from the Kubernetes Client.
 
-If you plan to run your code outside the Kubernetes cluster as your Agones install, 
+If you plan to run your code outside the Kubernetes cluster as your Agones install,
 look at the [out of cluster configuration](https://github.com/kubernetes/client-go/tree/master/examples/out-of-cluster-client-configuration)
 example from the Kubernetes client.
 
 ### Example
 
 The following is an example of a in-cluster configuration, that creates a `Clientset` for Agones
-and then creates a `GameServer`. 
+and then creates a `GameServer`.
 
 ```go
 package main
 
 import (
 	"fmt"
-	
+
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
@@ -62,9 +62,9 @@ func main() {
 	if err != nil {
 		logger.WithError(err).Fatal("Could not create in cluster config")
 	}
-	
+
 	// Access to standard Kubernetes resources through the Kubernetes Clientset
-	// We don't actually need this for this example, but it's just here for 
+	// We don't actually need this for this example, but it's just here for
 	// illustrative purposes
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -92,7 +92,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	
+
 	fmt.Printf("New game servers' name is: %s", newGS.ObjectMeta.Name)
 }
 
@@ -103,8 +103,8 @@ func main() {
 If there isn't a client written in your preferred language, it is always possible to communicate
 directly with Kubernetes API to interact with Agones.
 
-The Kubernetes API can be authenticated and exposed locally through the 
-[`kubectl proxy`](https://kubernetes.io/docs/tasks/access-kubernetes-api/http-proxy-access-api/) 
+The Kubernetes API can be authenticated and exposed locally through the
+[`kubectl proxy`](https://kubernetes.io/docs/tasks/access-kubernetes-api/http-proxy-access-api/)
 
 
 For example:
@@ -339,3 +339,8 @@ The [Verb Resources](https://github.com/kubernetes/community/blob/master/contrib
 section provide the more details on the API conventions that are used in the Kubernetes API.
 
 It may also be useful to look at the [API patterns for standard Kubernetes resources](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#-strong-write-operations-strong--54).
+
+
+## Next Steps
+
+Learn how to interact with Agones programmatically through the API while creating an [Allocator Service](../docs/create_allocator_service.md).

--- a/docs/create_allocator_service.md
+++ b/docs/create_allocator_service.md
@@ -1,0 +1,437 @@
+# Quickstart Create an Allocator Service
+
+This quickstart describes one way to implement a service which will allocate a Game Server on demand using the Agones API.  This allows a game client or matchmaker service to call the allocator service in order to allocate a Game Server and retrieve its IP address and port number. The game client can then connect directly to the Game Server, so that the minimized latency that is in the Agones design is preserved.
+
+## Objectives
+- Create a secure allocator service
+- Deploy the service to GKE
+- Allocate a Game Server from a Fleet using the service
+
+
+:warning: This quickstart requires Agones installed with agones.image.tag=0.5.0-03f4866 or newer :warning:
+
+## Prerequisites
+1. A [Go](https://golang.org/dl/) environment
+2. [Docker](https://www.docker.com/get-started/)
+3. Agones installed on GKE, with a simple-udp fleet
+4. kubectl properly configured
+5. A clone or fork of the [Agones repo](https://github.com/GoogleCloudPlatform/agones)
+
+
+>NOTE: Agones required Kubernetes versions 1.9 with role-based access controls (RBAC) and MutatingAdmissionWebhook features activated. To check your version, enter `kubectl version`.
+
+To install on GKE, follow the install instructions (if you haven't already) at
+[Setting up a Google Kubernetes Engine (GKE) cluster](../install/README.md#setting-up-a-google-kubernetes-engine-gke-cluster). Also complete the "Enabling creation of RBAC resources" and "Installing Agones" sets of instructions on the same page.
+
+While not required, you may wish to review the [Create a Game Server](../docs/create_gameserver.md), [Create Game Server Fleet](../docs/create_fleet.md), and/or [Edit a Game Server](../docs/edit_first_game_server.md) quickstarts.
+
+
+### 1. Create Firewall Rules
+
+Let's start off by making some firewall rules that will be used by kubernetes health checks and the ingress which we will create shortly.  
+
+First, we will make one for the HTTPS health checks that will be sent to our service by running:
+```
+gcloud compute firewall-rules create fleet-allocator-healthcheck \
+  --allow tcp \
+  --source-ranges 130.211.0.0/22,35.191.0.0/16 \
+  --target-tags fleet-allocator \
+  --description "Firewall to allow health check of fleet allocator service"
+```
+
+The output should be something like:
+```
+Creating firewall...done.                                                       
+NAME                         NETWORK  DIRECTION  PRIORITY  ALLOW  DENY  DISABLED
+fleet-allocator-healthcheck  default  INGRESS    1000      tcp          False
+```
+
+Create a firewall rule for nodePort traffic on the range of ports used by Ingress services of type nodePort.  We are using nobdePort becuase it supports TLS.
+```
+gcloud compute firewall-rules create nodeport-rule \
+  --allow=tcp:30000-32767 \
+  --target-tags fleet-allocator \
+  --description "Firewall to allow nodePort traffic of fleet allocator service"
+```
+
+The output should be something like:
+```
+Creating firewall...done.                                                       
+NAME           NETWORK  DIRECTION  PRIORITY  ALLOW            DENY  DISABLED
+nodeport-rule  default  INGRESS    1000      tcp:30000-32767        False
+```
+
+
+### 2. Make It Secure
+Let's keep security in mind from the beginning by creating a certificate, key and secret for the allocator service, and another set for the web server.
+
+Pick a more permanent location for the files if you like - /tmp may be purged depending on your operating system.
+
+Create a public private key pair for the allocator service:
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/allocsvc.key -out  /tmp/allocsvc.crt -subj "/CN=my-allocator/O=my-allocator"
+```
+
+The output should be something like:
+```
+Generating a 2048 bit RSA private key
+....................................................+++
+......................+++
+writing new private key to '/tmp/allocsvc.key'
+-----
+```
+
+Create a public private key pair that will be bound to the pod and used by the web server :
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out  /tmp/tls.crt -subj "/CN=my-allocator-w3/O=my-allocator-w3"
+```
+
+The output should be something like:
+```
+Generating a 2048 bit RSA private key
+....................................................+++
+......................+++
+writing new private key to '/tmp/tls.key'
+-----
+```
+
+
+### 3. Create Kubernetes Secrets
+
+The allocatorsecret will allow the service to use TLS for connections with workers.
+
+Create the secret by running this command:
+```
+kubectl create secret tls allocatorsecret --cert=/tmp/allocsvc.crt --key=/tmp/allocsvc.key
+```
+
+The output should be something like:
+```
+secret "allocatorsecret" created
+```
+
+The allocatorw3secret will let data be served by the webserver over https.
+
+Create the secret by running this command:
+```
+kubectl create secret tls allocatorw3secret --cert=/tmp/tls.crt --key=/tmp/tls.key
+```
+The output should be something like:
+```
+secret "allocatorw3secret" created
+```
+
+See that the secrets exist by running:
+```
+kubectl get secrets
+```
+
+The output should contain the secrets:
+```
+NAME                     TYPE                                  DATA      AGE
+...
+allocatorsecret          kubernetes.io/tls                     2         29s
+allocatorw3secret        kubernetes.io/tls                     2         15s
+...
+```
+
+
+### 4. Create the Service Account  
+This service will interact with the Agones via the Agones API by using a service account named fleet-allocator.  Specifically, the fleet-allocator service account is granted permissions to perform create operations against FleetAllocation objects.  The complete service account, role, and role binding definitions are in agones/examples/allocator-service/service-account.yaml.
+
+Create the service account by changing directories to your local agones/examples/allocator-service directory and running this command:
+```
+kubectl create -f service-account.yaml
+```
+
+The output should look like this:
+```
+role "fleet-allocator" created
+serviceaccount "fleet-allocator" created
+rolebinding "fleet-allocator" created
+```
+
+
+### 5. Define and Deploy the Service
+The service definition defines a nodePort service which uses https, and sets up ports and names.  The deployment describes the number of replicas we would like, which account to use, which image to use, and defines a health check.  The complete service definition is in agones/examples/allocator-service/allocator-service.yaml.
+
+Define and Deploy the service by running this command:
+```
+kubectl create -f allocator-service.yaml
+```
+
+The output should look like this:
+```
+service "fleet-allocator-backend" created
+deployment "fleet-allocator" created
+```
+
+
+### 6. Define an Ingress Resource
+This Ingress directs traffic to the allocator service using an ephemeral IP address.  Notice that we are specifying the ingress class as gce, which is specific to the Google Cloud Platform.  We also define which secret to use for TLS here.  
+
+This is in the file agones/examples/allocator-service/allocator-ingress.yaml
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: fleet-allocator-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - secretName: allocatorsecret
+  backend:
+    serviceName: fleet-allocator-backend
+    servicePort: 8000
+
+```
+
+
+### 7. Deploy the Ingress Resource  
+The allocator service pod needs to exist and the readiness probe should be passing health checks before the ingress is created.
+
+Deploy the Ingress with this command:
+```
+kubectl apply -f allocator-ingress.yaml
+```
+
+The output should look like this:
+```
+ingress "fleet-allocator-ingress" created
+```
+
+
+### 8. Retrieve the Ephemeral Public IP Address
+After deployment, it will take about a minute for the IP address to be present, and about 5 or 6 minutes before it can start returning data.
+
+Run this command to get the IP address:
+```
+kubectl get ingress fleet-allocator-ingress
+```
+
+The output should look something like this:
+```
+NAME                      HOSTS     ADDRESS         PORTS     AGE
+fleet-allocator-ingress   *         130.211.42.92   80, 443   1m
+```
+
+To learn more about the status of the ingress, run:
+```
+kubectl get ingress fleet-allocator-ingress -o yaml
+```
+
+When the output shows the ingress.kubernetes.io/backends as 'HEALTHY' rather than 'UNHEALTHY' or 'UNKOWN' it is ready.
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/backends: '{"k8s-be-30055--e34f41617775a061":"HEALTHY"}'
+    ingress.kubernetes.io/https-forwarding-rule: k8s-fws-default-fleet-allocator-ingress--e34f41617775a061
+    ingress.kubernetes.io/https-target-proxy: k8s-tps-default-fleet-allocator-ingress--e34f41617775a061
+    ingress.kubernetes.io/ssl-cert: k8s-ssl-e34f98d0d23b2aca-99c16222402fe1c4--e34f41617775a061
+    ingress.kubernetes.io/url-map: k8s-um-default-fleet-allocator-ingress--e34f41617775a061
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.allow-http":"false","kubernetes.io/ingress.class":"gce"},"name":"fleet-allocator-ingress","namespace":"default"},"spec":{"backend":{"serviceName":"fleet-allocator-backend","servicePort":8000},"tls":[{"secretName":"allocatorsecret"}]}}
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.class: gce
+  creationTimestamp: 2018-09-04T20:00:11Z
+  generation: 1
+  name: fleet-allocator-ingress
+  namespace: default
+  resourceVersion: "4127"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/fleet-allocator-ingress
+  uid: 218e0102-b07d-11e8-b86f-42010a8e0072
+spec:
+  backend:
+    serviceName: fleet-allocator-backend
+    servicePort: 8000
+  tls:
+  - secretName: allocatorsecret
+status:
+  loadBalancer:
+    ingress:
+    - ip: 130.211.42.92
+
+```
+
+
+### 9. Check the /healthz Endpoint.
+Inside of examples/allocator-service/main.go, we set up an endpoint /healthz so that kubernetes can determine the health status of the pod.  Let's hit that endpoint now from outside the cluster to see if it returns healthy or not, and to see if the ingress is working.
+
+Since the cert we created earlier is a self signed cert, ignoring insecure warning by adding the -k flag might be necessary:
+```
+curl -k https://the.ip.address/healthz
+```
+
+The output should look like this:
+```
+Healthy
+```
+
+You may need to wait a few moments longer if the output looks like this:
+```
+curl: (35) error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure
+```
+
+
+### 10. Check Game Servers
+Let's make sure that we have one or more Game Servers in a ready state by running this command:
+```
+kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+```
+
+For a fleet of 2 replicas, you should see 2 Game Servers with a Status of Ready:
+```
+NAME                     STATUS    IP              PORT
+simple-udp-thbvz-mqntp   Ready     35.196.249.83   [map[name:default port:7374]]
+simple-udp-thbvz-smchl   Ready     35.229.96.214   [map[name:default port:7016]]
+```
+
+If there is no fleet, please review [Create Game Server Fleet](../docs/create_fleet.md).
+
+
+### 11. Allocate a Game Server
+The service uses Basic Auth to provide some security as to who can allocate gameserver resources.  A generated key is in main.go that you can change.
+
+Now that the ingress has been created and we know it is healthy, let's allocate a Game Server by passing in our user and key to the /gameclient/address endpoint.
+
+Allocate a Game Server and retrieve its IP address and port by running this command:
+```
+curl -k -u v1GameClientKey:EAEC945C371B2EC361DE399C2F11E https://[the.ip.address]/gameclient/address
+```
+
+The output should show an IP address and port, similar to this:
+```
+{"address":"35.229.96.214","port":7016}
+```
+
+Check the Game Servers again, and notice the Allocated Status.  You should see something like this:
+```
+NAME                     STATUS      IP              PORT
+simple-udp-thbvz-mqntp   Ready       35.196.249.83   [map[name:default port:7374]]
+simple-udp-thbvz-smchl   Allocated   35.229.96.214   [map[name:default port:7016]]
+```
+
+
+### 12. Make the IP Address Permanent
+Since the ephemeral IP address previously created will only live for as long as the service lives, allocating a permanent IP address is necessary for longer term reliability.
+
+:warning: This step may cause additional billing charges. :warning:
+
+Reserve a static external IP address named allocator-static-ip by running:
+```
+gcloud compute addresses create allocator-static-ip --global
+```
+
+Configure the existing Ingress to use the reserved IP address by adding an annotation to allocator-ingress.yaml:
+```
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "allocator-static-ip"
+```
+
+Apply the change by running:
+```
+kubectl apply -f allocator-ingress.yaml
+```
+
+
+### 13. Create an A Record
+Setting up a DNS A record that points to the allocator service's permanent IP address is a flexible way to call it from other services or clients.
+
+This step requires that you have a registered domain available.  Use the permanent IP address created previously when creating a new A record with your registrar, and follow your registrars documentation on adding an A record.  When finished, a subdomain, such as allocator-service, should exist.
+
+Now https://allocator-service.yourdomain.ext should return the IP address and port of the allocated Game Server.
+
+
+### 14. Customize
+Edit main.go to reflect your kubernetes configuration by changing which namespace is used and which fleet GameServers are being allocated from.  Also create a unique key or password that will be used when calling this allocator service.
+
+
+Change some constants to reflect your environment.  These are the current values:
+```
+const namespace    = "default"
+const fleetname    = "simple-udp"
+const generatename = "simple-udp-"
+```
+
+Add a unique password to the authorized group in main.go, for example:
+```
+// Group that can allocate game servers
+authorized := router.Group("/gameclient", gin.BasicAuth(gin.Accounts{
+  "v1GameClientKey": "92d5cca8-1ef0-4ee3-b10c-3a3ea802bff7",
+}))
+```
+
+Since the Docker image is using Alpine Linux, the "go build" command has to include few more environment variables.
+
+Let's get our dependencies and build with these commands:
+```
+go get net/http
+go get agones.dev/agones/pkg/client/clientset/versioned
+go get agones.dev/agones/pkg/apis/stable/v1alpha1
+go get agones.dev/agones/pkg/util/runtime
+go get github.com/gin-gonic/gin
+go get k8s.io/api/core/v1
+go get k8s.io/apimachinery/pkg/apis/meta/v1
+go get k8s.io/client-go/rest
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/server -a -v main.go
+```
+
+Build a new docker image, where REPO is your repository and TAG is your tag:
+```
+docker build -t [REPO]/allocator-service:[TAG] .
+```
+
+Push it to whatever repo you use:
+```
+docker push [REPO]/allocator-service:[TAG]
+```
+
+Edit allocator-service.yaml to point to the new image:
+```
+containers:
+- name: fleet-allocator
+  image: your.repo/user/allocator-service:tag
+  imagePullPolicy: Always
+```
+
+Edit your game client, matchmaker, or other dependent service to hit the subdomain.domain.ext/gameclient/address endpoint to retrieve the IP address and port of the newly allocated Game Server.
+
+Consider adding some code to the dedicated game server that checks how many connected users there are, or how many players are in the world.  If it returns 0, call the Agones SDK /shutdown endpoint to destroy the stale Pod.
+
+
+### 15. Cleanup
+You can delete the allocator service and associated resources with the following commands.
+
+Delete the Ingress
+```
+kubectl delete ingress fleet-allocator-ingress
+```
+
+Delete the Reserved IP address
+```
+gcloud compute addresses delete allocator-static-ip --global
+```
+
+Delete the Service
+```
+kubectl delete -f allocator-service.yaml
+```
+
+Delete the Service Account
+```
+kubectl delete -f service-account.yaml
+```
+
+
+### 16. Related Documentation
+
+The [Gin Web Framework](https://github.com/gin-gonic/gin/)
+
+The Kubernetes documentation on [Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+
+The Kubernetes documentation on [Connecting Applications with Services](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/)

--- a/docs/create_fleet.md
+++ b/docs/create_fleet.md
@@ -1,6 +1,6 @@
 # Quickstart Create a Game Server Fleet
 
-This guide covers how you can quickly get started using Agones to create a Fleet 
+This guide covers how you can quickly get started using Agones to create a Fleet
 of warm GameServers ready for you to allocate out of and play on!
 
 ## Prerequisites
@@ -44,7 +44,7 @@ fleet "simple-udp" created
 
 This has created a Fleet record inside Kubernetes, which in turn creates two warm [GameServers](gameserver_spec.md) to
 be available to being allocated for usage for a game session.
- 
+
 ```
 kubectl get fleet
 ```
@@ -55,7 +55,7 @@ NAME         AGE
 simple-udp   5m
 ```
 
-You can also see the GameServers that have been created by the Fleet by running `kubectl get gameservers`, 
+You can also see the GameServers that have been created by the Fleet by running `kubectl get gameservers`,
 the GameServer will be prefixed by `simple-udp`.
 
 ```
@@ -289,7 +289,7 @@ grow and shrink.
 ### 6. Connect to the GameServer
 
 Since we've only got one allocation, we'll just grab the details of the IP and port of the
-only allocated `GameServer`: 
+only allocated `GameServer`:
 
 ```
 kubectl get $(kubectl get fleetallocation -o name) -o jsonpath='{.status.GameServer.staatus.GameServer.status.ports[0].port}'
@@ -312,7 +312,7 @@ If you run `kubectl describe gs | grep State` again - either the GameServer will
 , or it will be in `Shutdown` state, on the way to being deleted.
 
 Since we are running a `Fleet`, Agones will always do it's best to ensure there are always the configured number
-of `GameServers` in the pool in either a `Ready` or `Allocated` state. 
+of `GameServers` in the pool in either a `Ready` or `Allocated` state.
 
 ### 7. Deploy a new version of the GameServer on the Fleet
 
@@ -327,7 +327,7 @@ Let's also allocate ourselves a `GameServer`
 kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/master/examples/simple-udp/fleetallocation.yaml -o yaml
 ```
 
-We should now have four `Ready` `GameServers` and one `Allocated`. 
+We should now have four `Ready` `GameServers` and one `Allocated`.
 
 We can check this by running `kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports`.
 
@@ -349,7 +349,7 @@ with a Container Port of `6000`.
 
 > NOTE: This will make it such that you can no longer connect to the simple-udp game server.  
 
-Run `watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,CONTAINERPORT:.spec.ports[0].containerPort` 
+Run `watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,CONTAINERPORT:.spec.ports[0].containerPort`
 until you can see that there are
 one of `7654`, which is the `Allocated` `GameServer`, and four instances to `6000` which
 is the new configuration.
@@ -359,3 +359,5 @@ You have now deployed a new version of your game!
 ## Next Steps
 
 If you want to use your own GameServer container make sure you have properly integrated the [Agones SDK](../sdks/).
+
+If you want to learn how to programmatically allocate a Game Server from the Fleet using the Agones API, see creating an [Allocator Service](../docs/create_allocator_service.md).

--- a/docs/edit_first_game_server.md
+++ b/docs/edit_first_game_server.md
@@ -1,11 +1,12 @@
-# Getting Started
+# Quickstart Edit a Game Server
 The following guide is for developers without Docker or Kubernetes experience, that want to use the simple-udp example as a starting point for a custom game server. This guide addresses Google Kubernetes Engine and Minikube.  We would welcome a Pull Request to expand this to include other platforms as well.
 
 ## Prerequisites
 
-1. Downland and install Golang from https://golang.org/dl/.
-2. Install Docker from https://www.docker.com/get-docker.
-3. Install Agones on GKE or Minikube.  
+1. A [Go](https://golang.org/dl/) environment
+2. [Docker](https://www.docker.com/get-started/)
+3. Agones installed on GKE or Minikube
+4. kubectl properly configured
 
 To install on GKE, follow the install instructions (if you haven't already) at
 [Setting up a Google Kubernetes Engine (GKE) cluster](../install/README.md#setting-up-a-google-kubernetes-engine-gke-cluster). Also complete the "Enabling creation of RBAC resources" and "Installing Agones" sets of instructions on the same page.
@@ -14,7 +15,7 @@ To install locally on Minikube, read [Setting up a Minikube cluster](../install/
 
 ## Modify the code and push another new image
 
-### Modify the simple-udp example source source code
+### Modify the simple-udp example source code
 Modify the main.go file. For example:
 
 Change main.go line 92:

--- a/examples/allocator-service/README.md
+++ b/examples/allocator-service/README.md
@@ -1,0 +1,12 @@
+# Simple Allocator Service
+
+This service provides an example of using the Agones API to allocate a GameServer from a Fleet.
+
+:warning: Requires Agones installed with agones.image.tag=0.5.0-03f4866 or newer :warning:
+
+## Allocator Service
+The service exposes an endpoint which allows client calls to FleetAllocationInterface.Create() over a secure connection.  It also provides examples of how to create a service account with the least necessary privileges, how to create an Ingress, and how services can use secrets specific to their respective accounts.
+
+When the endpoint is called and a GameServer is allocated, it returns the JSON encoded IP addresss and port number of the freshly allocated GameServer.
+
+To learn how to deploy your edited version of an allocator service to GKE, please see the quick start [Create an Allocator Service (Go)](../../docs/create_allocator_service.md).

--- a/examples/allocator-service/allocator-ingress.yaml
+++ b/examples/allocator-service/allocator-ingress.yaml
@@ -1,0 +1,16 @@
+# Create a single service Ingress resource
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: fleet-allocator-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.allow-http: "false"
+    #kubernetes.io/ingress.global-static-ip-name: "allocator-static-ip"
+spec:
+  tls:
+  - secretName: allocatorsecret
+  backend:
+    serviceName: fleet-allocator-backend
+    servicePort: 8000

--- a/examples/allocator-service/allocator-service.yaml
+++ b/examples/allocator-service/allocator-service.yaml
@@ -1,0 +1,60 @@
+# Define a Service for the fleet-allocator
+apiVersion: v1
+kind: Service
+metadata:
+  name: fleet-allocator-backend
+  annotations:
+    service.alpha.kubernetes.io/app-protocols: '{"https":"HTTPS"}'
+  labels:
+    app: fleet-allocator
+spec:
+  type: NodePort
+  selector:
+    app: fleet-allocator
+  ports:
+  - port: 8000
+    protocol: TCP
+    name: https
+    targetPort: fleet-allocator  # retrieve port from deployment config
+
+---
+# Deploy a pod to run the fleet-allocator code
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fleet-allocator
+  template:
+    metadata:
+      labels:
+        app: fleet-allocator
+    spec:
+      serviceAccount: fleet-allocator
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: allocatorw3secret
+      containers:
+      - name: fleet-allocator
+        image: index.docker.io/trota/allocator-service:simple-udp-0.5.0-03f4866-2
+        imagePullPolicy: Always
+        ports:
+        - name: fleet-allocator
+          containerPort: 8000
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        volumeMounts:
+        - mountPath: /home/service/certs
+          name: secret-volume

--- a/examples/allocator-service/dockerfile
+++ b/examples/allocator-service/dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.7
+
+RUN adduser -D service
+
+COPY ./bin/service /home/service/service
+
+RUN chown -R service /home/service && \
+    chmod o+x /home/service/service
+
+USER service
+ENTRYPOINT /home/service/service

--- a/examples/allocator-service/main.go
+++ b/examples/allocator-service/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"net/http"
+	"agones.dev/agones/pkg/client/clientset/versioned"
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
+	"agones.dev/agones/pkg/util/runtime"	// for the logger
+	"github.com/gin-gonic/gin"            // for the web server
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+const namespace    = "default"
+const fleetname    = "simple-udp"
+const generatename = "simple-udp-"
+
+var (
+	logger  = runtime.NewLoggerWithSource("main")
+	address = "NoReadyGS"	// default response if no gameservers are available
+	port int32            // 0 until populated
+)
+
+// Move a replica from ready to allocated and return the ip and port
+func getIPAddress() (string, int32) {
+	// Create the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.WithError(err).Fatal("Could not create in cluster config")
+	}
+
+	// Access to the Agones resources through the Agones Clientset
+	agonesClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		logger.WithError(err).Fatal("Could not create the agones api clientset")
+	} else {
+		logger.Info("Created the agones api clientset")
+	}
+
+  // Log the values used in the fleet allocation
+	logger.WithField("namespace", namespace).Info("namespace for fa")
+	logger.WithField("generatename", generatename).Info("generatename for fa")
+	logger.WithField("fleetname", fleetname).Info("fleetname for fa")
+
+	// Get a FleetAllocationInterface for this namespace
+	fleetAllocationInterface := agonesClient.StableV1alpha1().FleetAllocations(namespace)
+
+	// Define the fleet allocation
+	fa := &v1alpha1.FleetAllocation{
+		ObjectMeta: v1.ObjectMeta{
+			GenerateName: generatename, Namespace: namespace,
+			},
+				Spec: v1alpha1.FleetAllocationSpec{FleetName: fleetname},
+		}
+
+	// Create a new fleet allocation
+	newFleetAllocation, err := fleetAllocationInterface.Create(fa)
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to create fleet allocation for ", fleetname)
+	} else {
+		logger.Info("Created a fleet allocation for ", fleetname)
+	}
+
+	// Log the address and port of the new allocation, then return those values
+	logger.Info(
+		"New GameServer allocated at %s:%d",
+		newFleetAllocation.Status.GameServer.Status.Address,
+		newFleetAllocation.Status.GameServer.Status.Ports[0].Port,
+	)
+	address = newFleetAllocation.Status.GameServer.Status.Address
+	port = newFleetAllocation.Status.GameServer.Status.Ports[0].Port
+
+	return address, port
+}
+
+// Set up an http server, fetch ip of allocated gameserver set, and return it
+func main() {
+	// Set up the HTTP server with default values
+	router := gin.Default()
+
+	// Serve 200 status on / for k8s health checks
+	router.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "Healthy")
+	})
+
+	// Serve 200 status on /healthz for k8s health checks
+	router.GET("/healthz", func(c *gin.Context) {
+		c.String(http.StatusOK, "Healthy")
+	})
+
+	// Group that can allocate game servers
+	authorized := router.Group("/gameclient", gin.BasicAuth(gin.Accounts{
+		"v1GameClientKey": "EAEC945C371B2EC361DE399C2F11E",
+	}))
+
+	// Return the ip and port of the allocated replica to the authorized client
+	authorized.GET("/address", func(c *gin.Context) {
+		address, port := getIPAddress()
+		c.JSON(http.StatusOK, gin.H{"address": address, "port": port})
+	})
+
+	// Run the HTTP server
+	if err := router.RunTLS(":8000", "/home/service/certs/tls.crt", "/home/service/certs/tls.key"); err != nil {
+		logger.WithError(err).Fatal("HTTPS server failed to run")
+	} else {
+		logger.Info("HTTPS server is running on port 8000")
+	}
+}

--- a/examples/allocator-service/service-account.yaml
+++ b/examples/allocator-service/service-account.yaml
@@ -1,0 +1,42 @@
+# Create a Role in the default namespace that grants access to the agones api
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: ["stable.agones.dev"]
+  resources: ["fleetallocations"]
+  verbs: ["create"]
+
+---
+# Create a ServiceAccount that will be bound to the above role
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+
+---
+# Bind the fleet-allocator ServiceAccount to the fleet-allocator Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+subjects:
+- kind: ServiceAccount
+  name: fleet-allocator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fleet-allocator


### PR DESCRIPTION
This is a service that allocates a game server from a fleet using the Agones API.  It then returns the IP address and port of the allocated game server.  I cleaned up the notes I took while making it, and maybe they might provide some useful documentation for people who are looking to programmatically allocate game servers.

Some things I'm not sure about:
- Is the document create_allocator_service.md more of a Quickstart or a Guide?
- The service in the example uses a container in my public Docker registry...I don't mind, but it might be better off in a repo controlled by this project.
- Step 12 and onward of create_allocator_service might be out of scope.
- The error handling in main.go seem inadequate to me...but maybe it is ok?

Please let me know if this would be useful, and if so, what changes should be made.
