### PR TITLE
Adding explicit length of git revision in Makefile and E2E Can't Allocate test 

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -35,7 +35,7 @@ release_registry = gcr.io/agones-images
 #
 
 # Version defaults to the short hash of the latest commit
-VERSION ?= $(base_version)-$(shell git rev-parse --short HEAD)
+VERSION ?= $(base_version)-$(shell git rev-parse --short=7 HEAD)
 # The registry that is being used to store docker images
 REGISTRY ?= $(release_registry)
 # kubectl configuration to use


### PR DESCRIPTION
Output of git rev-parse short command could be different for different environments. For example on my laptop I got 8 chars which leads to errors on deployment to test-cluster using make install.
Namely:
```
ImagePullBackOff     agones-controller: gcr.io/agones-images/agones-controller:0.7.0-5e2ad5ee 
```
which should be gcr.io/agones-images/agones-controller:0.7.0-5e2ad5e.
Also adding separate test for "Can't allocate on fully sized fleet".