### PR TITLE
Move the README.md into /agones/ so it's in the Helm Chart

### DIFF
--- a/docs/limiting_resources.md
+++ b/docs/limiting_resources.md
@@ -48,7 +48,7 @@ If you do not set a limit or request, the default is set my Kubernetes at a 100m
 You may also want to tweak the CPU request or limits on the SDK `GameServer` sidecar process that spins up alongside
 each game server container.
 
-You can do this through the [Helm configuration](../install/helm/README.md#configuration) when installing Agones.
+You can do this through the [Helm configuration](../install/helm/agones/README.md#configuration) when installing Agones.
 
 By default, this is set to having a CPU request value of 30m, with no hard CPU limit. This ensures that the sidecar always has enough CPU
 to function, but it is configurable in case a lower, or higher value is required on your clusters, or if you desire 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -37,7 +37,7 @@ Finally include that `ServiceMonitor` in your [Prometheus instance CRD](https://
 ### Stackdriver
 
 We don't yet support the [OpenCensus Stackdriver exporter](https://opencensus.io/exporters/supported-exporters/go/stackdriver/) but you can still use the Prometheus Stackdriver integration by following these [instructions](https://cloud.google.com/monitoring/kubernetes-engine/prometheus).
-Annotations required by this integration can be activated by setting the `agones.metrics.prometheusServiceDiscovery` to true (default) via the [helm chart value](../install/helm/README.md#configuration).
+Annotations required by this integration can be activated by setting the `agones.metrics.prometheusServiceDiscovery` to true (default) via the [helm chart value](../install/helm/agones/README.md#configuration).
 
 ## Metrics available
 

--- a/docs/ping_service.md
+++ b/docs/ping_service.md
@@ -12,7 +12,7 @@ for the purpose of timing how long the rountrip takes for information to be retu
 
 By default, Agones installs [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/) for
 both HTTP and the UDP ping endpoints. These can be disabled entirely,
-or disabled individually. See the [Helm install guide](../install/helm/README.md) for the parameters to pass through,
+or disabled individually. See the [Helm install guide](../install/helm/agones/README.md) for the parameters to pass through,
 as well as configuration options. 
 
 The ping services as all installed under the `agones-system` namespace.

--- a/install/README.md
+++ b/install/README.md
@@ -305,7 +305,7 @@ Also, we can install Agones using [Helm][helm] package manager. If you want more
 options see the [Helm installation guide for Agones][agones-install-guide]
 
 [helm]: https://docs.helm.sh
-[agones-install-guide]: helm/README.md
+[agones-install-guide]: helm/agones/README.md
 
 ## Confirming Agones started successfully
 

--- a/install/helm/agones/README.md
+++ b/install/helm/agones/README.md
@@ -127,7 +127,7 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `gameservers.maxPort`                               | Maximum port to use for dynamic port allocation                                                 | `8000`                 |
 
 [constraints]: https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/
-[ping]: ../../docs/ping_service.md
+[ping]: ../../../docs/ping_service.md
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -145,7 +145,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 $ helm install --name my-release --namespace agones-system -f values.yaml agones/agones
 ```
 
-> **Tip**: You can use the default [values.yaml](agones/values.yaml)
+> **Tip**: You can use the default [values.yaml](values.yaml)
 
 ## TLS Certificates
 
@@ -156,4 +156,4 @@ For most used cases the controller would have required a restart anyway (eg: con
 
 ## Confirm Agones is running
 
-To confirm Agones is up and running, [go to the next section](../README.md#confirming-agones-started-successfully)
+To confirm Agones is up and running, [go to the next section](../../README.md#confirming-agones-started-successfully)


### PR DESCRIPTION
This will mean Helm hub will get a nice readme on the landing page.