### PR TITLE
Fix for race condition: Allocation of Deleting GameServers Possible

### DIFF
--- a/pkg/fleetallocation/controller.go
+++ b/pkg/fleetallocation/controller.go
@@ -63,13 +63,14 @@ type Controller struct {
 	fleetAllocationGetter getterv1alpha1.FleetAllocationsGetter
 	fleetAllocationLister listerv1alpha1.FleetAllocationLister
 	stop                  <-chan struct{}
-	allocationMutex       sync.Mutex
+	allocationMutex       *sync.Mutex
 	recorder              record.EventRecorder
 }
 
 // NewController returns a controller for a FleetAllocation
 func NewController(
 	wh *webhooks.WebHook,
+	allocationMutex *sync.Mutex,
 	kubeClient kubernetes.Interface,
 	extClient extclientset.Interface,
 	agonesClient versioned.Interface,
@@ -85,7 +86,7 @@ func NewController(
 		fleetLister:           agonesInformer.Fleets().Lister(),
 		fleetAllocationGetter: agonesClient.StableV1alpha1(),
 		fleetAllocationLister: agonesInformer.FleetAllocations().Lister(),
-		allocationMutex:       sync.Mutex{},
+		allocationMutex:       allocationMutex,
 	}
 	c.logger = runtime.NewLoggerWithType(c)
 

--- a/pkg/fleetallocation/controller_test.go
+++ b/pkg/fleetallocation/controller_test.go
@@ -286,7 +286,7 @@ func defaultFixtures(gsLen int) (*v1alpha1.Fleet, *v1alpha1.GameServerSet, []v1a
 func newFakeController() (*Controller, agtesting.Mocks) {
 	m := agtesting.NewMocks()
 	wh := webhooks.NewWebHook("", "")
-	c := NewController(wh, m.KubeClient, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
+	c := NewController(wh, &sync.Mutex{}, m.KubeClient, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m
 }

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 
 	"agones.dev/agones/pkg/apis/stable"
@@ -1093,7 +1094,8 @@ func testWithNonZeroDeletionTimestamp(t *testing.T, f func(*Controller, *v1alpha
 func newFakeController() (*Controller, agtesting.Mocks) {
 	m := agtesting.NewMocks()
 	wh := webhooks.NewWebHook("", "")
-	c := NewController(wh, healthcheck.NewHandler(), 10, 20, "sidecar:dev", false,
+	c := NewController(wh, healthcheck.NewHandler(), &sync.Mutex{},
+		10, 20, "sidecar:dev", false,
 		m.KubeClient, m.KubeInformationFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -17,6 +17,7 @@ package gameserversets
 import (
 	"encoding/json"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -300,7 +301,7 @@ func TestSyncLessGameServers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, list2, 11)
 
-	err = c.syncLessGameSevers(gsSet, list2, int32(-expected))
+	err = c.syncLessGameSevers(gsSet, int32(-expected))
 	assert.Nil(t, err)
 
 	// subtract one, because one is already deleted
@@ -481,7 +482,7 @@ func createGameServers(gsSet *v1alpha1.GameServerSet, size int) []v1alpha1.GameS
 func newFakeController() (*Controller, agtesting.Mocks) {
 	m := agtesting.NewMocks()
 	wh := webhooks.NewWebHook("", "")
-	c := NewController(wh, healthcheck.NewHandler(), m.KubeClient, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
+	c := NewController(wh, healthcheck.NewHandler(), &sync.Mutex{}, m.KubeClient, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m
 }

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -130,7 +130,7 @@ func defaultGameServer() *v1alpha1.GameServer {
 					Containers: []corev1.Container{{
 						Name:            "udp-server",
 						Image:           framework.GameServerImage,
-						ImagePullPolicy: corev1.PullAlways}},
+						ImagePullPolicy: corev1.PullIfNotPresent}},
 				},
 			},
 		},


### PR DESCRIPTION
If an allocation occurred during a Fleet scale down, or during a update of a Fleet, it was entirely possible for those parallel delete operations to be applied to a GameServer that was being allocated at the same time.

This is mainly because the client-go informer cache is lazily consistent, but also because there was nothing preventing a `Delete()` of a `GameServer` from happening while allocating a specific `GameServer`.

To solve this, there are two strategies implemented here:

1. Share the `allocationLock` `sync.Mutex` between controllers such that allocations cannot occur while `GameServer` Deletes for Fleet resizing/update are happening and vice versa.
2. use `cache.WaitForCacheSync` to bring the cluster informer up to date, to remove the chance for non-updated information about `GameServers` to be
acted upon.

The shared lock is a quite broad approach - down the line, we could refine this to being per `Fleet`, or per `GameServerSet`, if we find this to be a bottleneck, but the priority here was to get something working that resolvesthe issue, and we can optimise as needed from here.

There are also e2e tests specifically designed for catching these race conditions as well.