### PR TITLE
Delete crds, and fleets, gameservers etc on deletion of Helm chart

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -231,7 +231,7 @@ push-agones-sdk-image: $(ensure-build-image)
 gen-install: $(ensure-build-image)
 	docker run --rm $(common_mounts) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
 		'helm template --name=agones-manual --namespace agones-system $(mount_path)/install/helm/agones \
-		--set agones.controller.generateTLS=false \
+		--set agones.controller.generateTLS=false --set agones.enableHelmCleanupHooks=false \
 		> $(mount_path)/install/yaml/install.yaml'
 
 # Generate the SDK gRPC server and client code
@@ -476,6 +476,9 @@ minikube-push: minikube-agones-profile
 # Use this instead of `make install`, as it disables PullAlways on the install.yaml
 minikube-install: minikube-agones-profile
 	$(MAKE) install DOCKER_RUN_ARGS="--network=host -v $(minikube_cert_mount)" ALWAYS_PULL_SIDECAR=false IMAGE_PULL_POLICY=IfNotPresent
+
+minikube-uninstall: $(ensure-build-image) minikube-agones-profile
+	$(MAKE) uninstall DOCKER_RUN_ARGS="--network=host -v $(minikube_cert_mount)"
 
 # Convenience target for transferring images into minikube.
 # Use TAG to specify the image to transfer into minikube

--- a/install/helm/agones/scripts/delete_agones_resources.sh
+++ b/install/helm/agones/scripts/delete_agones_resources.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+namespaces=$@
+
+for ns in $namespaces; do
+
+  # Building the list of pods we need to ensure are deleted.
+  gs=$(kubectl -n $ns get gs -o jsonpath='{.items[*].metadata.name}')
+
+  for g in $gs; do
+    pod=$(kubectl -n $ns get po -l stable.agones.dev/gameserver=$g -o jsonpath='{.items[*].metadata.name}')
+    pods="$pods $pod"
+  done
+
+  # Delete Agones resources to kickstart pod deletion.
+  kubectl -n $ns delete fleetautoscalers --all
+  kubectl -n $ns delete fleets --all
+  kubectl -n $ns delete gameserversets --all
+  kubectl -n $ns delete gameservers --all
+  kubectl -n $ns delete fleetallocations --all
+
+  # Since we don't have the nifty kubectl wait yet, hack one in the meantime
+  for p in $pods; do
+    get_po=$(kubectl -n $ns get po $p -o jsonpath='{.metadata.name}')
+    while [ "$get_po" = "$p" ]; do
+      sleep 0.1
+      get_po=$(kubectl -n $ns get po $p -o jsonpath='{.metadata.name}')
+    done
+  done
+done

--- a/install/helm/agones/scripts/delete_crds.sh
+++ b/install/helm/agones/scripts/delete_crds.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kubectl delete crd fleets.stable.agones.dev
+kubectl delete crd fleetallocations.stable.agones.dev
+kubectl delete crd fleetautoscalers.stable.agones.dev
+kubectl delete crd gameservers.stable.agones.dev
+kubectl delete crd gameserversets.stable.agones.dev

--- a/install/helm/agones/templates/hooks/post_delete_hook.yaml
+++ b/install/helm/agones/templates/hooks/post_delete_hook.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.agones.enableHelmCleanupHooks }}
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}-delete-crds"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}-delete-crds"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+        helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      serviceAccountName: helm-hook-cleanup
+      restartPolicy: Never
+      containers:
+      - name: post-delete-delete-crd
+        image: "lachlanevenson/k8s-kubectl:v1.10.9"
+        command: ["/bin/sh", "/scripts/delete_crds.sh"]
+        volumeMounts:
+        - name: script
+          mountPath: /scripts/
+      volumes:
+      - name: script
+        configMap:
+          name: delete-crds
+{{- end }}

--- a/install/helm/agones/templates/hooks/pre_delete_hook.yaml
+++ b/install/helm/agones/templates/hooks/pre_delete_hook.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.agones.enableHelmCleanupHooks }}
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}-delete-agones-resources"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}-delete-agones-resources"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+        helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      serviceAccountName: helm-hook-cleanup
+      restartPolicy: Never
+      containers:
+      - name: pre-delete-delete-agones-resources
+        image: "lachlanevenson/k8s-kubectl:v1.10.9"
+        command: 
+        - "/bin/sh"
+        - "/scripts/delete_agones_resources.sh"
+        {{- range .Values.gameservers.namespaces }}
+        - "{{ . }}"
+        {{- end }}
+        volumeMounts:
+        - name: script
+          mountPath: /scripts/
+      volumes:
+      - name: script
+        configMap:
+          name: delete-agones-resources
+{{- end }}

--- a/install/helm/agones/templates/hooks/sa.yaml
+++ b/install/helm/agones/templates/hooks/sa.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.agones.enableHelmCleanupHooks }}
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm-hook-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "agones.name" . }}
+    chart: {{ template "agones.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+{{- if .Values.agones.rbacEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: helm-hook-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "agones.name" . }}
+    chart: {{ template "agones.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["delete"]
+- apiGroups: ["stable.agones.dev"]
+  resources: ["fleets", "fleetallocations", "fleetautoscalers", "gameservers", "gameserversets"]
+  verbs: ["delete", "list" ]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: helm-hook-cleanup-access
+  labels:
+    app: {{ template "agones.name" . }}
+    chart: {{ template "agones.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation
+subjects:
+- kind: User
+  name: system:serviceaccount:{{ .Release.Namespace }}:helm-hook-cleanup
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: helm-hook-cleanup
+{{- end }}
+{{- end }}

--- a/install/helm/agones/templates/hooks/scripts.yaml
+++ b/install/helm/agones/templates/hooks/scripts.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.agones.enableHelmCleanupHooks }}
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: delete-crds
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  delete_crds.sh: |
+{{ .Files.Get "scripts/delete_crds.sh" | indent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: delete-agones-resources
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  delete_agones_resources.sh: |
+{{ .Files.Get "scripts/delete_agones_resources.sh" | indent 4 }}
+{{- end }}

--- a/install/helm/agones/values.yaml
+++ b/install/helm/agones/values.yaml
@@ -16,6 +16,7 @@
 
 agones:
   rbacEnabled: true
+  enableHelmCleanupHooks: true
   serviceaccount:
     controller: agones-controller
     sdk: agones-sdk

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -849,6 +849,22 @@ spec:
           secretName: agones-manual-cert
 
 ---
+# Source: agones/templates/hooks/post_delete_hook.yaml
+
+
+---
+# Source: agones/templates/hooks/pre_delete_hook.yaml
+
+
+---
+# Source: agones/templates/hooks/sa.yaml
+
+
+---
+# Source: agones/templates/hooks/scripts.yaml
+
+
+---
 # Source: agones/templates/admissionregistration.yaml
 # Copyright 2018 Google Inc. All Rights Reserved.
 #


### PR DESCRIPTION
This implements helm hooks to delete all Agones resources and CRDs when uninstalling our chart.

Deletion of resources is done in a pre-delete hook while crds are deleted in a post-delete hook. Had to add a new service account and a few other resources to accomplish it.

Fixes #426 