### PR TITLE
Add Agones version into Gameserver Annotation

### DIFF
--- a/pkg/apis/stable/register.go
+++ b/pkg/apis/stable/register.go
@@ -17,4 +17,7 @@ package stable
 const (
 	// GroupName is the Scheme Group Name for Agones Custom Resource Definitions
 	GroupName = "stable.agones.dev"
+	// VersionAnnotation is the key for version annotation
+	// associated with the CRD
+	VersionAnnotation = GroupName + "/sdk-version"
 )

--- a/pkg/apis/stable/v1alpha1/fleet.go
+++ b/pkg/apis/stable/v1alpha1/fleet.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"agones.dev/agones/pkg"
 	"agones.dev/agones/pkg/apis/stable"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,6 +125,11 @@ func (f *Fleet) ApplyDefaults() {
 			f.Spec.Strategy.RollingUpdate.MaxUnavailable = &def
 		}
 	}
+	// Add Agones version into Fleet Annotations
+	if f.ObjectMeta.Annotations == nil {
+		f.ObjectMeta.Annotations = make(map[string]string, 1)
+	}
+	f.ObjectMeta.Annotations[stable.VersionAnnotation] = pkg.Version
 }
 
 // UpperBoundReplicas returns whichever is smaller,

--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/mattbaird/jsonpatch"
 
+	"agones.dev/agones/pkg"
 	"agones.dev/agones/pkg/apis/stable"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -360,6 +361,15 @@ func (gs *GameServer) podObjectMeta(pod *corev1.Pod) {
 		// (and evict the Pod in the process)
 		pod.ObjectMeta.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
 	}
+
+	// Add Agones version into Pod Annotations
+	pod.ObjectMeta.Annotations[stable.VersionAnnotation] = pkg.Version
+	if gs.ObjectMeta.Annotations == nil {
+		gs.ObjectMeta.Annotations = make(map[string]string, 1)
+	}
+	// VersionAnnotation is the annotation that stores
+	// the version of sdk which runs in a sidecar
+	gs.ObjectMeta.Annotations[stable.VersionAnnotation] = pkg.Version
 }
 
 // podScheduling applies the Fleet scheduling strategy to the passed in Pod

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"agones.dev/agones/pkg/apis/stable"
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
 	e2eframework "agones.dev/agones/test/e2e/framework"
 	"github.com/stretchr/testify/assert"
@@ -113,6 +114,8 @@ func TestSDKSetAnnotation(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, gs.ObjectMeta.Annotations["stable.agones.dev/sdk-timestamp"])
+
+	assert.NotEmpty(t, gs.ObjectMeta.Annotations[stable.VersionAnnotation])
 }
 
 func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {


### PR DESCRIPTION
Add "stable.agones.dev/sdk-version" annotation into Gameserver CRD and Pod specification as well as Fleet CRD. So that Sidecar can be retrieved using WatchGameServer() callback. 
Covers #310 As a game server, I want to get the Agones sidecar version. 