### PR TITLE
Specify CPU Request for the SDK Server Sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Documentation and usage guides on how to develop and host dedicated game servers
 
 ### Advanced
 - [Scheduling and Autoscaling](./docs/scheduling_autoscaling.md)
+- [Limiting CPU/Memory](./docs/limiting_resources.md)
 
 ## Get involved
 

--- a/docs/limiting_resources.md
+++ b/docs/limiting_resources.md
@@ -1,0 +1,57 @@
+# Limiting CPU & Memory
+
+Kubernetes natively has inbuilt capabilities for requesting and limiting both CPU and Memory usage of running containers.
+
+As a short description:
+
+- CPU `Requests` are limits that are applied when there is CPU congestion, and as such can burst above their set limits.
+- CPU `Limits` are hard limits on how much CPU time the particular container gets access to.
+
+This is useful for game servers, not just as a mechanism to distribute compute resources evenly, but also as a way
+to advice the Kubernetes scheduler how many game server processes it is able to fit into a given node in the cluster.
+
+It's worth reading the [Managing Compute Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
+Kubernetes documentation for more details on "requests" and "limits" to both CPU and Memory, and how to configure them.
+
+## GameServers
+
+Since the `GameServer` specification provides a full [`PodSpecTemplate`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#podtemplatespec-v1-core),
+we can take advantage of both resource limits and requests in our `GameServer` configurations. 
+
+For example, to set a CPU limit on our `GameServer` configuration of 250m/0.25 of a cpu, 
+we could do so as followed:
+
+```yaml
+apiVersion: "stable.agones.dev/v1alpha1"
+kind: GameServer
+metadata:
+  name: "simple-udp"
+spec:
+  ports:
+  - name: default
+    portPolicy: "dynamic"
+    containerPort: 7654
+  template:
+    spec:
+      containers:
+      - name: simple-udp
+        image: gcr.io/agones-images/udp-server:0.4
+        resources:
+          limit:
+            cpu: "250m" #this is our limit here
+```
+
+If you do not set a limit or request, the default is set my Kubernetes at a 100m CPU request. 
+
+## SDK GameServer sidecar
+
+⚠️⚠️⚠️ **This is currently a development feature and has not been released** ⚠️⚠️⚠️
+
+You may also want to tweak the CPU request or limits on the SDK `GameServer` sidecar process that spins up alongside
+each game server container.
+
+You can do this through the [Helm configuration](../install/helm/README.md#configuration) when installing Agones.
+
+By default, this is set to having a CPU request value of 30m, with no hard CPU limit. This ensures that the sidecar always has enough CPU
+to function, but it is configurable in case a lower, or higher value is required on your clusters, or if you desire 
+hard limit.

--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -92,6 +92,8 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.image.controller.pullPolicy`                | Image pull policy for the controller                                                            | `IfNotPresent`         |
 | `agones.image.controller.pullSecret`                | Image pull secret for the controller                                                            | ``                     |
 | `agones.image.sdk.name`                             | Image name for the sdk                                                                          | `agones-sdk`           |
+| `agones.image.sdk.cpuRequest`                       | (⚠️ Development feature ⚠️) the [cpu request][constraints] for sdk server container              | `30m`                  |
+| `agones.image.sdk.cpuLimit`                         | (⚠️ Development feature ⚠️) the [cpu limit][constraints] for the sdk server container            | `0` (none)             |
 | `agones.image.sdk.alwaysPull`                       | Tells if the sdk image should always be pulled                                                  | `false`                |
 | `agones.controller.healthCheck.http.port`           | Port to use for liveness probe service                                                          | `8080`                 |
 | `agones.controller.healthCheck.initialDelaySeconds` | Initial delay before performing the first probe (in seconds)                                    | `3`                    |
@@ -103,6 +105,8 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `gameservers.namespaces`                            | a list of namespaces you are planning to use to deploy game servers                             | `["default"]`          |
 | `gameservers.minPort`                               | Minimum port to use for dynamic port allocation                                                 | `7000`                 |
 | `gameservers.maxPort`                               | Maximum port to use for dynamic port allocation                                                 | `8000`                 |
+
+[constraints]: https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -51,16 +51,20 @@ spec:
         image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ .Values.agones.image.tag }}"
         imagePullPolicy: {{ .Values.agones.image.controller.pullPolicy }}
         env:
-        - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
-          value: {{ .Values.agones.image.sdk.alwaysPull | quote }}
         # minimum port that can be exposed to GameServer traffic
         - name: MIN_PORT
-          value: {{ .Values.gameservers.minPort | quote }} 
+          value: {{ .Values.gameservers.minPort | quote }}
         # maximum port that can be exposed to GameServer traffic
         - name: MAX_PORT
           value: {{ .Values.gameservers.maxPort | quote }}
-        - name: SIDECAR # overwrite the GameServer sidecar image that is used
+        - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
           value: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.sdk.name}}:{{ .Values.agones.image.tag }}"
+        - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
+          value: {{ .Values.agones.image.sdk.alwaysPull | quote }}
+        - name: SIDECAR_CPU_REQUEST
+          value: {{ .Values.agones.image.sdk.cpuRequest | quote }}
+        - name: SIDECAR_CPU_LIMIT
+          value: {{ .Values.agones.image.sdk.cpuLimit | quote }}
         livenessProbe:
           httpGet:
             path: /live

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -37,6 +37,8 @@ agones:
       pullPolicy: IfNotPresent
     sdk:
       name: agones-sdk
+      cpuRequest: 30m
+      cpuLimit: 0
       alwaysPull: false
 
 gameservers:

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -859,16 +859,20 @@ spec:
         image: "gcr.io/agones-images/agones-controller:0.6.0-rc"
         imagePullPolicy: IfNotPresent
         env:
-        - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
-          value: "false"
         # minimum port that can be exposed to GameServer traffic
         - name: MIN_PORT
-          value: "7000" 
+          value: "7000"
         # maximum port that can be exposed to GameServer traffic
         - name: MAX_PORT
           value: "8000"
-        - name: SIDECAR # overwrite the GameServer sidecar image that is used
+        - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
           value: "gcr.io/agones-images/agones-sdk:0.6.0-rc"
+        - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
+          value: "false"
+        - name: SIDECAR_CPU_REQUEST
+          value: "30m"
+        - name: SIDECAR_CPU_LIMIT
+          value: "0"
         livenessProbe:
           httpGet:
             path: /live

--- a/pkg/testing/controller.go
+++ b/pkg/testing/controller.go
@@ -16,9 +16,8 @@ package testing
 
 import (
 	"context"
-	"time"
-
 	gotesting "testing"
+	"time"
 
 	agonesfake "agones.dev/agones/pkg/client/clientset/versioned/fake"
 	"agones.dev/agones/pkg/client/informers/externalversions"

--- a/pkg/util/webhooks/webhooks_test.go
+++ b/pkg/util/webhooks/webhooks_test.go
@@ -15,12 +15,11 @@
 package webhooks
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"bytes"
-	"encoding/json"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/admission/v1beta1"

--- a/pkg/util/workerqueue/workerqueue_test.go
+++ b/pkg/util/workerqueue/workerqueue_test.go
@@ -15,12 +15,11 @@
 package workerqueue
 
 import (
-	"testing"
-	"time"
-
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"testing"
+	"time"
 
 	"github.com/heptiolabs/healthcheck"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
This provides the mechanism (and defaults) for being able to set both the CPU request, and CPU limits for the SDK Server `GameServer` sidecar.

I've only set the Request level, as it seems that the major issue is not CPU usage, but actually how the scheduler allots space for the sidecar (by default 100/0.1 vCPU is alloted to each container.

I've set the default request level to be 5m/0.005 vCPU -- while this is above what load tests have shown, I wanted to be conservative. Also, the controls exist to tweak this value yourself via the Helm chart.

I've not set a CPU limit, as I found when setting a low (<= 20m) CPU limit on the sidecar it mostly stopped working. But if people want to experiment with this, it is also configurable via the Helm chart.

Closes #344