### PR TITLE
Packed: Fleet scaled down removes GameServers from least used Nodes

### DIFF
--- a/docs/scheduling_autoscaling.md
+++ b/docs/scheduling_autoscaling.md
@@ -7,14 +7,23 @@
 Table of Contents
 =================
 
-* [Fleet Autoscaling](#fleet-autoscaling)
-* [Autoscalng Concepts](#autoscalng-concepts)
-   * [Allocation Scheduling](#allocation-scheduling)
-* [Fleet Scheduling](#fleet-scheduling)
-   * [Packed](#packed)
-      * [Allocation Scheduling Strategy](#allocation-scheduling-strategy)
-   * [Distributed](#distributed)
-      * [Allocation Scheduling Stategy](#allocation-scheduling-stategy)
+   * [Scheduling and Autoscaling](#scheduling-and-autoscaling)
+   * [Table of Contents](#table-of-contents)
+      * [Fleet Autoscaling](#fleet-autoscaling)
+      * [Autoscaling Concepts](#autoscaling-concepts)
+         * [Allocation Scheduling](#allocation-scheduling)
+         * [Pod Scheduling](#pod-scheduling)
+         * [Fleet Scale Down Strategy](#fleet-scale-down-strategy)
+      * [Fleet Scheduling](#fleet-scheduling)
+         * [Packed](#packed)
+            * [Allocation Scheduling Strategy](#allocation-scheduling-strategy)
+            * [Pod Scheduling Strategy](#pod-scheduling-strategy)
+            * [Fleet Scale Down Strategy](#fleet-scale-down-strategy-1)
+         * [Distributed](#distributed)
+            * [Allocation Scheduling Strategy](#allocation-scheduling-strategy-1)
+            * [Pod Scheduling Strategy](#pod-scheduling-strategy-1)
+            * [Fleet Scale Down Strategy](#fleet-scale-down-strategy-2)
+
 
 Scheduling and autoscaling go hand in hand, as where in the cluster `GameServers` are provisioned
 impacts how to autoscale fleets up and down (or if you would even want to)
@@ -41,6 +50,11 @@ from across the Kubernetes cluster within a given `Fleet` when [allocation](./cr
 Each `GameServer` is backed by a Kubernetes [`Pod`](https://kubernetes.io/docs/concepts/workloads/pods/pod/). Pod scheduling
 refers to the strategy that is in place that determines which node in the Kubernetes cluster the Pod is assigned to,
 when it is created.
+
+### Fleet Scale Down Strategy
+
+Fleet Scale Down strategy refers to the order in which the `GameServers` that belong to a `Fleet` are deleted, 
+when Fleets are shrunk in size.
 
 ## Fleet Scheduling
 
@@ -74,8 +88,7 @@ for the infrastructure you use.
 It attempts to _pack_ as much as possible into the smallest set of nodes, to make
 scaling infrastructure down as easy as possible.
 
-Currently, Allocation scheduling is the only aspect this strategy affects, but in future releases it will
-also affect `GameServer` `Pod` scheduling, and `Fleet` scale down scheduling as well.
+This affects Allocation Scheduling, Pod Scheduling and Fleet Scale Down Scheduling.
 
 #### Allocation Scheduling Strategy
 
@@ -90,6 +103,11 @@ topology. This attempts to group together `GameServer` Pods within as few nodes 
 
 > The default Kubernetes scheduler doesn't do a perfect job of packing, but it's a good enough job for what we need - 
   at least at this stage. 
+
+#### Fleet Scale Down Strategy
+
+With the "Packed" strategy, Fleets will remove `Ready` `GameServers` from Nodes with the _least_ number of `Ready` and 
+`Allocated` `GameServers` on them. Attempting to empty Nodes so that they can be safely removed.
 
 ### Distributed
 
@@ -118,8 +136,7 @@ on bare metal, and the cluster size rarely changes, if at all.
 This attempts to distribute the load across the entire cluster as much as possible, to take advantage of the static
 size of the cluster.
 
-Currently, the only thing the scheduling strategy affects is Allocation scheduling, but in future releases it will
-also affect `GameServer` `Pod` scheduling, and `Fleet` scaledown scheduling as well.
+This affects Allocation Scheduling, Pod Scheduling and Fleet Scale Down Scheduling.
 
 #### Allocation Scheduling Strategy
 
@@ -130,3 +147,8 @@ number of allocated `GameServers` on them.
 
 Under the "Distributed" strategy, `Pod` scheduling is provided by the default Kubernetes scheduler, which will attempt
 to distribute the `GameServer` `Pods` across as many nodes as possible.
+
+#### Fleet Scale Down Strategy
+
+With the "Distributed" strategy, Fleets will remove `Ready` `GameServers` from Nodes with at random, to ensure
+a distributed load is maintained.

--- a/examples/simple-udp/fleet.yaml
+++ b/examples/simple-udp/fleet.yaml
@@ -25,7 +25,6 @@ spec:
     spec:
       ports:
       - name: default
-        portPolicy: "dynamic"
         containerPort: 7654
       template:
         spec:

--- a/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
+++ b/install/helm/agones/templates/crds/_gameserverspecvalidation.yaml
@@ -57,7 +57,7 @@ properties:
       ports:
         title: array of ports to expose on the game server container
         type: array
-        minItems: 0 # make this 1 in 0.4.0
+        minItems: 1
         required:
           - containerPort
         items:
@@ -91,34 +91,11 @@ properties:
               type: integer
               minimum: 1
               maximum: 65535
-      portPolicy: # remove this in 0.4.0
-        title: the port policy that will be applied to the game server
-        description: |
-            portPolicy has two options:
-            - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
-            - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
-            port is available. When static is the policy specified, `hostPort` is required to be populated
+      scheduling:
         type: string
         enum:
-        - dynamic
-        - static
-      protocol: # remove this in 0.4.0
-        title: Protocol being used. Defaults to UDP. TCP is the only other option
-        type: string
-        enum:
-        - UDP
-        - TCP
-      containerPort: # remove this in 0.4.0
-        title: The port that is being opened on the game server process
-        type: integer
-        minimum: 1
-        maximum: 65535
-      hostPort: # remove this in 0.4.0
-        title: The port exposed on the host
-        description: Only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
-        type: integer
-        minimum: 1
-        maximum: 65535
+        - Packed
+        - Distributed
       health:
         type: object
         title: Health checking for the running game server

--- a/install/helm/agones/templates/crds/fleet.yaml
+++ b/install/helm/agones/templates/crds/fleet.yaml
@@ -43,9 +43,15 @@ spec:
             replicas:
               type: integer
               minimum: 0
+            scheduling:
+              type: string
+              enum:
+              - Packed
+              - Distributed
             strategy:
               properties:
                 type:
+                  type: string
                   enum:
                     - Recreate
                     - RollingUpdate

--- a/install/helm/agones/templates/crds/fleetautoscaler.yaml
+++ b/install/helm/agones/templates/crds/fleetautoscaler.yaml
@@ -50,8 +50,9 @@ spec:
                 - type
               properties:
                 type:
+                  type: string
                   enum:
-                    - Buffer
+                  - Buffer
                 buffer:
                   required:
                     - maxReplicas

--- a/install/helm/agones/templates/crds/gameserverset.yaml
+++ b/install/helm/agones/templates/crds/gameserverset.yaml
@@ -44,5 +44,10 @@ spec:
             replicas:
               type: integer
               minimum: 0
+            scheduling:
+              type: string
+              enum:
+              - Packed
+              - Distributed
             template:
               {{- include "gameserver.validation" . | indent 14 }}

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -184,9 +184,15 @@ spec:
             replicas:
               type: integer
               minimum: 0
+            scheduling:
+              type: string
+              enum:
+              - Packed
+              - Distributed
             strategy:
               properties:
                 type:
+                  type: string
                   enum:
                     - Recreate
                     - RollingUpdate
@@ -234,7 +240,7 @@ spec:
                     ports:
                       title: array of ports to expose on the game server container
                       type: array
-                      minItems: 0 # make this 1 in 0.4.0
+                      minItems: 1
                       required:
                         - containerPort
                       items:
@@ -268,34 +274,11 @@ spec:
                             type: integer
                             minimum: 1
                             maximum: 65535
-                    portPolicy: # remove this in 0.4.0
-                      title: the port policy that will be applied to the game server
-                      description: |
-                          portPolicy has two options:
-                          - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
-                          - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
-                          port is available. When static is the policy specified, `hostPort` is required to be populated
+                    scheduling:
                       type: string
                       enum:
-                      - dynamic
-                      - static
-                    protocol: # remove this in 0.4.0
-                      title: Protocol being used. Defaults to UDP. TCP is the only other option
-                      type: string
-                      enum:
-                      - UDP
-                      - TCP
-                    containerPort: # remove this in 0.4.0
-                      title: The port that is being opened on the game server process
-                      type: integer
-                      minimum: 1
-                      maximum: 65535
-                    hostPort: # remove this in 0.4.0
-                      title: The port exposed on the host
-                      description: Only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
-                      type: integer
-                      minimum: 1
-                      maximum: 65535
+                      - Packed
+                      - Distributed
                     health:
                       type: object
                       title: Health checking for the running game server
@@ -421,8 +404,9 @@ spec:
                 - type
               properties:
                 type:
+                  type: string
                   enum:
-                    - Buffer
+                  - Buffer
                 buffer:
                   required:
                     - maxReplicas
@@ -515,7 +499,7 @@ spec:
             ports:
               title: array of ports to expose on the game server container
               type: array
-              minItems: 0 # make this 1 in 0.4.0
+              minItems: 1
               required:
                 - containerPort
               items:
@@ -549,34 +533,11 @@ spec:
                     type: integer
                     minimum: 1
                     maximum: 65535
-            portPolicy: # remove this in 0.4.0
-              title: the port policy that will be applied to the game server
-              description: |
-                  portPolicy has two options:
-                  - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
-                  - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
-                  port is available. When static is the policy specified, `hostPort` is required to be populated
+            scheduling:
               type: string
               enum:
-              - dynamic
-              - static
-            protocol: # remove this in 0.4.0
-              title: Protocol being used. Defaults to UDP. TCP is the only other option
-              type: string
-              enum:
-              - UDP
-              - TCP
-            containerPort: # remove this in 0.4.0
-              title: The port that is being opened on the game server process
-              type: integer
-              minimum: 1
-              maximum: 65535
-            hostPort: # remove this in 0.4.0
-              title: The port exposed on the host
-              description: Only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
-              type: integer
-              minimum: 1
-              maximum: 65535
+              - Packed
+              - Distributed
             health:
               type: object
               title: Health checking for the running game server
@@ -647,6 +608,11 @@ spec:
             replicas:
               type: integer
               minimum: 0
+            scheduling:
+              type: string
+              enum:
+              - Packed
+              - Distributed
             template:              
               required:
               - spec
@@ -691,7 +657,7 @@ spec:
                     ports:
                       title: array of ports to expose on the game server container
                       type: array
-                      minItems: 0 # make this 1 in 0.4.0
+                      minItems: 1
                       required:
                         - containerPort
                       items:
@@ -725,34 +691,11 @@ spec:
                             type: integer
                             minimum: 1
                             maximum: 65535
-                    portPolicy: # remove this in 0.4.0
-                      title: the port policy that will be applied to the game server
-                      description: |
-                          portPolicy has two options:
-                          - "dynamic" (default) the system allocates a free hostPort for the gameserver, for game clients to connect to
-                          - "static", user defines the hostPort that the game client will connect to. Then onus is on the user to ensure that the
-                          port is available. When static is the policy specified, `hostPort` is required to be populated
+                    scheduling:
                       type: string
                       enum:
-                      - dynamic
-                      - static
-                    protocol: # remove this in 0.4.0
-                      title: Protocol being used. Defaults to UDP. TCP is the only other option
-                      type: string
-                      enum:
-                      - UDP
-                      - TCP
-                    containerPort: # remove this in 0.4.0
-                      title: The port that is being opened on the game server process
-                      type: integer
-                      minimum: 1
-                      maximum: 65535
-                    hostPort: # remove this in 0.4.0
-                      title: The port exposed on the host
-                      description: Only required when `portPolicy` is "static". Overwritten when portPolicy is "dynamic".
-                      type: integer
-                      minimum: 1
-                      maximum: 65535
+                      - Packed
+                      - Distributed
                     health:
                       type: object
                       title: Health checking for the running game server

--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -118,7 +118,7 @@ type GameServerSpec struct {
 	// Health configures health checking
 	Health Health `json:"health,omitempty"`
 	// Scheduling strategy. Defaults to "Packed".
-	Scheduling SchedulingStrategy `json:"scheduling"`
+	Scheduling SchedulingStrategy `json:"scheduling,omitempty"`
 	// Template describes the Pod that will be created for the GameServer
 	Template corev1.PodTemplateSpec `json:"template"`
 }

--- a/pkg/apis/stable/v1alpha1/gameserverset.go
+++ b/pkg/apis/stable/v1alpha1/gameserverset.go
@@ -57,7 +57,7 @@ type GameServerSetSpec struct {
 	// Replicas are the number of GameServers that should be in this set
 	Replicas int32 `json:"replicas"`
 	// Scheduling strategy. Defaults to "Packed".
-	Scheduling SchedulingStrategy `json:"scheduling"`
+	Scheduling SchedulingStrategy `json:"scheduling,omitempty"`
 	// Template the GameServer template to apply for this GameServerSet
 	Template GameServerTemplateSpec `json:"template"`
 }

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -262,7 +262,7 @@ func TestSyncLessGameServers(t *testing.T) {
 
 	list := createGameServers(gsSet, 11)
 
-	// make some as unhealthy
+	// mark some as Allocated
 	list[0].Status.State = v1alpha1.Allocated
 	list[3].Status.State = v1alpha1.Allocated
 
@@ -301,7 +301,7 @@ func TestSyncLessGameServers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, list2, 11)
 
-	err = c.syncLessGameSevers(gsSet, int32(-expected))
+	err = c.syncLessGameServers(gsSet, int32(-expected))
 	assert.Nil(t, err)
 
 	// subtract one, because one is already deleted
@@ -459,8 +459,9 @@ func defaultFixture() *v1alpha1.GameServerSet {
 	gsSet := &v1alpha1.GameServerSet{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test", UID: "1234"},
 		Spec: v1alpha1.GameServerSetSpec{
-			Replicas: 10,
-			Template: v1alpha1.GameServerTemplateSpec{},
+			Replicas:   10,
+			Scheduling: v1alpha1.Packed,
+			Template:   v1alpha1.GameServerTemplateSpec{},
 		},
 	}
 	return gsSet

--- a/pkg/gameserversets/gameserversets.go
+++ b/pkg/gameserversets/gameserversets.go
@@ -15,22 +15,81 @@
 package gameserversets
 
 import (
-	stablev1alpha1 "agones.dev/agones/pkg/apis/stable/v1alpha1"
+	"sort"
+
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	listerv1alpha1 "agones.dev/agones/pkg/client/listers/stable/v1alpha1"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+// node is just a convenience data structure for
+// keeping relevant GameServer information about Nodes
+type node struct {
+	name  string
+	total int64
+	ready []*v1alpha1.GameServer
+}
+
+// filterGameServersOnLeastFullNodes returns a limited list of GameServers, ordered by the nodes
+// they are hosted on, with the least utilised Nodes being prioritised
+func filterGameServersOnLeastFullNodes(gsList []*v1alpha1.GameServer, limit int32) []*v1alpha1.GameServer {
+	if limit <= 0 {
+		return nil
+	}
+
+	nodeMap := map[string]*node{}
+	var nodeList []*node
+
+	// count up the number of allocated and ready game servers that exist
+	// also, since we're already looping through, track all the deletable GameServers
+	// per node, so we can use this as a shortlist to delete from
+	for _, gs := range gsList {
+		if gs.DeletionTimestamp.IsZero() &&
+			(gs.Status.State == v1alpha1.Allocated || gs.Status.State == v1alpha1.Ready) {
+			_, ok := nodeMap[gs.Status.NodeName]
+			if !ok {
+				node := &node{name: gs.Status.NodeName}
+				nodeMap[gs.Status.NodeName] = node
+				nodeList = append(nodeList, node)
+			}
+
+			nodeMap[gs.Status.NodeName].total++
+			if gs.Status.State == v1alpha1.Ready {
+				nodeMap[gs.Status.NodeName].ready = append(nodeMap[gs.Status.NodeName].ready, gs)
+			}
+		}
+	}
+
+	// sort our nodes, least to most
+	sort.Slice(nodeList, func(i, j int) bool {
+		return nodeList[i].total < nodeList[j].total
+	})
+
+	// we need to get Ready GameServer until we equal or pass limit
+	result := make([]*v1alpha1.GameServer, 0, limit)
+
+	for _, n := range nodeList {
+		result = append(result, n.ready...)
+
+		if int32(len(result)) >= limit {
+			return result
+		}
+	}
+
+	return result
+}
+
 // ListGameServersByGameServerSetOwner lists the GameServers for a given GameServerSet
 func ListGameServersByGameServerSetOwner(gameServerLister listerv1alpha1.GameServerLister,
-	gsSet *stablev1alpha1.GameServerSet) ([]*stablev1alpha1.GameServer, error) {
-	list, err := gameServerLister.List(labels.SelectorFromSet(labels.Set{stablev1alpha1.GameServerSetGameServerLabel: gsSet.ObjectMeta.Name}))
+	gsSet *v1alpha1.GameServerSet) ([]*v1alpha1.GameServer, error) {
+	list, err := gameServerLister.List(labels.SelectorFromSet(labels.Set{v1alpha1.GameServerSetGameServerLabel: gsSet.ObjectMeta.Name}))
 	if err != nil {
 		return list, errors.Wrapf(err, "error listing gameservers for gameserverset %s", gsSet.ObjectMeta.Name)
 	}
 
-	var result []*stablev1alpha1.GameServer
+	var result []*v1alpha1.GameServer
 	for _, gs := range list {
 		if metav1.IsControlledBy(gs, gsSet) {
 			result = append(result, gs)


### PR DESCRIPTION
This implements the strategy such that when a Fleet is scaled down, and
has the "Packed" strategy, it removed GameServers from Nodes that have the
least GameServers running on them.

This also fixes up some issues with the OpenAPI validation as well.

(Sorry - there was a bunch of cleanup in here, lemme know if you want me to point out the most important sections - basically controller.go and `filterGameServersOnLeastFullNodes` implementation)