### PR TITLE
Extend e2e lock to 30m

### DIFF
--- a/build/e2e-image/entrypoint.sh
+++ b/build/e2e-image/entrypoint.sh
@@ -30,6 +30,6 @@ kubectl port-forward statefulset/consul 8500:8500 &
 echo "Waiting consul port-forward to launch on 8500..."
 timeout 60 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' 127.0.0.1 8500
 echo "consul port-forward launched. Starting e2e tests..."
-consul lock -child-exit-code=true -timeout 5m -try 5m -verbose LockE2E /root/e2e.sh
+consul lock -child-exit-code=true -timeout 30m -try 5m -verbose LockE2E /root/e2e.sh
 killall -q kubectl
 


### PR DESCRIPTION
As we get more PRs, we shouldn't be failing on concurrent builds timing out on e2e, so extending the timeout for now.

Also, e2e takes 6.5 mins at least to complete.