### PR TITLE
Split pkg/gameservers into two 

### DIFF
--- a/cmd/sdk-server/main.go
+++ b/cmd/sdk-server/main.go
@@ -25,8 +25,8 @@ import (
 
 	"agones.dev/agones/pkg"
 	"agones.dev/agones/pkg/client/clientset/versioned"
-	"agones.dev/agones/pkg/gameservers"
 	"agones.dev/agones/pkg/sdk"
+	"agones.dev/agones/pkg/sdkserver"
 	"agones.dev/agones/pkg/util/runtime"
 	"agones.dev/agones/pkg/util/signals"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -108,8 +108,8 @@ func main() {
 			logger.WithError(err).Fatalf("Could not create the agones api clientset")
 		}
 
-		var s *gameservers.SDKServer
-		s, err = gameservers.NewSDKServer(viper.GetString(gameServerNameEnv),
+		var s *sdkserver.SDKServer
+		s, err = sdkserver.NewSDKServer(viper.GetString(gameServerNameEnv),
 			viper.GetString(podNamespaceEnv), kubeClient, agonesClient)
 		if err != nil {
 			logger.WithError(err).Fatalf("Could not start sidecar")
@@ -146,7 +146,7 @@ func registerLocal(grpcServer *grpc.Server, ctlConf config) error {
 		}
 	}
 
-	local, err := gameservers.NewLocalSDKServer(filePath)
+	local, err := sdkserver.NewLocalSDKServer(filePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -1106,3 +1106,14 @@ func newFakeController() (*Controller, agtesting.Mocks) {
 	c.recorder = m.FakeRecorder
 	return c, m
 }
+
+func newSingleContainerSpec() v1alpha1.GameServerSpec {
+	return v1alpha1.GameServerSpec{
+		Ports: []v1alpha1.GameServerPort{{ContainerPort: 7777, HostPort: 9999, PortPolicy: v1alpha1.Static}},
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "container", Image: "container/image"}},
+			},
+		},
+	}
+}

--- a/pkg/sdkserver/helper_test.go
+++ b/pkg/sdkserver/helper_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"context"
@@ -22,26 +22,13 @@ import (
 	"testing"
 	"time"
 
-	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	"agones.dev/agones/pkg/sdk"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	netcontext "golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
-
-func newSingleContainerSpec() v1alpha1.GameServerSpec {
-	return v1alpha1.GameServerSpec{
-		Ports: []v1alpha1.GameServerPort{{ContainerPort: 7777, HostPort: 9999, PortPolicy: v1alpha1.Static}},
-		Template: corev1.PodTemplateSpec{
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{Name: "container", Image: "container/image"}},
-			},
-		},
-	}
-}
 
 func testHTTPHealth(t *testing.T, url string, expectedResponse string, expectedStatus int) {
 	// do a poll, because this code could run before the health check becomes live

--- a/pkg/sdkserver/localsdk.go
+++ b/pkg/sdkserver/localsdk.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"io"

--- a/pkg/sdkserver/localsdk_test.go
+++ b/pkg/sdkserver/localsdk_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"encoding/json"

--- a/pkg/sdkserver/sdk.go
+++ b/pkg/sdkserver/sdk.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"

--- a/pkg/sdkserver/sdk_test.go
+++ b/pkg/sdkserver/sdk_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"testing"

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"io"

--- a/pkg/sdkserver/sdkserver_test.go
+++ b/pkg/sdkserver/sdkserver_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gameservers
+package sdkserver
 
 import (
 	"net/http"


### PR DESCRIPTION
This cleanly extracts `pkg/sdkserver` from `pkg/gameserver`. No code was actually shared between SDK and controller, so this was a very clean split (only one test function had to be moved)

Addresses #445 