### PR TITLE
[Security] Upgrade Go to 1.11.4

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -47,7 +47,7 @@ RUN wget -q https://static.rust-lang.org/rustup/archive/1.11.0/${RUST_ARCH}/rust
 
 # install go
 WORKDIR /usr/local
-ENV GO_VERSION=1.11.1
+ENV GO_VERSION=1.11.4
 ENV GOPATH /go
 RUN wget -q https://redirector.gvt1.com/edgedl/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir ${GOPATH}

--- a/examples/simple-udp/Dockerfile
+++ b/examples/simple-udp/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build
-FROM golang:1.11.1 as builder
+FROM golang:1.11.4 as builder
 WORKDIR /go/src/simple-udp
 
 COPY examples/simple-udp/main.go .


### PR DESCRIPTION
Fixes 3 security issues in previous Go releases.

Details: https://groups.google.com/forum/m/#!topic/golang-nuts/Gz_KNmdXbn0