### PR TITLE
Speed up creation/deletion of game servers in a set

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -18,6 +18,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
 
 	"agones.dev/agones/pkg/apis/stable"
 	"agones.dev/agones/pkg/apis/stable/v1alpha1"
@@ -73,6 +76,8 @@ type Controller struct {
 	portAllocator          *PortAllocator
 	healthController       *HealthController
 	workerqueue            *workerqueue.WorkerQueue
+	creationWorkerQueue    *workerqueue.WorkerQueue // handles creation only
+	deletionWorkerQueue    *workerqueue.WorkerQueue // handles deletion only
 	allocationMutex        *sync.Mutex
 	stop                   <-chan struct {
 	}
@@ -124,20 +129,24 @@ func NewController(
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	c.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "gameserver-controller"})
 
-	c.workerqueue = workerqueue.NewWorkerQueue(c.syncGameServer, c.logger, stable.GroupName+".GameServerController")
+	c.workerqueue = workerqueue.NewWorkerQueueWithRateLimiter(c.syncGameServer, c.logger, stable.GroupName+".GameServerController", fastRateLimiter())
+	c.creationWorkerQueue = workerqueue.NewWorkerQueueWithRateLimiter(c.syncGameServer, c.logger, stable.GroupName+".GameServerControllerCreation", fastRateLimiter())
+	c.deletionWorkerQueue = workerqueue.NewWorkerQueueWithRateLimiter(c.syncGameServer, c.logger, stable.GroupName+".GameServerControllerDeletion", fastRateLimiter())
 	health.AddLivenessCheck("gameserver-workerqueue", healthcheck.Check(c.workerqueue.Healthy))
+	health.AddLivenessCheck("gameserver-creation-workerqueue", healthcheck.Check(c.creationWorkerQueue.Healthy))
+	health.AddLivenessCheck("gameserver-deletion-workerqueue", healthcheck.Check(c.deletionWorkerQueue.Healthy))
 
 	wh.AddHandler("/mutate", v1alpha1.Kind("GameServer"), admv1beta1.Create, c.creationMutationHandler)
 	wh.AddHandler("/validate", v1alpha1.Kind("GameServer"), admv1beta1.Create, c.creationValidationHandler)
 
 	gsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: c.workerqueue.Enqueue,
+		AddFunc: c.enqueueGameServerBasedOnState,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			// no point in processing unless there is a State change
 			oldGs := oldObj.(*v1alpha1.GameServer)
 			newGs := newObj.(*v1alpha1.GameServer)
 			if oldGs.Status.State != newGs.Status.State || oldGs.ObjectMeta.DeletionTimestamp != newGs.ObjectMeta.DeletionTimestamp {
-				c.workerqueue.Enqueue(newGs)
+				c.enqueueGameServerBasedOnState(newGs)
 			}
 		},
 	})
@@ -166,6 +175,31 @@ func NewController(
 	})
 
 	return c
+}
+
+func (c *Controller) enqueueGameServerBasedOnState(item interface{}) {
+	gs := item.(*v1alpha1.GameServer)
+
+	switch gs.Status.State {
+	case v1alpha1.GameServerStatePortAllocation,
+		v1alpha1.GameServerStateCreating:
+		c.creationWorkerQueue.Enqueue(gs)
+
+	case v1alpha1.GameServerStateShutdown:
+		c.deletionWorkerQueue.Enqueue(gs)
+
+	default:
+		c.workerqueue.Enqueue(gs)
+	}
+}
+
+// fastRateLimiter returns a fast rate limiter, without exponential back-off.
+func fastRateLimiter() workqueue.RateLimiter {
+	const numFastRetries = 5
+	const fastDelay = 20 * time.Millisecond  // first few retries up to 'numFastRetries' are fast
+	const slowDelay = 500 * time.Millisecond // subsequent retries are slow
+
+	return workqueue.NewItemFastSlowRateLimiter(fastDelay, slowDelay, numFastRetries)
 }
 
 // creationMutationHandler is the handler for the mutating webhook that sets the
