### PR TITLE
This should fail e2e in any command fails

### DIFF
--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 echo "installing current release"
 DOCKER_RUN= make install
 echo "starting e2e test"


### PR DESCRIPTION
In the current incarnation, if the install section fails, and e2e passes, then e2e all passes.

This should fail now if install fails.