### PR TITLE
Test is using gcloud base for e2e works.

### DIFF
--- a/build/e2e-image/Dockerfile
+++ b/build/e2e-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud-slim
+FROM gcr.io/cloud-builders/gcloud
 
 RUN apt-get update && \
     apt-get install -y wget psmisc make gcc python jq zip && \


### PR DESCRIPTION
e2e slim seems to have lost access to Docker.

Let's see if this fixes it.