### PR TITLE
[SECURITY] Update Go to 1.11.5

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -47,7 +47,7 @@ RUN wget -q https://static.rust-lang.org/rustup/archive/1.11.0/${RUST_ARCH}/rust
 
 # install go
 WORKDIR /usr/local
-ENV GO_VERSION=1.11.4
+ENV GO_VERSION=1.11.5
 ENV GOPATH /go
 RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz && mkdir ${GOPATH}

--- a/examples/autoscaler-webhook/Dockerfile
+++ b/examples/autoscaler-webhook/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Gather dependencies and build the executable
-FROM golang:1.11.4 as builder
+FROM golang:1.11.5 as builder
 WORKDIR /go/src/autoscaler-webhook
 
 COPY examples/autoscaler-webhook/main.go .

--- a/examples/simple-udp/Dockerfile
+++ b/examples/simple-udp/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # build
-FROM golang:1.11.4 as builder
+FROM golang:1.11.5 as builder
 WORKDIR /go/src/simple-udp
 
 COPY examples/simple-udp/main.go .


### PR DESCRIPTION
Updating Go tooling, because of security issue in crypto/elliptic.

Details: https://groups.google.com/forum/m/#!msg/golang-announce/mVeX35iXuSw/Flp8FX7QEAAJ