### PR TITLE
improve docker layers using COPY --chown

### DIFF
--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -3,10 +3,7 @@ FROM alpine:3.8
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
-COPY ./bin/controller /home/agones/controller
-
-RUN chown -R agones /home/agones && \
-    chmod o+x /home/agones/controller
+COPY  --chown=agones:root ./bin/controller /home/agones/controller
 
 USER agones
 ENTRYPOINT ["/home/agones/controller"]

--- a/cmd/ping/Dockerfile
+++ b/cmd/ping/Dockerfile
@@ -17,10 +17,7 @@ FROM alpine:3.8
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
-COPY ./bin/ping /home/agones/ping
-
-RUN chown -R agones /home/agones && \
-    chmod o+x /home/agones/ping
+COPY --chown=agones:root ./bin/ping /home/agones/ping
 
 USER agones
 ENTRYPOINT ["/home/agones/ping"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -3,10 +3,7 @@ FROM alpine:3.8
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
-COPY ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
-
-RUN chown -R agones /home/agones && \
-    chmod o+x /home/agones/sdk-server
+COPY --chown=agones:root ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
 
 USER agones
 ENTRYPOINT ["/home/agones/sdk-server"]


### PR DESCRIPTION
Closes #481 

After following suggestions, I'm having:
```
gcr.io/agones-images/agones-ping              0.8.0-9646141     18.9MB
gcr.io/agones-images/agones-sdk               0.8.0-9646141      42.7MB
gcr.io/agones-images/agones-controller        0.8.0-9646141    44.5MB
```
compared to previously: 

```
gcr.io/agones-images/agones-ping              0.7.0-f3cb1ee  31.6MB
gcr.io/agones-images/agones-sdk               0.7.0-f3cb1ee   78.9MB
gcr.io/agones-images/agones-controller        0.7.0-f3cb1ee 82.5MB
```
@Oleksii-Terekhov @aLekSer Good catch guys !