### PR TITLE
Fix potential data race in allocation counter

### DIFF
--- a/pkg/gameserverallocations/allocationcounter.go
+++ b/pkg/gameserverallocations/allocationcounter.go
@@ -166,11 +166,18 @@ func (ac *AllocationCounter) Run(stop <-chan struct{}) error {
 }
 
 // Counts returns the NodeCount map in a thread safe way
-func (ac *AllocationCounter) Counts() map[string]*NodeCount {
+func (ac *AllocationCounter) Counts() map[string]NodeCount {
 	ac.countMutex.RLock()
 	defer ac.countMutex.RUnlock()
 
-	return ac.counts
+	result := make(map[string]NodeCount, len(ac.counts))
+
+	// return a copy, so it's thread safe
+	for k, v := range ac.counts {
+		result[k] = *v
+	}
+
+	return result
 }
 
 func (ac *AllocationCounter) inc(gs *v1alpha1.GameServer, ready, allocated int64) {

--- a/pkg/gameserverallocations/allocationcounter_test.go
+++ b/pkg/gameserverallocations/allocationcounter_test.go
@@ -177,6 +177,7 @@ func TestAllocationCounterRun(t *testing.T) {
 	assert.Nil(t, err)
 
 	counts := ac.Counts()
+
 	assert.Len(t, counts, 2)
 	assert.Equal(t, int64(1), counts[n1].ready)
 	assert.Equal(t, int64(2), counts[n1].allocated)

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -72,7 +72,7 @@ type Controller struct {
 // findComparator is a comparator function specifically for the
 // findReadyGameServerForAllocation method for determining
 // scheduling strategy
-type findComparator func(bestCount, currentCount *NodeCount) bool
+type findComparator func(bestCount, currentCount NodeCount) bool
 
 // NewController returns a controller for a GameServerAllocation
 func NewController(wh *webhooks.WebHook,
@@ -380,8 +380,8 @@ func (c *Controller) findReadyGameServerForAllocation(gsa *v1alpha1.GameServerAl
 	for nodeName, gs := range allocationSet {
 		count := counts[nodeName]
 		// bestGS == nil: if there is no best GameServer, then this node & GameServer is the always the best
-		if bestGS == nil || comparator(bestCount, count) {
-			bestCount = count
+		if bestGS == nil || comparator(*bestCount, count) {
+			bestCount = &count
 			bestGS = gs
 		}
 	}

--- a/pkg/gameserverallocations/find.go
+++ b/pkg/gameserverallocations/find.go
@@ -16,7 +16,7 @@ package gameserverallocations
 
 // packedComparator prioritises Nodes with GameServers that are allocated, and then Nodes with the most
 // Ready GameServers -- this will bin pack allocated game servers together.
-func packedComparator(bestCount, currentCount *NodeCount) bool {
+func packedComparator(bestCount, currentCount NodeCount) bool {
 	if currentCount.allocated == bestCount.allocated && currentCount.ready > bestCount.ready {
 		return true
 	} else if currentCount.allocated > bestCount.allocated {
@@ -28,6 +28,6 @@ func packedComparator(bestCount, currentCount *NodeCount) bool {
 
 // distributedComparator is the inverse of the packed comparator,
 // looking to distribute allocated gameservers on as many nodes as possible.
-func distributedComparator(bestCount, currentCount *NodeCount) bool {
+func distributedComparator(bestCount, currentCount NodeCount) bool {
 	return !packedComparator(bestCount, currentCount)
 }


### PR DESCRIPTION
Found a rare data race in tests for the allocation counter.

Could have potentially have leaked into production code, so here is a fix.