### PR TITLE
Fix stackdriver distribution without bucket bounds

### DIFF
--- a/pkg/metrics/kubernetes_client.go
+++ b/pkg/metrics/kubernetes_client.go
@@ -86,7 +86,7 @@ func init() {
 		Name:        "k8s_client_cache_list_items",
 		Measure:     cacheListItemCountStats,
 		Description: "Count of items in a list from the Kubernetes API.",
-		Aggregation: view.Distribution(),
+		Aggregation: view.Distribution(0),
 	}))
 
 	runtime.Must(view.Register(&view.View{
@@ -107,14 +107,14 @@ func init() {
 		Name:        "k8s_client_cache_watch_duration_seconds",
 		Measure:     cacheWatchesLatencyStats,
 		Description: "Duration of watches on the Kubernetes API.",
-		Aggregation: view.Distribution(),
+		Aggregation: view.Distribution(0),
 	}))
 
 	runtime.Must(view.Register(&view.View{
 		Name:        "k8s_client_cache_watch_events",
 		Measure:     cacheItemsInWatchesCountStats,
 		Description: "Number of items in watches on the Kubernetes API.",
-		Aggregation: view.Distribution(),
+		Aggregation: view.Distribution(0),
 	}))
 
 	runtime.Must(view.Register(&view.View{
@@ -144,7 +144,7 @@ func init() {
 		Name:        "k8s_client_workqueue_latency_seconds",
 		Measure:     workQueueLatencyStats,
 		Description: "How long an item stays in the work queue.",
-		Aggregation: view.Distribution(),
+		Aggregation: view.Distribution(0),
 		TagKeys:     []tag.Key{keyQueueName},
 	}))
 
@@ -152,7 +152,7 @@ func init() {
 		Name:        "k8s_client_workqueue_work_duration_seconds",
 		Measure:     workQueueWorkDurationStats,
 		Description: "How long processing an item from the work queue takes.",
-		Aggregation: view.Distribution(),
+		Aggregation: view.Distribution(0),
 		TagKeys:     []tag.Key{keyQueueName},
 	}))
 

--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -12,7 +12,7 @@ description: >
 Installing Agones creates several [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources),
 which can be accessed and manipulated through the Kubernetes API.
 
-Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/client-libraries/), however,
+Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/using-api/client-libraries/), however,
 at time of writing, only
 the [Go](https://github.com/kubernetes/client-go) and
 [Python](https://github.com/kubernetes-client/python/) clients are documented to support accessing CRDs.


### PR DESCRIPTION
New k8s metrics results in error in Stackdriver exporter. In order to
fix it we need to define two infinite buckets with a delimiter of 0.
Fix was verified in Stackdriver dashboard.

Fix was proposed [here](https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/issues/41#issuecomment-421154451)
```
The documentation is here: https://godoc.org/go.opencensus.io/stats/view#Distribution . 
The problem is although OpenCensus allows Distribution with no bucket bounds,
 Stackdriver doesn't support it.
```