### PR TITLE
CRD: added additionalPrinterColumns to GameServer for kubectl

### DIFF
--- a/install/helm/agones/templates/crds/fleet.yaml
+++ b/install/helm/agones/templates/crds/fleet.yaml
@@ -25,6 +25,25 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.scheduling
+    name: Scheduling
+    type: string
+  - JSONPath: .spec.replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.allocatedReplicas
+    name: Allocated
+    type: integer
+  - JSONPath: .status.readyReplicas
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced

--- a/install/helm/agones/templates/crds/fleetallocation.yaml
+++ b/install/helm/agones/templates/crds/fleetallocation.yaml
@@ -25,6 +25,22 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.gameServer.status.state
+    name: State
+    type: string
+  - JSONPath: .status.gameServer.status.address
+    name: Address
+    type: string
+  - JSONPath: .status.gameServer.status.ports[0].port
+    name: Port
+    type: string
+  - JSONPath: .status.gameServer.status.nodeName
+    name: Node
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced

--- a/install/helm/agones/templates/crds/gameserver.yaml
+++ b/install/helm/agones/templates/crds/gameserver.yaml
@@ -28,6 +28,22 @@ spec:
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .status.address
+    name: Address
+    type: string
+  - JSONPath: .status.ports[0].port
+    name: Port
+    type: string
+  - JSONPath: .status.nodeName
+    name: Node
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   names:
     kind: GameServer
     plural: gameservers

--- a/install/helm/agones/templates/crds/gameserverset.yaml
+++ b/install/helm/agones/templates/crds/gameserverset.yaml
@@ -25,6 +25,25 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.scheduling
+    name: Scheduling
+    type: string
+  - JSONPath: .spec.replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.allocatedReplicas
+    name: Allocated
+    type: integer
+  - JSONPath: .status.readyReplicas
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -164,6 +164,25 @@ metadata:
     release: agones-manual
     heritage: Tiller
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.scheduling
+    name: Scheduling
+    type: string
+  - JSONPath: .spec.replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.allocatedReplicas
+    name: Allocated
+    type: integer
+  - JSONPath: .status.readyReplicas
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced
@@ -328,6 +347,22 @@ metadata:
     release: agones-manual
     heritage: Tiller
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.gameServer.status.state
+    name: State
+    type: string
+  - JSONPath: .status.gameServer.status.address
+    name: Address
+    type: string
+  - JSONPath: .status.gameServer.status.ports[0].port
+    name: Port
+    type: string
+  - JSONPath: .status.gameServer.status.nodeName
+    name: Node
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced
@@ -349,6 +384,7 @@ spec:
               minLength: 1
               maxLength: 63
               pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+
 ---
 # Source: agones/templates/crds/fleetautoscaler.yaml
 # Copyright 2018 Google Inc. All Rights Reserved.
@@ -446,6 +482,22 @@ spec:
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .status.address
+    name: Address
+    type: string
+  - JSONPath: .status.ports[0].port
+    name: Port
+    type: string
+  - JSONPath: .status.nodeName
+    name: Node
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   names:
     kind: GameServer
     plural: gameservers
@@ -586,6 +638,25 @@ metadata:
     release: agones-manual
     heritage: Tiller
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.scheduling
+    name: Scheduling
+    type: string
+  - JSONPath: .spec.replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.allocatedReplicas
+    name: Allocated
+    type: integer
+  - JSONPath: .status.readyReplicas
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: stable.agones.dev
   version: v1alpha1
   scope: Namespaced


### PR DESCRIPTION
This only works on Kubernetes >=1.11 and is ignored by older versions.

```
$ kubectl get gameservers
NAME                     STATE       ADDRESS        PORT   NODE                                     AGE
simple-udp-lrw4k-6c8rg   Ready       35.247.xx.xx   7741   gke-test-cluster-default-405277ca-2fr0   15m
simple-udp-lrw4k-78td7   Ready       35.247.xx.xx   7378   gke-test-cluster-default-405277ca-2fr0   15m
simple-udp-lrw4k-8mcwk   Ready       35.247.xx.xx   7795   gke-test-cluster-default-405277ca-2fr0   15m
simple-udp-lrw4k-wqwsn   Allocated   35.247.xx.xx   7301   gke-test-cluster-default-405277ca-2fr0   15m
simple-udp-lrw4k-xxj2f   Ready       35.247.xx.xx   7052   gke-test-cluster-default-405277ca-2fr0   15m

$ kubectl get gameserversets
NAME               SCHEDULING   DESIRED   CURRENT   ALLOCATED   READY   AGE
simple-udp-lrw4k   Packed       10        10        1           9       16m

$ kubectl get fleets
NAME         SCHEDULING   DESIRED   CURRENT   ALLOCATED   READY   AGE
simple-udp   Packed       10        10        1           9       16m

$ kubectl get fleetallocations
NAME               STATE       ADDRESS        PORT   NODE                                     AGE
simple-udp-sf66j   Allocated   35.247.xx.xx   7301   gke-test-cluster-default-405277ca-2fr0   16m