### PR TITLE
specify resource limits on simple-udp/fleet.yaml

### DIFF
--- a/examples/simple-udp/fleet.yaml
+++ b/examples/simple-udp/fleet.yaml
@@ -28,3 +28,10 @@ spec:
           containers:
           - name: simple-udp
             image: gcr.io/agones-images/udp-server:0.5
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "20m"
+              limits:
+                memory: "64Mi"
+                cpu: "20m"


### PR DESCRIPTION
This allows simple-udp to be used for scale testing of GS controller with fewer nodes.