### PR TITLE
Prioritise Allocation from Nodes with Allocated/Ready GameServers

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Documentation and usage guides on how to develop and host dedicated game servers
 - [CPP Simple](./examples/cpp-simple) (C++) - C++ example that starts up, stays healthy and then shuts down after 60 seconds.
 - [Xonotic](./examples/xonotic) - Wraps the SDK around the open source FPS game [Xonotic](http://www.xonotic.org) and hosts it on Agones.
 
+### Advanced
+- [Scheduling and Autoscaling](./docs/scheduling_autoscaling.md)
+
 ## Get involved
 
 - [Slack](https://join.slack.com/t/agones/shared_invite/enQtMzE5NTE0NzkyOTk1LWQ2ZmY1Mjc4ZDQ4NDJhOGYxYTY2NTY0NjUwNjliYzVhMWFjYjMxM2RlMjg3NGU0M2E0YTYzNDIxNDMyZGNjMjU)

--- a/docs/create_fleetautoscaler.md
+++ b/docs/create_fleetautoscaler.md
@@ -253,4 +253,6 @@ simple-udp-mzhrl-zg9rq   Ready     10.30.64.99    [map[name:default port:7745]]
 
 ## Next Steps
 
+Read the advanced [Scheduling and Autoscaling](scheduling_autoscaling.md) guide, for more details on autoscaling. 
+
 If you want to use your own GameServer container make sure you have properly integrated the [Agones SDK](../sdks/). 

--- a/docs/fleet_spec.md
+++ b/docs/fleet_spec.md
@@ -15,6 +15,7 @@ metadata:
   name: fleet-example
 spec:
   replicas: 2
+  scheduling: Packed
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -53,6 +54,11 @@ This is a very common pattern in the Kubernetes ecosystem.
 The `spec` field is the actual `Fleet` specification and it is composed as follow:
 
 - `replicas` is the number of `GameServers` to keep Ready or Allocated in this Fleet
+- `scheduling`(⚠️⚠️⚠️ **This is currently a development feature and has not been released** ⚠️⚠️⚠️) defines how GameServers are organised across the cluster. Currently only affects Allocation, but will expand
+                 in future releases. Options include:
+                 "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack
+                 resources. "Distributed" is aimed at static Kubernetes clusters, wherein we want to distribute resources across the entire
+                 cluster. See [Scheduling and Autoscaling](scheduling_autoscaling.md) for more details.
 - `strategy` is the `GameServer` replacement strategy for when the `GameServer` template is edited.
   - `type` is replacement strategy for when the GameServer template is changed. Default option is "RollingUpdate", but "Recreate" is also available.
     - `RollingUpdate` will increment by `maxSurge` value on each iteration, while decrementing by `maxUnavailable` on each iteration, until all GameServers have been switched from one version to another.   

--- a/docs/scheduling_autoscaling.md
+++ b/docs/scheduling_autoscaling.md
@@ -1,0 +1,113 @@
+# Scheduling and Autoscaling
+
+⚠️⚠️⚠️ **This is currently a development feature and has not been released** ⚠️⚠️⚠️
+
+> Autoscaling is currently ongoing work within Agones. The work you see here is just the beginning.
+
+
+Table of Contents
+=================
+
+* [Fleet Autoscaling](#fleet-autoscaling)
+* [Autoscalng Concepts](#autoscalng-concepts)
+   * [Allocation Scheduling](#allocation-scheduling)
+* [Fleet Scheduling](#fleet-scheduling)
+   * [Packed](#packed)
+      * [Allocation Scheduling Strategy](#allocation-scheduling-strategy)
+   * [Distributed](#distributed)
+      * [Allocation Scheduling Stategy](#allocation-scheduling-stategy)
+
+Scheduling and autoscaling go hand in hand, as where in the cluster `GameServers` are provisioned
+impacts how to autoscale fleets up and down (or if you would even want to)
+
+## Fleet Autoscaling
+
+Fleet autoscaling is currently the only type of autoscaling that exists in Agones. It is also only available as a simple
+buffer autoscaling strategy. Have a look at the [Create a Fleet Autoscaler](create_fleetautoscaler.md) quickstart,
+and the [Fleet Autoscaler Specification](fleetautoscaler_spec.md) for details.
+
+Node scaling, and more sophisticated fleet autoscaling will be coming in future releases ([design](https://github.com/GoogleCloudPlatform/agones/issues/368))
+
+## Autoscaling Concepts
+
+To facilitate autoscaling, we need to combine several piece of concepts and functionality, described below.
+
+### Allocation Scheduling
+
+Allocation scheduling refers to the order in which `GameServers`, and specifically their backing `Pods` are chosen
+from across the Kubernetes cluster within a given `Fleet` when [allocation](./create_fleet.md#4-allocate-a-game-server-from-the-fleet) occurs.
+
+## Fleet Scheduling
+
+There are two scheduling strategies for Fleets - each designed for different types of Kubernetes Environments.
+
+### Packed
+
+```yaml
+apiVersion: "stable.agones.dev/v1alpha1"
+kind: Fleet
+metadata:
+  name: simple-udp
+spec:
+  replicas: 100
+  scheduling: Packed
+  template:
+    spec:
+      ports:
+      - containerPort: 7654
+      template:
+        spec:
+          containers:
+          - name: simple-udp
+            image: gcr.io/agones-images/udp-server:0.4
+```
+
+This is the *default* Fleet scheduling strategy. It is designed for dynamic Kubernetes environments, wherein you wish 
+to scale up and down as load increases or decreases, such as in a Cloud environment where you are paying
+for the infrastructure you use.
+
+It attempts to _pack_ as much as possible into the smallest set of nodes, to make
+scaling infrastructure down as easy as possible.
+
+Currently, Allocation scheduling is the only aspect this strategy affects, but in future releases it will
+also affect `GameServer` `Pod` scheduling, and `Fleet` scale down scheduling as well.
+
+#### Allocation Scheduling Strategy
+
+Under the "Packed" strategy, allocation will prioritise allocating `GameServers` to nodes that are running on 
+Nodes that already have allocated `GameServers` running on them.
+
+### Distributed
+
+```yaml
+apiVersion: "stable.agones.dev/v1alpha1"
+kind: Fleet
+metadata:
+  name: simple-udp
+spec:
+  replicas: 100
+  scheduling: Distributed
+  template:
+    spec:
+      ports:
+      - containerPort: 7654
+      template:
+        spec:
+          containers:
+          - name: simple-udp
+            image: gcr.io/agones-images/udp-server:0.4
+```
+
+This Fleet scheduling strategy is designed for static Kubernetes environments, such as when you are running Kubernetes
+on bare metal, and the cluster size rarely changes, if at all.
+
+This attempts to distribute the load across the entire cluster as much as possible, to take advantage of the static
+size of the cluster.
+
+Currently, the only thing the scheduling strategy affects is Allocation scheduling, but in future releases it will
+also affect `GameServer` `Pod` scheduling, and `Fleet` scaledown scheduling as well.
+
+#### Allocation Scheduling Strategy
+
+Under the "Distributed" strategy, allocation will prioritise allocating `GameSerers` to nodes that have the least
+number of allocated `GameServers` on them.

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -27,6 +27,13 @@ metadata:
 spec:
   # the number of GameServers to keep Ready or Allocated in this Fleet
   replicas: 2
+  # defines how GameServers are organised across the cluster. Currently only affects Allocation, but will expand
+  # in future releases. Options include:
+  # "Packed" (default) is aimed at dynamic Kubernetes clusters, such as cloud providers, wherein we want to bin pack
+  # resources
+  # "Distributed" is aimed at static Kubernetes clusters, wherein we want to distribute resources across the entire
+  # cluster
+  scheduling: Packed
   # a GameServer template - see:
   # https://github.com/GoogleCloudPlatform/agones/blob/master/docs/gameserver_spec.md for all the options
   strategy:

--- a/pkg/apis/stable/v1alpha1/fleet_test.go
+++ b/pkg/apis/stable/v1alpha1/fleet_test.go
@@ -60,11 +60,13 @@ func TestFleetApplyDefaults(t *testing.T) {
 
 	// gate
 	assert.EqualValues(t, "", f.Spec.Strategy.Type)
+	assert.EqualValues(t, "", f.Spec.Scheduling)
 
 	f.ApplyDefaults()
 	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, f.Spec.Strategy.Type)
 	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxUnavailable.String())
 	assert.Equal(t, "25%", f.Spec.Strategy.RollingUpdate.MaxSurge.String())
+	assert.Equal(t, Packed, f.Spec.Scheduling)
 }
 
 func TestFleetUpperBoundReplicas(t *testing.T) {

--- a/pkg/fleetallocation/find.go
+++ b/pkg/fleetallocation/find.go
@@ -1,0 +1,88 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fleetallocation
+
+import (
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
+)
+
+// nodeCount is just a convenience data structure for
+// keeping relevant GameServer counts about Nodes
+type nodeCount struct {
+	ready     int64
+	allocated int64
+}
+
+// findReadyGameServerForAllocation is a O(n) implementation to find a GameServer with priority
+// defined in the comparator function.
+func findReadyGameServerForAllocation(gsList []*v1alpha1.GameServer, comparator func(bestCount, currentCount *nodeCount) bool) *v1alpha1.GameServer {
+	counts := map[string]*nodeCount{}
+	// track potential gameservers, one for each node
+	allocatableGameServers := map[string]*v1alpha1.GameServer{}
+
+	// count up the number of allocated and ready game servers that exist
+	// also, since we're already looping through, track one Ready GameServer
+	// per node, so we can use that as a short list to allocate from
+	for _, gs := range gsList {
+		if gs.DeletionTimestamp.IsZero() &&
+			(gs.Status.State == v1alpha1.Allocated || gs.Status.State == v1alpha1.Ready) {
+			_, ok := counts[gs.Status.NodeName]
+			if !ok {
+				counts[gs.Status.NodeName] = &nodeCount{}
+			}
+
+			if gs.Status.State == v1alpha1.Allocated {
+				counts[gs.Status.NodeName].allocated++
+			} else if gs.Status.State == v1alpha1.Ready {
+				counts[gs.Status.NodeName].ready++
+				allocatableGameServers[gs.Status.NodeName] = gs
+			}
+		}
+	}
+
+	// track the best node count
+	var bestCount *nodeCount
+	// the current GameServer from the node with the most GameServers (allocated, ready)
+	var bestGS *v1alpha1.GameServer
+
+	for nodeName, count := range counts {
+		// count.ready > 0: no reason to check if we don't have ready GameServers on this node
+		// bestGS == nil: if there is no best GameServer, then this node & GameServer is the always the best
+		if count.ready > 0 && (bestGS == nil || comparator(bestCount, count)) {
+			bestCount = count
+			bestGS = allocatableGameServers[nodeName]
+		}
+	}
+
+	return bestGS
+}
+
+// packedComparator prioritises Nodes with GameServers that are allocated, and then Nodes with the most
+// Ready GameServers -- this will bin pack allocated game servers together.
+func packedComparator(bestCount, currentCount *nodeCount) bool {
+	if currentCount.allocated == bestCount.allocated && currentCount.ready > bestCount.ready {
+		return true
+	} else if currentCount.allocated > bestCount.allocated {
+		return true
+	}
+
+	return false
+}
+
+// distributedComparator is the inverse of the packed comparator,
+// looking to distribute allocated gameservers on as many nodes as possible.
+func distributedComparator(bestCount, currentCount *nodeCount) bool {
+	return !packedComparator(bestCount, currentCount)
+}

--- a/pkg/fleetallocation/find_test.go
+++ b/pkg/fleetallocation/find_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fleetallocation
+
+import (
+	"testing"
+
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindPackedReadyGameServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("test one", func(t *testing.T) {
+		n := metav1.Now()
+
+		gsList := []*v1alpha1.GameServer{
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs6", DeletionTimestamp: &n}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Ready}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs1"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Ready}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs2"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs3"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Allocated}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs4"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Allocated}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs5"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Error}},
+		}
+
+		gs := findReadyGameServerForAllocation(gsList, packedComparator)
+		assert.Equal(t, "node1", gs.Status.NodeName)
+		assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+		// mock that the first game server is allocated
+		gsList[1].Status.State = v1alpha1.Allocated
+		gs = findReadyGameServerForAllocation(gsList, packedComparator)
+		assert.Equal(t, "node2", gs.Status.NodeName)
+		assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+		gsList[2].Status.State = v1alpha1.Allocated
+		gs = findReadyGameServerForAllocation(gsList, packedComparator)
+		assert.Nil(t, gs)
+	})
+
+	t.Run("allocation trap", func(t *testing.T) {
+		gsList := []*v1alpha1.GameServer{
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs1"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Allocated}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs2"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Allocated}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs3"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Allocated}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs4"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Allocated}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs5"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs6"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs7"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "gs8"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+		}
+
+		gs := findReadyGameServerForAllocation(gsList, packedComparator)
+		assert.Equal(t, "node2", gs.Status.NodeName)
+		assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+	})
+}
+
+func TestFindDistributedReadyGameServer(t *testing.T) {
+	t.Parallel()
+
+	n := metav1.Now()
+	gsList := []*v1alpha1.GameServer{
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs6", DeletionTimestamp: &n}, Status: v1alpha1.GameServerStatus{NodeName: "node3", State: v1alpha1.Ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs1"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs2"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs3"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs4"}, Status: v1alpha1.GameServerStatus{NodeName: "node1", State: v1alpha1.Error}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs5"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs6"}, Status: v1alpha1.GameServerStatus{NodeName: "node2", State: v1alpha1.Ready}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "gs7"}, Status: v1alpha1.GameServerStatus{NodeName: "node3", State: v1alpha1.Ready}},
+	}
+
+	gs := findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Equal(t, "node3", gs.Status.NodeName)
+	assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+
+	gsList[7].Status.State = v1alpha1.Allocated
+
+	gs = findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Equal(t, "node2", gs.Status.NodeName)
+	assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+
+	gsList[5].Status.State = v1alpha1.Allocated
+	assert.Equal(t, "node2", gsList[5].Status.NodeName)
+
+	gs = findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Equal(t, "node1", gs.Status.NodeName)
+	assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+
+	gsList[1].Status.State = v1alpha1.Allocated
+
+	gs = findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Equal(t, "node2", gs.Status.NodeName)
+	assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+
+	gsList[6].Status.State = v1alpha1.Allocated
+
+	gs = findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Equal(t, "node1", gs.Status.NodeName)
+	assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+
+	gsList[2].Status.State = v1alpha1.Allocated
+
+	gs = findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Equal(t, "node1", gs.Status.NodeName)
+	assert.Equal(t, v1alpha1.Ready, gs.Status.State)
+
+	gsList[3].Status.State = v1alpha1.Allocated
+
+	gs = findReadyGameServerForAllocation(gsList, distributedComparator)
+	assert.Nil(t, gs)
+}


### PR DESCRIPTION
One of the first parts for Node autoscaling (#368) - make sure we essentially bin pack our allocated game servers.

This change makes allocation first prioritise allocation from `Nodes` that already have the most `Allocated` `GameServers`, and then in the case of a tie, to the `Nodes` that have the most `Ready` `GameServers`.

This sets us up for the next part, such that when we scale down a Fleet, it removes `GameServers` from `Nodes` that have the least `GameServers` on them.