### PR TITLE
Remove c++ sdk destructor causing linker errors

### DIFF
--- a/examples/cpp-simple/server.cc
+++ b/examples/cpp-simple/server.cc
@@ -110,5 +110,7 @@ int main() {
         }
     }
 
+    delete sdk;
+
     return 0;
 }

--- a/sdks/cpp/sdk.h
+++ b/sdks/cpp/sdk.h
@@ -55,7 +55,6 @@ namespace agones {
             // This is a blocking function, and as such you will likely want to run it inside a thread.
             grpc::Status WatchGameServer(const std::function<void(stable::agones::dev::sdk::GameServer)> callback);
 
-            ~SDK();
 
         private:
             std::shared_ptr<grpc::Channel> channel;


### PR DESCRIPTION
I removed the destructor declaration, because it had no body in the cpp file it caused linker errors. I removed the declaration from the header file so that the compiler will generate a default dtor. I also updated the cpp example to `delete` the sdk pointer in the end. That way it will act as a "unit-test" if the same thing happens in the future.

fixes #366 