### PR TITLE
Fixes race condition bug with Pod not being scheduled before Ready()

### DIFF
--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -31,8 +31,11 @@ const (
 	// Creating is before the Pod for the GameServer is being created
 	Creating State = "Creating"
 	// Starting is for when the Pods for the GameServer are being
-	// created but have yet to register themselves as Ready
+	// created but are not yet Scheduled
 	Starting State = "Starting"
+	// Scheduled is for when we have determined that the Pod has been
+	// scheduled in the cluster -- basically, we have a NodeName
+	Scheduled State = "Scheduled"
 	// RequestReady is when the GameServer has declared that it is ready
 	RequestReady State = "RequestReady"
 	// Ready is when a GameServer is ready to take connections


### PR DESCRIPTION
This fix does several things:

1. Breaks out ip and port setting of the `Status` into its own state, to make
    implementation and testing easier.
1. Listen for Pod updates, and if a Pod is a `GameServer` pod that has had
    its `NodeName` set, then queue the backing `GameServer`
1. Finally - if Ready() gets called before any of this, populate the `Status` ip
   and port values at this time as well.

Fixes #354