### PR TITLE
Put CI buiild logs in a public bucket.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -148,5 +148,6 @@ steps:
 
 timeout: "1h"
 images: ['gcr.io/$PROJECT_ID/agones-controller', 'gcr.io/$PROJECT_ID/agones-sdk', 'gcr.io/$PROJECT_ID/agones-ping']
+logsBucket: "gs://agones-build-logs"
 options:
  machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
This is the first step to making it so that we don't have to push the full build log to github, and can instead point to a file (or even the Cloud Build page!)