### PR TITLE
PortAllocator.Run() is no longer blocking.

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -261,11 +261,9 @@ func (c *Controller) Run(workers int, stop <-chan struct{}) error {
 	}
 
 	// Run the Port Allocator
-	go func() {
-		if err := c.portAllocator.Run(stop); err != nil {
-			c.logger.WithError(err).Error("error running the port allocator")
-		}
-	}()
+	if err = c.portAllocator.Run(stop); err != nil {
+		return errors.Wrap(err, "error running the port allocator")
+	}
 
 	// Run the Health Controller
 	go c.healthController.Run(stop)


### PR DESCRIPTION
We no longer need the goroutine, so cleaning it up.