### PR TITLE
Set test clusters to base version. GKE will work out the rest.

### DIFF
--- a/build/gke-test-cluster/cluster-e2e.yml
+++ b/build/gke-test-cluster/cluster-e2e.yml
@@ -19,7 +19,7 @@ resources:
     cluster:
       name: e2e-test-cluster
       description: End to end tests cluster for Agones
-      initialClusterVersion: 1.10.7-gke.1
+      initialClusterVersion: "1.10"
       nodePools:
         - name: "default"
           initialNodeCount: 2
@@ -28,9 +28,10 @@ resources:
             tags:
               - game-server
             oauthScopes:
-              - https://www.googleapis.com/auth/devstorage.read_only
               - https://www.googleapis.com/auth/compute
-              - https://www.googleapis.com/auth/cloud-platform
+              - https://www.googleapis.com/auth/devstorage.read_only
+              - https://www.googleapis.com/auth/logging.write
+              - https://www.googleapis.com/auth/monitoring
 - name: game-server-firewall
   type: compute.beta.firewall
   properties:

--- a/build/gke-test-cluster/cluster.yml.jinja
+++ b/build/gke-test-cluster/cluster.yml.jinja
@@ -21,7 +21,7 @@ resources:
     cluster:
       name: {{ properties["cluster.name"] }}
       description: Test cluster for Agones
-      initialClusterVersion: 1.10.7-gke.1
+      initialClusterVersion: "1.10"
       nodePools:
         - name: "default"
           initialNodeCount: {{ properties["cluster.nodePool.initialNodeCount"] }}
@@ -30,9 +30,10 @@ resources:
             tags:
               - game-server
             oauthScopes:
-              - https://www.googleapis.com/auth/devstorage.read_only
               - https://www.googleapis.com/auth/compute
-              - https://www.googleapis.com/auth/cloud-platform
+              - https://www.googleapis.com/auth/devstorage.read_only
+              - https://www.googleapis.com/auth/logging.write
+              - https://www.googleapis.com/auth/monitoring
       masterAuth:
         username: admin
         password: supersecretpassword


### PR DESCRIPTION
Apparently we now don't have to be brittle, and can set the base K8s version we want, and GKE will sort out the rest. Neat.

Also updated the permissions to be inline with the documentation.