### PR TITLE
Restructure cloudbuild.yaml

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -202,7 +202,7 @@ test-go:
 # Runs end-to-end tests on the current configured cluster
 # For minikube user the minikube-test-e2e targets
 test-e2e: $(ensure-build-image)
-	$(DOCKER_RUN) go test -v -race $(agones_package)/test/e2e/... \
+	$(DOCKER_RUN) go test -v -race $(ARGS) $(agones_package)/test/e2e/... \
 		--kubeconfig /root/.kube/$(kubeconfig_file) \
 		--gameserver-image=$(GS_TEST_IMAGE) \
 		--pullsecret=$(IMAGE_PULL_SECRET)

--- a/build/e2e-image/e2e.sh
+++ b/build/e2e-image/e2e.sh
@@ -17,4 +17,4 @@ set -e
 echo "installing current release"
 DOCKER_RUN= make install
 echo "starting e2e test"
-DOCKER_RUN= make test-e2e
+DOCKER_RUN= make test-e2e ARGS=-parallel=32

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,68 +17,135 @@
 #
 
 steps:
+
+#
+# Creates the initial make + docker build platform
+#
+
 - name: "ubuntu"
   args: ["bash", "-c", "echo 'FROM gcr.io/cloud-builders/docker\nRUN apt-get install make\nENTRYPOINT [\"/usr/bin/make\"]' > Dockerfile.build"]
 - name: "gcr.io/cloud-builders/docker"
   args: ['build', '-f', 'Dockerfile.build', '-t', 'make-docker', '.'] # we need docker and make to run everything.
 - name: "make-docker"
+  id: make-docker
   dir: "build"
   args: ["pull-build-image"] # pull the build image if it exists
+
+#
+# build the e2e test runner
+#
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-f', 'Dockerfile', '-t', 'e2e-runner', '.']
+  dir: 'build/e2e-image'
+  id: build-e2e
+  waitFor: ['-']
+
+#
+# Runs the linter -- but also builds the build image, if not able to download
+#
+
 - name: "make-docker"
+  id: lint
+  waitFor:
+    - make-docker
   dir: "build"
   args: ["lint"] # pull the build image if it exists
-  id: lint
+
+#
+# Run the all the automated tests (except e2e) in parallel
+#
+
 - name: "make-docker"
-  dir: "build"
-  args: [ "-j", "3", "test" ] # run tests, in parallel
-  waitFor: ['lint']
   id: tests
+  waitFor:
+    - lint
+  dir: "build"
+  args: [ "-j", "3", "test" ]
+
+#
+# Push the build image, can run while we do other things.
+#
+
+- name: "make-docker"
+  waitFor:
+    - lint
+  dir: "build"
+  args: ["push-build-image"] # push the build image (which won't do anything if it's already there)
+
+#
+# Build all the images and sdks, and push them up to the repository
+#
+
+- name: "make-docker"
+  id: build
+  waitFor:
+    - lint
+  dir: "build"
+  args: [ "-j", "4", "build"]
+- name: "make-docker"
+  id: push-images
+  waitFor:
+    - build
+  dir: "build"
+  args: [ "-j", "3", "push"]
 
 #
 # Site preview
 #
 
 - name: "make-docker" # build a preview of the website
-  id: "site-static"
+  id: site-static
+  waitFor:
+    - tests
   dir: "build"
   args: ["site-static-preview", "site-gen-app-yaml", "SERVICE=preview"]
-  waitFor: ['tests']
 - name: "ubuntu" # fake a new gopath
-  id: "site-gopath"
+  id: site-gopath
+  waitFor:
+    - site-static
   args: ["bash", "-c", "mkdir -p ./go/src && mv ./site ./go/src && cp -r ./vendor/gopkg.in ./go/src && ls -a ./go/src/site"]
 - name: "gcr.io/cloud-builders/gcloud" # deploy the preview of the website
   id: "deploy-site-static"
+  waitFor:
+    - site-gopath
   dir: "go/src/site"
   args: ["app", "deploy", ".app.yaml", "--no-promote", "--version=$SHORT_SHA"]
-  waitFor: ['site-gopath']
   env:
     - GOPATH=/workspace/go
 
-- name: "make-docker"
-  dir: "build"
-  args: [ "build", "push" ] # build all the things, and push images
-  waitFor: ['lint']
-  id: build
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-f', 'Dockerfile', '-t', 'e2e-runner', '.']
-  dir: 'build/e2e-image'
-  id: build-e2e
-  waitFor: ["lint"]
+#
+# Run the e2e tests
+#
+
 - name: 'e2e-runner'
-  waitFor: ['build','build-e2e']
+  waitFor:
+    - push-images
+    - build-e2e
+
+#
+# Zip up artifacts and push to storage
+#
+
 - name: 'gcr.io/cloud-builders/gsutil'
+  waitFor:
+    - build
+    - tests
   dir: "sdks/cpp/bin"
   args: ['cp', '*.tar.gz', 'gs://agones-artifacts/cpp-sdk']
-  waitFor: ['build', 'tests']
 - name: 'gcr.io/cloud-builders/gsutil'
+  waitFor:
+    - build
+    - tests
   dir: "sdks/cpp/bin"
   args: ['cp', '*.zip', 'gs://agones-artifacts/cpp-sdk']
 - name: 'gcr.io/cloud-builders/gsutil'
+  waitFor:
+    - build
+    - tests
   dir: "cmd/sdk-server/bin"
   args: ['cp', '*.zip', 'gs://agones-artifacts/sdk-server']
-- name: "make-docker"
-  dir: "build"
-  args: ["push-build-image"] # push the build image (which won't do anything if it's already there)
+
 timeout: "1h"
 images: ['gcr.io/$PROJECT_ID/agones-controller', 'gcr.io/$PROJECT_ID/agones-sdk', 'gcr.io/$PROJECT_ID/agones-ping']
 options:


### PR DESCRIPTION
Aim to (a) make the cloudbuild.yaml much more readable so that you can see what is supposed to run in what order and (b) make more things run in parallel to attempt to make the build faster.