### PR TITLE
Update Helm to 2.11.0

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -385,8 +385,10 @@ gcloud-e2e-test-cluster: $(ensure-build-image)
 	GCP_CLUSTER_NAME=e2e-test-cluster GCP_CLUSTER_ZONE=us-west1-c $(MAKE) gcloud-auth-cluster
 	docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) \
 		kubectl apply -f $(mount_path)/build/helm.yaml
-	docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) helm init --service-account helm --wait && \
-		 helm install --wait --set Replicas=1,uiService.type=ClusterIP --name consul stable/consul
+	docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) \
+		helm init --service-account helm --wait
+	docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) \
+		helm install --wait --set Replicas=1,uiService.type=ClusterIP --name consul stable/consul
 
 # Deletes the gcloud e2e cluster and cleanup any left pvc volumes
 clean-gcloud-e2e-test-cluster: $(ensure-build-image)

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
 RUN echo "source <(kubectl completion bash)" >> /root/.bashrc
 
 # install Helm package manager
-ENV HELM_VER 2.9.1
+ENV HELM_VER 2.11.0
 ENV HELM_URL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz
 RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
     && tar -zxvf /tmp/helm.tar.gz -C /tmp \
@@ -69,8 +69,7 @@ RUN go get -u github.com/golang/dep/cmd/dep && \
     go get -u golang.org/x/tools/cmd/goimports
 
 # install golang-ci linter
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | \
-    bash -s -- -b $GOPATH/bin v1.10.2
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.10.2
 
 # install the release branch of the code generator tools
 RUN mkdir -p /go/src && cd /go/src && mkdir -p k8s.io && cd k8s.io && \

--- a/build/e2e-image/Dockerfile
+++ b/build/e2e-image/Dockerfile
@@ -1,12 +1,12 @@
 FROM gcr.io/cloud-builders/gcloud-slim
 
 RUN apt-get update && \
-    apt-get install -y wget psmisc make python jq zip && \
+    apt-get install -y wget psmisc make gcc python jq zip && \
     apt-get clean
 
 # install go
 WORKDIR /usr/local
-ENV GO_VERSION=1.10.3
+ENV GO_VERSION=1.11.1
 ENV GOPATH /go
 RUN wget -q https://redirector.gvt1.com/edgedl/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir ${GOPATH}
@@ -20,7 +20,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
     mv ./kubectl /usr/local/bin/kubectl
 
 # install Helm package manager
-ENV HELM_VER 2.9.1
+ENV HELM_VER 2.11.0
 ENV HELM_URL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VER}-linux-amd64.tar.gz
 RUN curl -L  ${HELM_URL} > /tmp/helm.tar.gz \
     && tar -zxvf /tmp/helm.tar.gz -C /tmp \

--- a/build/e2e-image/entrypoint.sh
+++ b/build/e2e-image/entrypoint.sh
@@ -26,7 +26,7 @@ then
 fi
 gcloud container clusters get-credentials e2e-test-cluster \
         --zone=us-west1-c --project=agones-images
-kubectl port-forward statefulset/consul-consul 8500:8500 &
+kubectl port-forward statefulset/consul 8500:8500 &
 echo "Waiting consul port-forward to launch on 8500..."
 timeout 60 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' 127.0.0.1 8500
 echo "consul port-forward launched. Starting e2e tests..."

--- a/build/gke-test-cluster/cluster-e2e.yml
+++ b/build/gke-test-cluster/cluster-e2e.yml
@@ -22,7 +22,7 @@ resources:
       initialClusterVersion: "1.10"
       nodePools:
         - name: "default"
-          initialNodeCount: 2
+          initialNodeCount: 4
           config:
             machineType: n1-standard-4
             tags:


### PR DESCRIPTION
This will likely fail on first PR, as we will need to update the Helm install on the e2e cluster.

A good opportunity to delete and restart the e2e cluster anyway -- but will need to manage this around other PRs.

Should enable #375 to pass tests as well.