### PR TITLE
Cluster Autoscaling: safe-to-evict=false annotations for GameServer Pods

### DIFF
--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -35,8 +35,9 @@ spec:
     type: Recreate
   template:
     metadata:
-{{- if .Values.agones.controller.generateTLS }}
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: {{ .Values.agones.controller.safeToEvict | quote }}
+{{- if .Values.agones.controller.generateTLS }}
         revision/tls-cert: {{ .Release.Revision | quote }}
 {{- end }}
       labels:

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -22,6 +22,7 @@ agones:
   controller:
     resources: {}
     generateTLS: true
+    safeToEvict: false
     healthCheck:
       http:
         port: 8080

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -790,6 +790,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         stable.agones.dev/role: controller
         app: agones


### PR DESCRIPTION
This is the final piece for ensuring that the Kubernetes Autoscaler works with Agones.

This ensures that `GameServer` Pods cannot be evicted from the cluster, via annotations that the autoscaler uses to determine that `GameServer` Pods are unsafe to be evicted.

This annotation has also been placed on the controller, but can be turned off via Helm chart variables.

I expect that cluster autoscaling, and the backing strategies will get tweaked for performance and resource usage as we get more real world experience with it, but this is working relatively nicely right now.

Closes #368