### PR TITLE
Add allocator service example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ This software is currently alpha, and subject to change. Not to be used in produ
 - Client SDKs for integration with dedicated game servers to work with Agones.
 
 ## Why does this project exist?
-For more details on why this project was written, read the 
+For more details on why this project was written, read the
 [announcement blog post](https://cloudplatform.googleblog.com/2018/03/introducing-Agones-open-source-multiplayer-dedicated-game-server-hosting-built-on-Kubernetes.html).
 
 ## Requirements
 - Kubernetes cluster version 1.9+
     - [Minikube](https://github.com/kubernetes/minikube), [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) and [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) have been tested
     - If you are creating and managing your own Kubernetes cluster, the
-    [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook-beta-in-19), and 
+    [MutatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#mutatingadmissionwebhook-beta-in-19), and
     [ValidatingAdmissionWebhook](https://kubernetes.io/docs/admin/admission-controllers/#validatingadmissionwebhook-alpha-in-18-beta-in-19)
     admission controllers are required.
     We also recommend following the
@@ -51,6 +51,9 @@ Documentation and usage guides on how to develop and host dedicated game servers
  - [Integrating the Game Server SDK](sdks)
  - [GameServer Health Checking](./docs/health_checking.md)
  - [Accessing Agones via the Kubernetes API](./docs/access_api.md)
+
+### Tutorials
+ - [Create an Allocator Service (Go)](./docs/create_allocator_service.md) - Learn to programmatically access Agones via the API
 
 ### Reference
 - [Game Server Specification](./docs/gameserver_spec.md)
@@ -80,7 +83,7 @@ Please read the [contributing](CONTRIBUTING.md) guide for directions on submitti
 
 See the [Developing, Testing and Building Agones](build/README.md) documentation for developing, testing and building Agones from source.
 
-The [Release Process](docs/governance/release_process.md) documentation displays the project's upcoming release calendar and release process. 
+The [Release Process](docs/governance/release_process.md) documentation displays the project's upcoming release calendar and release process.
 
 Agones is in active development - we would love your help in shaping its future!
 

--- a/docs/access_api.md
+++ b/docs/access_api.md
@@ -1,15 +1,15 @@
 # Accessing Agones via the Kubernetes API
 
 It's likely that we will want to programmatically interact with Agones. Everything that can be done
-via the `kubectl` and yaml configurations can also be done via 
+via the `kubectl` and yaml configurations can also be done via
 the [Kubernetes API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/).
 
 Installing Agones creates several [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources),
 which can be accessed and manipulated through the Kubernetes API.
 
-Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/client-libraries/), however, 
-at time of writing, only 
-the [Go](https://github.com/kubernetes/client-go) and 
+Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/client-libraries/), however,
+at time of writing, only
+the [Go](https://github.com/kubernetes/client-go) and
 [Python](https://github.com/kubernetes-client/python/) clients are documented to support accessing CRDs.
 
 This can be found in the [Accessing a custom resource](https://kubernetes.io/docs/concepts/api-extension/custom-resources/#accessing-a-custom-resource)
@@ -34,21 +34,21 @@ If you plan to run your code in the same cluster as the Agones install, have a l
 [in cluster configuration](https://github.com/kubernetes/client-go/tree/master/examples/in-cluster-client-configuration)
 example from the Kubernetes Client.
 
-If you plan to run your code outside the Kubernetes cluster as your Agones install, 
+If you plan to run your code outside the Kubernetes cluster as your Agones install,
 look at the [out of cluster configuration](https://github.com/kubernetes/client-go/tree/master/examples/out-of-cluster-client-configuration)
 example from the Kubernetes client.
 
 ### Example
 
 The following is an example of a in-cluster configuration, that creates a `Clientset` for Agones
-and then creates a `GameServer`. 
+and then creates a `GameServer`.
 
 ```go
 package main
 
 import (
 	"fmt"
-	
+
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
@@ -62,9 +62,9 @@ func main() {
 	if err != nil {
 		logger.WithError(err).Fatal("Could not create in cluster config")
 	}
-	
+
 	// Access to standard Kubernetes resources through the Kubernetes Clientset
-	// We don't actually need this for this example, but it's just here for 
+	// We don't actually need this for this example, but it's just here for
 	// illustrative purposes
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -92,7 +92,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	
+
 	fmt.Printf("New game servers' name is: %s", newGS.ObjectMeta.Name)
 }
 
@@ -103,8 +103,8 @@ func main() {
 If there isn't a client written in your preferred language, it is always possible to communicate
 directly with Kubernetes API to interact with Agones.
 
-The Kubernetes API can be authenticated and exposed locally through the 
-[`kubectl proxy`](https://kubernetes.io/docs/tasks/access-kubernetes-api/http-proxy-access-api/) 
+The Kubernetes API can be authenticated and exposed locally through the
+[`kubectl proxy`](https://kubernetes.io/docs/tasks/access-kubernetes-api/http-proxy-access-api/)
 
 
 For example:
@@ -339,3 +339,8 @@ The [Verb Resources](https://github.com/kubernetes/community/blob/master/contrib
 section provide the more details on the API conventions that are used in the Kubernetes API.
 
 It may also be useful to look at the [API patterns for standard Kubernetes resources](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#-strong-write-operations-strong--54).
+
+
+## Next Steps
+
+Learn how to interact with Agones programmatically through the API while creating an [Allocator Service](./create_allocator_service.md).

--- a/docs/create_allocator_service.md
+++ b/docs/create_allocator_service.md
@@ -1,0 +1,333 @@
+# Tutorial Create an Allocator Service
+
+This tutorial describes how to interact programmatically with the [Agones API](https://godoc.org/agones.dev/agones/pkg/client/clientset/versioned/typed/stable/v1alpha1).  To do this, we will implement a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) which allocates a Game Server on demand by calling the Create() method of the FleetAllocationInterface.  After creating the fleet allocation, we will return the JSON encoded GameServerStatus of the allocated GameServer.
+
+The type of service we will be learning about could be used by a game client to connect directly to a dedicated Game Server, as part of a larger system, such as a matchmaker service, or in conjunction with a database of level transition data.  We will be using the service as a vehicle with which to execute the API calls found in our main.go file.
+
+## Objectives
+- Create a secure allocator service
+- Deploy the service to [GKE](https://cloud.google.com/kubernetes-engine/)
+- Allocate a Game Server from a Fleet using the Agones API
+
+## Prerequisites
+1. [Docker](https://www.docker.com/get-started/)
+2. Agones installed on GKE, running a simple-udp fleet
+3. kubectl properly configured
+4. A local copy of the [allocator service](https://github.com/GoogleCloudPlatform/agones/tree/master/examples/allocator-service)
+5. A repository for Docker images, such as [Docker Hub](https://hub.docker.com/) or [GC Container Registry](https://cloud.google.com/container-registry/)
+
+
+>NOTE: Agones requires Kubernetes versions 1.9 with role-based access controls (RBAC) and MutatingAdmissionWebhook features activated. To check your version, enter `kubectl version`.
+
+To install on GKE, follow the install instructions (if you haven't already) at
+[Setting up a Google Kubernetes Engine (GKE) cluster](../install/README.md#setting-up-a-google-kubernetes-engine-gke-cluster). Also complete the "Enabling creation of RBAC resources" and "Installing Agones" sets of instructions on the same page.
+
+While not required, you may wish to review the [Create a Game Server](./create_gameserver.md), [Create Game Server Fleet](./create_fleet.md), and/or [Edit a Game Server](./edit_first_game_server.md) quickstarts.
+
+
+### 1. Build and Push the Service
+Change directories to your local agones/examples/allocator-service directory and build a new docker image.  The multi-stage Dockerfile will pull down all the dependencies for you and build the executable.  For example, where USER is your username, REPO is your repository, and TAG is your tag:
+```
+docker build -t [USER]/allocator-service:[TAG] .
+```
+
+Push it to your repository:
+```
+docker push [USER]/allocator-service:[TAG]
+```
+
+Edit allocator-service.yaml to point to your new image:
+```
+containers:
+- name: fleet-allocator
+  image: [REPO]/[USER]/allocator-service:[TAG]
+  imagePullPolicy: Always
+```
+
+
+### 2. Create Firewall Rules
+
+Let's making some [firewall](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/) rules that will be used by kubernetes health checks and the ingress which we will create shortly.
+
+First, we will make one for the HTTPS health checks that will be sent to our service by running:
+```
+gcloud compute firewall-rules create fleet-allocator-healthcheck \
+  --allow tcp \
+  --source-ranges 130.211.0.0/22,35.191.0.0/16 \
+  --target-tags fleet-allocator \
+  --description "Firewall to allow health check of fleet allocator service"
+```
+
+The output should be something like:
+```
+Creating firewall...done.                                            
+NAME                         NETWORK  DIRECTION  PRIORITY  ALLOW  DENY  DISABLED
+fleet-allocator-healthcheck  default  INGRESS    1000      tcp          False
+```
+
+Create a firewall rule for nodePort traffic on the range of ports used by Ingress services of type nodePort.  We are using nobdePort becuase it supports TLS.
+```
+gcloud compute firewall-rules create nodeport-rule \
+  --allow=tcp:30000-32767 \
+  --target-tags fleet-allocator \
+  --description "Firewall to allow nodePort traffic of fleet allocator service"
+```
+
+The output should be something like:
+```
+Creating firewall...done.                                            
+NAME           NETWORK  DIRECTION  PRIORITY  ALLOW            DENY  DISABLED
+nodeport-rule  default  INGRESS    1000      tcp:30000-32767        False
+```
+
+
+### 3. Make It Secure
+Let's keep security in mind from the beginning by creating a certificate, key and secret for the allocator service, and another set for the web server.
+
+Pick a more permanent location for the files if you like - /tmp may be purged depending on your operating system.
+
+Create a public private key pair for the allocator service:
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/allocsvc.key -out  /tmp/allocsvc.crt -subj "/CN=my-allocator/O=my-allocator"
+```
+
+The output should be something like:
+```
+Generating a 2048 bit RSA private key
+....................................................+++
+......................+++
+writing new private key to '/tmp/allocsvc.key'
+-----
+```
+
+Create a public private key pair that will be bound to the pod and used by the web server :
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out  /tmp/tls.crt -subj "/CN=my-allocator-w3/O=my-allocator-w3"
+```
+
+The output should be something like:
+```
+Generating a 2048 bit RSA private key
+....................................................+++
+......................+++
+writing new private key to '/tmp/tls.key'
+-----
+```
+
+
+### 4. Create Kubernetes Secrets
+
+The allocatorsecret will allow the service to use TLS for connections with workers.
+
+Create the [secret](https://kubernetes.io/docs/concepts/configuration/secret/) by running this command:
+```
+kubectl create secret tls allocatorsecret --cert=/tmp/allocsvc.crt --key=/tmp/allocsvc.key
+```
+
+The output should be something like:
+```
+secret "allocatorsecret" created
+```
+
+The allocatorw3secret will let data be served by the webserver over https.
+
+Create the secret by running this command:
+```
+kubectl create secret tls allocatorw3secret --cert=/tmp/tls.crt --key=/tmp/tls.key
+```
+The output should be something like:
+```
+secret "allocatorw3secret" created
+```
+
+See that the secrets exist by running:
+```
+kubectl get secrets
+```
+
+The output should contain the secrets:
+```
+NAME                     TYPE                                  DATA      AGE
+...
+allocatorsecret          kubernetes.io/tls                     2         29s
+allocatorw3secret        kubernetes.io/tls                     2         15s
+...
+```
+
+
+### 5. Create the Service Account
+This service will interact with Agones via the Agones API by using a [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) named fleet-allocator.  Specifically, the fleet-allocator service account is granted permissions to perform create operations against FleetAllocation objects, and get operations against Fleet objects.
+
+Create the service account by changing directories to your local agones/examples/allocator-service directory and running this command:
+```
+kubectl create -f service-account.yaml
+```
+
+The output should look like this:
+```
+role "fleet-allocator" created
+serviceaccount "fleet-allocator" created
+rolebinding "fleet-allocator" created
+```
+
+
+### 6. Define and Deploy the Service
+The service definition defines a [nodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) service which uses https, and sets up ports and names.  The deployment describes the number of replicas we would like, which account to use, which image to use, and defines a health check.
+
+Define and Deploy the service by running this command:
+```
+kubectl create -f allocator-service.yaml
+```
+
+The output should look like this:
+```
+service "fleet-allocator-backend" created
+deployment "fleet-allocator" created
+```
+
+
+### 7. Deploy the Ingress Resource
+This [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) directs traffic to the allocator service using an ephemeral IP address.  The allocator service pod needs to exist and the readiness probe should be passing health checks before the ingress is created.
+
+Deploy the Ingress with this command:
+```
+kubectl apply -f allocator-ingress.yaml
+```
+
+The output should look like this:
+```
+ingress "fleet-allocator-ingress" created
+```
+
+
+### 8. Retrieve the Ephemeral Public IP Address
+After deployment, it will take about a minute for the IP address to be present, and up to 10 minutes before it can start returning data.
+
+Run this command to get the IP address:
+```
+kubectl get ingress fleet-allocator-ingress
+```
+
+The output should look something like this:
+```
+NAME                      HOSTS     ADDRESS          PORTS     AGE
+fleet-allocator-ingress   *         35.186.225.103   80, 443   1m
+```
+
+To learn more about the status of the ingress, run:
+```
+kubectl get ingress fleet-allocator-ingress -o yaml
+```
+
+When the output shows the ingress.kubernetes.io/backends as 'HEALTHY' rather than 'UNHEALTHY' or 'UNKOWN' it is probably ready.
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/backends: '{"k8s-be-30021--7e98a70481f48a13":"HEALTHY"}'
+    ingress.kubernetes.io/https-forwarding-rule: k8s-fws-default-fleet-allocator-ingress--7e98a70481f48a13
+    ingress.kubernetes.io/https-target-proxy: k8s-tps-default-fleet-allocator-ingress--7e98a70481f48a13
+    ingress.kubernetes.io/ssl-cert: k8s-ssl-1ab99915a1f6b5f1-b2a9924cee73d20a--7e98a70481f48a13
+    ingress.kubernetes.io/url-map: k8s-um-default-fleet-allocator-ingress--7e98a70481f48a13
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"extensions/v1beta1","kind":"Ingress","metadata":{"annotations":{"kubernetes.io/ingress.allow-http":"false","kubernetes.io/ingress.class":"gce"},"labels":{"app":"fleet-allocator"},"name":"fleet-allocator-ingress","namespace":"default"},"spec":{"backend":{"serviceName":"fleet-allocator-backend","servicePort":8000},"tls":[{"secretName":"allocatorsecret"}]}}
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.class: gce
+  creationTimestamp: 2018-09-23T19:13:36Z
+  generation: 1
+  labels:
+    app: fleet-allocator
+  name: fleet-allocator-ingress
+  namespace: default
+  resourceVersion: "4086"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/fleet-allocator-ingress
+  uid: c5a149b3-bf64-11e8-8a6e-42010a8e013f
+spec:
+  backend:
+    serviceName: fleet-allocator-backend
+    servicePort: 8000
+  tls:
+  - secretName: allocatorsecret
+status:
+  loadBalancer:
+    ingress:
+    - ip: 35.186.225.103
+```
+
+### 9. Check Game Servers
+Let's make sure that we have one or more Game Servers in a ready state by running this command:
+```
+kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+```
+
+For a fleet of 2 replicas, you should see 2 Game Servers with a Status of Ready:
+```
+NAME                     STATUS    IP               PORT
+simple-udp-s2snf-765bc   Ready     35.231.204.26    [map[name:default port:7260]]
+simple-udp-s2snf-vf6l8   Ready     35.196.162.169   [map[name:default port:7591]]
+```
+
+If there is no fleet, please review [Create Game Server Fleet](../docs/create_fleet.md).
+
+
+### 10. Allocate a Game Server
+Now that the ingress has been created, let's allocate a Game Server by passing in our user and key to the /address endpoint.  This will call the allocate() function in main.go, which will return a JSON string of the GameServerStatus of an allocated GameServer, or an error.  The service uses Basic Auth to provide some security as to who can allocate GameServer resources, and the generated key is in main.go, in the function basicAuth().  Read the comments and code in main.go for a more detailed explanation of each function and method.
+
+Allocate a Game Server by running this command:
+```
+curl -k -u v1GameClientKey:EAEC945C371B2EC361DE399C2F11E https://[the.ip.address]/address
+```
+
+The output should show the JSON of the GameServerStatus, similar to this:
+```
+{"status":{"state":"Allocated","ports":[{"name":"default","port":7260}],"address":"35.231.204.26","nodeName":"gke-agones-simple-udp-cluste-default-pool-e03a9bde-000f"}}
+```
+
+You may need to wait a few moments longer if the output has ssl errors like this:
+```
+curl: (35) error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure
+```
+
+Check the Game Servers again, and notice the Allocated Status.  You should see something like this:
+```
+NAME                     STATUS      IP               PORT
+simple-udp-s2snf-765bc   Allocated   35.231.204.26    [map[name:default port:7260]]
+simple-udp-s2snf-vf6l8   Ready       35.196.162.169   [map[name:default port:7591]]
+```
+
+Congratulations, your call to the API has allocated a Game Server from your simple-udp Fleet!
+
+
+### 11. Cleanup
+You can delete the allocator service and associated resources with the following commands.
+
+Delete the Ingress
+```
+kubectl delete ingress fleet-allocator-ingress
+```
+
+Delete the Service
+```
+kubectl delete -f allocator-service.yaml
+```
+
+Delete the Service Account
+```
+kubectl delete -f service-account.yaml
+```
+
+Delete the health check and firewall rules
+```
+gcloud compute health-checks delete fleet-allocator-healthcheck
+gcloud compute firewall-rules delete fleet-allocator-healthcheck
+gcloud compute health-checks delete nodeport-rule
+gcloud compute firewall-rules delete nodeport-rule
+```
+
+
+### Next Steps
+- Customize the service by changing the constants and service key in main.go
+- Make the [IP Address Permanent](https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip)
+- Create an A record that points to your permanent IP address
+- [Create a Fleet Autoscaler](./create_fleetautoscaler.md)

--- a/docs/create_fleet.md
+++ b/docs/create_fleet.md
@@ -1,6 +1,6 @@
 # Quickstart Create a Game Server Fleet
 
-This guide covers how you can quickly get started using Agones to create a Fleet 
+This guide covers how you can quickly get started using Agones to create a Fleet
 of warm GameServers ready for you to allocate out of and play on!
 
 ## Prerequisites
@@ -44,7 +44,7 @@ fleet "simple-udp" created
 
 This has created a Fleet record inside Kubernetes, which in turn creates two warm [GameServers](gameserver_spec.md) to
 be available to being allocated for usage for a game session.
- 
+
 ```
 kubectl get fleet
 ```
@@ -55,7 +55,7 @@ NAME         AGE
 simple-udp   5m
 ```
 
-You can also see the GameServers that have been created by the Fleet by running `kubectl get gameservers`, 
+You can also see the GameServers that have been created by the Fleet by running `kubectl get gameservers`,
 the GameServer will be prefixed by `simple-udp`.
 
 ```
@@ -289,7 +289,7 @@ grow and shrink.
 ### 6. Connect to the GameServer
 
 Since we've only got one allocation, we'll just grab the details of the IP and port of the
-only allocated `GameServer`: 
+only allocated `GameServer`:
 
 ```
 kubectl get $(kubectl get fleetallocation -o name) -o jsonpath='{.status.GameServer.staatus.GameServer.status.ports[0].port}'
@@ -312,7 +312,7 @@ If you run `kubectl describe gs | grep State` again - either the GameServer will
 , or it will be in `Shutdown` state, on the way to being deleted.
 
 Since we are running a `Fleet`, Agones will always do it's best to ensure there are always the configured number
-of `GameServers` in the pool in either a `Ready` or `Allocated` state. 
+of `GameServers` in the pool in either a `Ready` or `Allocated` state.
 
 ### 7. Deploy a new version of the GameServer on the Fleet
 
@@ -327,7 +327,7 @@ Let's also allocate ourselves a `GameServer`
 kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/master/examples/simple-udp/fleetallocation.yaml -o yaml
 ```
 
-We should now have four `Ready` `GameServers` and one `Allocated`. 
+We should now have four `Ready` `GameServers` and one `Allocated`.
 
 We can check this by running `kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports`.
 
@@ -349,7 +349,7 @@ with a Container Port of `6000`.
 
 > NOTE: This will make it such that you can no longer connect to the simple-udp game server.  
 
-Run `watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,CONTAINERPORT:.spec.ports[0].containerPort` 
+Run `watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,CONTAINERPORT:.spec.ports[0].containerPort`
 until you can see that there are
 one of `7654`, which is the `Allocated` `GameServer`, and four instances to `6000` which
 is the new configuration.
@@ -358,7 +358,9 @@ You have now deployed a new version of your game!
 
 ## Next Steps
 
-You can now create a fleet autoscaler to automatically resize your fleet based on the actual usage. 
+You can now create a fleet autoscaler to automatically resize your fleet based on the actual usage.
 See [Create a Fleet Autoscaler](./create_fleetautoscaler.md).
 
 Or if you want to try to use your own GameServer container make sure you have properly integrated the [Agones SDK](../sdks/).
+
+If you would like to learn how to programmatically allocate a Game Server from the fleet using the Agones API, see the [Allocator Service](./create_allocator_service.md) tutorial.

--- a/docs/edit_first_game_server.md
+++ b/docs/edit_first_game_server.md
@@ -1,11 +1,12 @@
-# Getting Started
+# Quickstart Edit a Game Server
 The following guide is for developers without Docker or Kubernetes experience, that want to use the simple-udp example as a starting point for a custom game server. This guide addresses Google Kubernetes Engine and Minikube.  We would welcome a Pull Request to expand this to include other platforms as well.
 
 ## Prerequisites
 
-1. Downland and install Golang from https://golang.org/dl/.
-2. Install Docker from https://www.docker.com/get-docker.
-3. Install Agones on GKE or Minikube.  
+1. A [Go](https://golang.org/dl/) environment
+2. [Docker](https://www.docker.com/get-started/)
+3. Agones installed on GKE or Minikube
+4. kubectl properly configured
 
 To install on GKE, follow the install instructions (if you haven't already) at
 [Setting up a Google Kubernetes Engine (GKE) cluster](../install/README.md#setting-up-a-google-kubernetes-engine-gke-cluster). Also complete the "Enabling creation of RBAC resources" and "Installing Agones" sets of instructions on the same page.
@@ -14,7 +15,7 @@ To install locally on Minikube, read [Setting up a Minikube cluster](../install/
 
 ## Modify the code and push another new image
 
-### Modify the simple-udp example source source code
+### Modify the simple-udp example source code
 Modify the main.go file. For example:
 
 Change main.go line 92:

--- a/examples/allocator-service/README.md
+++ b/examples/allocator-service/README.md
@@ -1,0 +1,10 @@
+# Simple Allocator Service
+
+This service provides an example of using the [Agones API](https://godoc.org/agones.dev/agones/pkg/client/clientset/versioned/typed/stable/v1alpha1) to allocate a GameServer from a Fleet, and is used in the [Create an Allocator Service (Go)](../../docs/create_allocator_service.md) tutorial.
+
+## Allocator Service
+The service exposes an endpoint which allows client calls to FleetAllocationInterface.Create() over a secure connection.  It also provides examples of how to create a service account with the least necessary privileges, how to create an Ingress, and how services can use secrets specific to their respective accounts.
+
+When the endpoint is called and a GameServer is allocated, it returns the JSON encoded GameServerStatus of the freshly allocated GameServer.
+
+To learn how to deploy this allocator service to GKE, please see the tutorial [Create an Allocator Service (Go)](../../docs/create_allocator_service.md).

--- a/examples/allocator-service/allocator-ingress.yaml
+++ b/examples/allocator-service/allocator-ingress.yaml
@@ -1,0 +1,18 @@
+# Create a single service Ingress resource
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: fleet-allocator-ingress
+  labels:
+    app: fleet-allocator
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.allow-http: "false"
+    #kubernetes.io/ingress.global-static-ip-name: "allocator-static-ip"
+spec:
+  tls:
+  - secretName: allocatorsecret
+  backend:
+    serviceName: fleet-allocator-backend
+    servicePort: 8000

--- a/examples/allocator-service/allocator-service.yaml
+++ b/examples/allocator-service/allocator-service.yaml
@@ -1,0 +1,61 @@
+# Define a Service for the fleet-allocator
+apiVersion: v1
+kind: Service
+metadata:
+  name: fleet-allocator-backend
+  annotations:
+    service.alpha.kubernetes.io/app-protocols: '{"https":"HTTPS"}'
+  labels:
+    app: fleet-allocator
+spec:
+  type: NodePort
+  selector:
+    app: fleet-allocator
+  ports:
+  - port: 8000
+    protocol: TCP
+    name: https
+    targetPort: fleet-allocator  # retrieve port from deployment config
+
+---
+# Deploy a pod to run the fleet-allocator code
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fleet-allocator
+  template:
+    metadata:
+      labels:
+        app: fleet-allocator
+    spec:
+      serviceAccount: fleet-allocator
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: allocatorw3secret
+      containers:
+      - name: fleet-allocator
+        image: [REPO]/[USER]/allocator-service:[TAG]
+        #image: index.docker.io/exampleuser/allocator-service:simple-udp-5
+        imagePullPolicy: Always
+        ports:
+        - name: fleet-allocator
+          containerPort: 8000
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        volumeMounts:
+        - mountPath: /home/service/certs
+          name: secret-volume

--- a/examples/allocator-service/dockerfile
+++ b/examples/allocator-service/dockerfile
@@ -1,0 +1,24 @@
+# Gather dependencies and build the executable
+FROM golang:1.10.3 as builder
+
+WORKDIR /go/src/agones.dev
+RUN git clone https://github.com/GoogleCloudPlatform/agones.git
+
+WORKDIR /go/src/agones.dev/agones/examples/allocator-service
+ADD ./main.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o service .
+
+
+# Create the final image that will run the allocator service
+FROM alpine:3.8
+RUN apk add --update ca-certificates
+RUN adduser -D service
+
+COPY --from=builder /go/src/agones.dev/agones/examples/allocator-service \
+                    /home/service
+
+RUN chown -R service /home/service && \
+    chmod o+x /home/service/service
+
+USER service
+ENTRYPOINT /home/service/service

--- a/examples/allocator-service/main.go
+++ b/examples/allocator-service/main.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
+	"agones.dev/agones/pkg/client/clientset/versioned"
+	"agones.dev/agones/pkg/util/runtime" // for the logger
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// Constants which define the fleet and namespace we are using
+const namespace = "default"
+const fleetname = "simple-udp"
+const generatename = "simple-udp-"
+
+// Variables for the logger and Agones Clientset
+var (
+	logger       = runtime.NewLoggerWithSource("main")
+	agonesClient = getAgonesClient()
+)
+
+// A handler for the web server
+type handler func(w http.ResponseWriter, r *http.Request)
+
+// The structure of the json response
+type result struct {
+	Status v1alpha1.GameServerStatus `json:"status"`
+}
+
+// Main will set up an http server and three endpoints
+func main() {
+	// Serve 200 status on / for k8s health checks
+	http.HandleFunc("/", handleRoot)
+
+	// Serve 200 status on /healthz for k8s health checks
+	http.HandleFunc("/healthz", handleHealthz)
+
+	// Return the GameServerStatus of the allocated replica to the authorized client
+	http.HandleFunc("/address", getOnly(basicAuth(handleAddress)))
+
+	// Run the HTTP server using the bound certificate and key for TLS
+	if err := http.ListenAndServeTLS(":8000", "/home/service/certs/tls.crt", "/home/service/certs/tls.key", nil); err != nil {
+		logger.WithError(err).Fatal("HTTPS server failed to run")
+	} else {
+		logger.Info("HTTPS server is running on port 8000")
+	}
+}
+
+// Set up our client which we will use to call the API
+func getAgonesClient() *versioned.Clientset {
+	// Create the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.WithError(err).Fatal("Could not create in cluster config")
+	}
+
+	// Access to the Agones resources through the Agones Clientset
+	agonesClient, err := versioned.NewForConfig(config)
+	if err != nil {
+		logger.WithError(err).Fatal("Could not create the agones api clientset")
+	} else {
+		logger.Info("Created the agones api clientset")
+	}
+	return agonesClient
+}
+
+// Limit verbs the web server handles
+func getOnly(h handler) handler {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			h(w, r)
+			return
+		}
+		http.Error(w, "Get Only", http.StatusMethodNotAllowed)
+	}
+}
+
+// Let the web server do basic authentication
+func basicAuth(pass handler) handler {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key, value, _ := r.BasicAuth()
+		if key != "v1GameClientKey" || value != "EAEC945C371B2EC361DE399C2F11E" {
+			http.Error(w, "authorization failed", http.StatusUnauthorized)
+			return
+		}
+		pass(w, r)
+	}
+}
+
+// Let / return Healthy and status code 200
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := io.WriteString(w, "Healthy")
+	if err != nil {
+		logger.WithError(err).Fatal("Error writing string Healthy from /")
+	}
+}
+
+// Let /healthz return Healthy and status code 200
+func handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := io.WriteString(w, "Healthy")
+	if err != nil {
+		logger.WithError(err).Fatal("Error writing string Healthy from /healthz")
+	}
+}
+
+// Let /address return the GameServerStatus
+func handleAddress(w http.ResponseWriter, r *http.Request) {
+	status, err := allocate()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	result, _ := json.Marshal(&result{status})
+	_, err = io.WriteString(w, string(result))
+	if err != nil {
+		logger.WithError(err).Fatal("Error writing json from /address")
+	}
+}
+
+// Return the number of ready game servers available to this fleet for allocation
+func checkReadyReplicas() int32 {
+	// Get a FleetInterface for this namespace
+	fleetInterface := agonesClient.StableV1alpha1().Fleets(namespace)
+	// Get our fleet
+	fleet, err := fleetInterface.Get(fleetname, v1.GetOptions{})
+	if err != nil {
+		logger.WithError(err).Info("Get fleet failed")
+	}
+
+	return fleet.Status.ReadyReplicas
+}
+
+// Move a replica from ready to allocated and return the GameServerStatus
+func allocate() (v1alpha1.GameServerStatus, error) {
+	var result v1alpha1.GameServerStatus
+
+	// Log the values used in the fleet allocation
+	logger.WithField("namespace", namespace).Info("namespace for fa")
+	logger.WithField("generatename", generatename).Info("generatename for fa")
+	logger.WithField("fleetname", fleetname).Info("fleetname for fa")
+
+	// Find out how many ready replicas the fleet has - we need at least one
+	readyReplicas := checkReadyReplicas()
+	logger.WithField("readyReplicas", readyReplicas).Info("numer of ready replicas")
+
+	// Log and return an error if there are no ready replicas
+	if readyReplicas < 1 {
+		logger.WithField("fleetname", fleetname).Info("Insufficient ready replicas, cannot create fleet allocation")
+		return result, errors.New("Insufficient ready replicas, cannot create fleet allocation")
+	}
+
+	// Get a FleetAllocationInterface for this namespace
+	fleetAllocationInterface := agonesClient.StableV1alpha1().FleetAllocations(namespace)
+
+	// Define the fleet allocation using the constants set earlier
+	fa := &v1alpha1.FleetAllocation{
+		ObjectMeta: v1.ObjectMeta{
+			GenerateName: generatename, Namespace: namespace,
+		},
+		Spec: v1alpha1.FleetAllocationSpec{FleetName: fleetname},
+	}
+
+	// Create a new fleet allocation
+	newFleetAllocation, err := fleetAllocationInterface.Create(fa)
+	if err != nil {
+		// Log and return the error if the call to Create fails
+		logger.WithError(err).Info("Failed to create fleet allocation")
+		return result, errors.New("Failed to ceate fleet allocation")
+	}
+
+	// Log the GameServer.Staus of the new allocation, then return those values
+	logger.Info("New GameServer allocated: ", newFleetAllocation.Status.GameServer.Status)
+	result = newFleetAllocation.Status.GameServer.Status
+	return result, nil
+}

--- a/examples/allocator-service/service-account.yaml
+++ b/examples/allocator-service/service-account.yaml
@@ -1,0 +1,45 @@
+# Create a Role in the default namespace that grants access to the agones api
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: ["stable.agones.dev"]
+  resources: ["fleetallocations"]
+  verbs: ["create"]
+- apiGroups: ["stable.agones.dev"]
+  resources: [fleets, fleet"]
+  verbs: ["get"]
+
+---
+# Create a ServiceAccount that will be bound to the above role
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+
+---
+# Bind the fleet-allocator ServiceAccount to the fleet-allocator Role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: fleet-allocator
+  namespace: default
+  labels:
+    app: fleet-allocator
+subjects:
+- kind: ServiceAccount
+  name: fleet-allocator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fleet-allocator


### PR DESCRIPTION
This is a service that allocates a game server from a fleet using the Agones API. It then returns the IP address and port of the allocated game server. I cleaned up the notes I took while making it, and maybe they might provide some useful documentation for people who are looking to programmatically allocate game servers.

Some things I'm not sure about:

    Is the document create_allocator_service.md more of a Quickstart or a Guide?
    The service in the example uses a container in my public Docker registry...I don't mind, but it might be better off in a repo controlled by this project.
    Step 12 and onward of create_allocator_service might be out of scope.
    The error handling in main.go seem inadequate to me...but maybe it is ok?

Please let me know if this would be useful, and if so, what changes should be made.