@@ -268,7 +302,21 @@ func (c *Controller) Run(workers int, stop <-chan struct{}) error {
 	// Run the Health Controller
 	go c.healthController.Run(stop)
 
-	c.workerqueue.Run(workers, stop)
+	// start work queues
+	var wg sync.WaitGroup
+
+	startWorkQueue := func(wq *workerqueue.WorkerQueue) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wq.Run(workers, stop)
+		}()
+	}
+
+	startWorkQueue(c.workerqueue)
+	startWorkQueue(c.creationWorkerQueue)
+	startWorkQueue(c.deletionWorkerQueue)
+	wg.Wait()
 	return nil
 }
 

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -172,11 +172,15 @@ func TestControllerWatchGameServers(t *testing.T) {
 	received := make(chan string)
 	defer close(received)
 
-	c.workerqueue.SyncHandler = func(name string) error {
+	h := func(name string) error {
 		assert.Equal(t, "default/test", name)
 		received <- name
 		return nil
 	}
+
+	c.workerqueue.SyncHandler = h
+	c.creationWorkerQueue.SyncHandler = h
+	c.deletionWorkerQueue.SyncHandler = h
 
 	stop, cancel := agtesting.StartInformers(m, c.gameServerSynced)
 	defer cancel()

--- a/pkg/gameserversets/gameserver_state_cache.go
+++ b/pkg/gameserversets/gameserver_state_cache.go
@@ -1,0 +1,106 @@
+package gameserversets
+
+import (
+	"sync"
+
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// gameServerSetCacheEntry manages a list of items created and deleted locally for a single game server set.
+type gameServerSetCacheEntry struct {
+	mu              sync.Mutex
+	pendingCreation map[string]*v1alpha1.GameServer
+	pendingDeletion map[string]*v1alpha1.GameServer
+}
+
+func (e *gameServerSetCacheEntry) created(gs *v1alpha1.GameServer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.pendingCreation == nil {
+		e.pendingCreation = map[string]*v1alpha1.GameServer{}
+	}
+	e.pendingCreation[gs.Name] = gs.DeepCopy()
+}
+
+func (e *gameServerSetCacheEntry) deleted(gs *v1alpha1.GameServer) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.pendingDeletion == nil {
+		e.pendingDeletion = map[string]*v1alpha1.GameServer{}
+	}
+
+	// Was pending creation, but deleted already.
+	if _, ok := e.pendingCreation[gs.Name]; ok {
+		delete(e.pendingCreation, gs.Name)
+	}
+
+	gsClone := gs.DeepCopy()
+	t := metav1.Now()
+	gsClone.ObjectMeta.DeletionTimestamp = &t
+	e.pendingDeletion[gs.Name] = gsClone
+}
+
+// reconcileWithUpdatedServerList returns a list of game servers for a game server set taking into account
+// the complete list of game servers passed as parameter and a list of pending creations and deletions.
+func (e *gameServerSetCacheEntry) reconcileWithUpdatedServerList(list []*v1alpha1.GameServer) []*v1alpha1.GameServer {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var result []*v1alpha1.GameServer
+
+	found := map[string]bool{}
+
+	for _, gs := range list {
+		if d := e.pendingDeletion[gs.Name]; d != nil {
+			if !gs.ObjectMeta.DeletionTimestamp.IsZero() {
+				// has deletion timestamp - return theirs
+				result = append(result, d)
+				delete(e.pendingDeletion, gs.Name)
+			} else {
+				result = append(result, d)
+			}
+		} else {
+			// object not deleted locally, trust the list.
+			result = append(result, gs)
+		}
+
+		if e.pendingCreation[gs.Name] != nil {
+			// object was pending creation and now showed up in list results, remove local overlay.
+			delete(e.pendingCreation, gs.Name)
+		}
+
+		found[gs.Name] = true
+	}
+
+	// now delete from 'pendingDeletion' all the items that were not found in the result.
+	for gsName := range e.pendingDeletion {
+		if !found[gsName] {
+			// ("GSSC: %v is now fully deleted", gsName)
+			delete(e.pendingDeletion, gsName)
+		}
+	}
+
+	// add all game servers that are pending creation which were not in the list
+	for _, gs := range e.pendingCreation {
+		result = append(result, gs)
+	}
+
+	return result
+}
+
+// gameServerStateCache manages per-GSS cache of items created and deleted by this controller process
+// to compensate for latency due to eventual consistency between client actions and K8s API server.
+type gameServerStateCache struct {
+	cache sync.Map
+}
+
+func (c *gameServerStateCache) forGameServerSet(gsSet *v1alpha1.GameServerSet) *gameServerSetCacheEntry {
+	v, _ := c.cache.LoadOrStore(gsSet.ObjectMeta.Namespace+"/"+gsSet.ObjectMeta.Name, &gameServerSetCacheEntry{})
+	return v.(*gameServerSetCacheEntry)
+}
+
+func (c *gameServerStateCache) deleteGameServerSet(gsSet *v1alpha1.GameServerSet) {
+	c.cache.Delete(gsSet.ObjectMeta.Namespace + "/" + gsSet.ObjectMeta.Name)
+}

--- a/pkg/gameserversets/gameserver_state_cache_test.go
+++ b/pkg/gameserversets/gameserver_state_cache_test.go
@@ -1,0 +1,198 @@
+package gameserversets
+
+import (
+	"sort"
+	"testing"
+
+	"agones.dev/agones/pkg/apis/stable/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var deletionTime = metav1.Now()
+
+func TestGameServerStateCache(t *testing.T) {
+	var cache gameServerStateCache
+	gsSet1 := &v1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "set-1",
+			Namespace: "ns1",
+		},
+	}
+	gsSet1b := &v1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "set-1",
+			Namespace: "ns2",
+		},
+	}
+	gsSet2 := &v1alpha1.GameServerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "set-2",
+			Namespace: "ns1",
+		},
+	}
+
+	entry1 := cache.forGameServerSet(gsSet1)
+	if got, want := entry1, cache.forGameServerSet(gsSet1); got != want {
+		t.Errorf("unexpectedly different entries for the same set")
+	}
+	if got, want := entry1, cache.forGameServerSet(gsSet1b); got == want {
+		t.Errorf("unexpectedly same entries for different sets 1 and 1b")
+	}
+	if got, want := entry1, cache.forGameServerSet(gsSet2); got == want {
+		t.Errorf("unexpectedly same entries for different sets 1 and 2")
+	}
+	if got, want := entry1, cache.forGameServerSet(gsSet1); got != want {
+		t.Errorf("unexpectedly different entries for the same set")
+	}
+	cache.deleteGameServerSet(gsSet1)
+	if got, want := entry1, cache.forGameServerSet(gsSet1); got == want {
+		t.Errorf("unexpectedly same entries for sets 1  before and after deletion")
+	}
+}
+
+func TestGameServerSetCacheEntry(t *testing.T) {
+	gs1 := makeGameServer("gs-1")
+	gs2 := makeGameServer("gs-2")
+
+	cases := []struct {
+		desc                     string
+		setup                    func(c *gameServerSetCacheEntry)
+		list                     []*v1alpha1.GameServer
+		expected                 []*v1alpha1.GameServer
+		expectedPendingCreations int
+		expectedPendingDeletions int
+	}{
+		{
+			desc:     "EmptyList",
+			setup:    func(c *gameServerSetCacheEntry) {},
+			list:     nil,
+			expected: nil,
+		},
+		{
+			desc:                     "LocallyAddedGameServerNotInServerResults",
+			setup:                    func(c *gameServerSetCacheEntry) { c.created(gs1) },
+			list:                     nil,
+			expected:                 []*v1alpha1.GameServer{gs1},
+			expectedPendingCreations: 1,
+		},
+		{
+			desc:                     "LocallyAddedGameServerAnotherOneFoundOnServer",
+			setup:                    func(c *gameServerSetCacheEntry) { c.created(gs1) },
+			list:                     []*v1alpha1.GameServer{gs2},
+			expected:                 []*v1alpha1.GameServer{gs1, gs2},
+			expectedPendingCreations: 1,
+		},
+		{
+			desc:     "LocallyAddedGameServerAlsoFoundOnServer",
+			setup:    func(c *gameServerSetCacheEntry) { c.created(gs1) },
+			list:     []*v1alpha1.GameServer{gs1},
+			expected: []*v1alpha1.GameServer{gs1},
+		},
+		{
+			desc:                     "LocallyDeletedStillFoundOnServer",
+			setup:                    func(c *gameServerSetCacheEntry) { c.deleted(gs1) },
+			list:                     []*v1alpha1.GameServer{gs1},
+			expected:                 []*v1alpha1.GameServer{deleted(gs1)},
+			expectedPendingDeletions: 1,
+		},
+		{
+			desc:     "LocallyDeletedNotFoundOnServer",
+			setup:    func(c *gameServerSetCacheEntry) { c.deleted(gs1) },
+			list:     []*v1alpha1.GameServer{},
+			expected: []*v1alpha1.GameServer{},
+		},
+		{
+			desc: "LocallyCreatedAndDeletedFoundOnServer",
+			setup: func(c *gameServerSetCacheEntry) {
+				c.created(gs1)
+				c.deleted(gs1)
+			},
+			list:                     []*v1alpha1.GameServer{gs1},
+			expected:                 []*v1alpha1.GameServer{deleted(gs1)},
+			expectedPendingDeletions: 1,
+		},
+		{
+			desc: "LocallyCreatedAndDeletedFoundDeletedOnServer",
+			setup: func(c *gameServerSetCacheEntry) {
+				c.created(gs1)
+				c.deleted(gs1)
+			},
+			list:     []*v1alpha1.GameServer{deleted(gs1)},
+			expected: []*v1alpha1.GameServer{deleted(gs1)},
+		},
+		{
+			desc: "LocallyCreatedAndDeletedNotFoundOnServer",
+			setup: func(c *gameServerSetCacheEntry) {
+				c.created(gs1)
+				c.deleted(gs1)
+			},
+			list:     []*v1alpha1.GameServer{},
+			expected: []*v1alpha1.GameServer{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			entry := &gameServerSetCacheEntry{}
+
+			tc.setup(entry)
+			result := entry.reconcileWithUpdatedServerList(tc.list)
+			assert.Equal(t, sortedStatusInfo(result), sortedStatusInfo(tc.expected))
+
+			if got, want := len(entry.pendingCreation), tc.expectedPendingCreations; got != want {
+				t.Errorf("unexpected # of pending creations %v, wanted %v", got, want)
+			}
+			if got, want := len(entry.pendingDeletion), tc.expectedPendingDeletions; got != want {
+				t.Errorf("unexpected # of pending deletions %v, wanted %v", got, want)
+			}
+
+			result2 := entry.reconcileWithUpdatedServerList(result)
+			assert.Equal(t, sortedStatusInfo(result2), sortedStatusInfo(result))
+
+			// now both pending creations and deletions must be zero
+			if got, want := len(entry.pendingCreation), 0; got != want {
+				t.Errorf("unexpected # of pending creations %v, wanted %v", got, want)
+			}
+			if got, want := len(entry.pendingDeletion), 0; got != want {
+				t.Errorf("unexpected # of pending deletions %v, wanted %v", got, want)
+			}
+		})
+	}
+}
+
+func makeGameServer(s string) *v1alpha1.GameServer {
+	return &v1alpha1.GameServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s,
+		},
+	}
+}
+
+func deleted(gs *v1alpha1.GameServer) *v1alpha1.GameServer {
+	gs2 := gs.DeepCopy()
+	gs2.ObjectMeta.DeletionTimestamp = &deletionTime
+	return gs2
+}
+
+type gameServerStatusInfo struct {
+	name    string
+	status  string
+	deleted bool
+}
+
+func sortedStatusInfo(list []*v1alpha1.GameServer) []gameServerStatusInfo {
+	var result []gameServerStatusInfo
+	for _, gs := range list {
+		result = append(result, gameServerStatusInfo{
+			gs.Name,
+			string(gs.Status.State),
+			gs.DeletionTimestamp != nil,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].name < result[j].name
+	})
+	return result
+}


### PR DESCRIPTION
- parallelizing create/delete calls in GSS controller
- creating dedicated worker queues for creation/deletion requests
- replacing default rate limiters with ones that don't have global QPS limit

That, plus general cleanup of GSS controller for readability.

Also, introduced GS state cache, so that actions taken by GSS controller are more precise because they don't rely on stale informer data.