### PR TITLE
Add crd-install helm hook to crds templates

### DIFF
--- a/install/helm/agones/templates/crds/fleet.yaml
+++ b/install/helm/agones/templates/crds/fleet.yaml
@@ -22,6 +22,8 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1

--- a/install/helm/agones/templates/crds/fleetallocation.yaml
+++ b/install/helm/agones/templates/crds/fleetallocation.yaml
@@ -22,6 +22,8 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1

--- a/install/helm/agones/templates/crds/fleetautoscaler.yaml
+++ b/install/helm/agones/templates/crds/fleetautoscaler.yaml
@@ -22,6 +22,8 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1

--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -22,6 +22,8 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1

--- a/install/helm/agones/templates/crds/gameserverset.yaml
+++ b/install/helm/agones/templates/crds/gameserverset.yaml
@@ -22,6 +22,8 @@ metadata:
     chart: {{ template "agones.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -163,6 +163,8 @@ metadata:
     chart: agones-0.6.0-rc
     release: agones-manual
     heritage: Tiller
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1
@@ -301,6 +303,7 @@ spec:
                           type: integer
                           minimum: 1
                           maximum: 2147483648
+
 ---
 # Source: agones/templates/crds/fleetallocation.yaml
 # Copyright 2018 Google Inc. All Rights Reserved.
@@ -327,6 +330,8 @@ metadata:
     chart: agones-0.6.0-rc
     release: agones-manual
     heritage: Tiller
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1
@@ -376,6 +381,8 @@ metadata:
     chart: agones-0.6.0-rc
     release: agones-manual
     heritage: Tiller
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1
@@ -444,6 +451,8 @@ metadata:
     chart: agones-0.6.0-rc
     release: agones-manual
     heritage: Tiller
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1
@@ -560,6 +569,7 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 2147483648
+
 ---
 # Source: agones/templates/crds/gameserverset.yaml
 # Copyright 2018 Google Inc. All Rights Reserved.
@@ -586,6 +596,8 @@ metadata:
     chart: agones-0.6.0-rc
     release: agones-manual
     heritage: Tiller
+  annotations:
+    "helm.sh/hook": "crd-install"
 spec:
   group: stable.agones.dev
   version: v1alpha1
@@ -718,6 +730,7 @@ spec:
                           type: integer
                           minimum: 1
                           maximum: 2147483648
+
 ---
 # Source: agones/templates/service.yaml
 # Copyright 2018 Google Inc. All Rights Reserved.


### PR DESCRIPTION
From Helm documentation:
> crd-install: Adds CRD resources before any other checks are run. This is used only on CRD definitions that are used by other manifests in the chart.

This PR aims to update agones helm charts crds adding the `crd-install` hook, ensuring then the installation of those to be done before other workloads.

This change also fixes third party charts with agones as dependency that deploy workloads related to those custom resources. 
