### PR TITLE
Remove the custom kubectl commands from quickstarts

### DIFF
--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -53,17 +53,17 @@ kubectl get fleet
 It should look something like this:
 
 ```
-NAME         AGE
-simple-udp   5m
+NAME         SCHEDULING   DESIRED   CURRENT   ALLOCATED   READY     AGE
+simple-udp   Packed       2         3         0           2         9m
 ```
 
 You can also see the GameServers that have been created by the Fleet by running `kubectl get gameservers`,
 the GameServer will be prefixed by `simple-udp`.
 
 ```
-NAME                     AGE
-simple-udp-xvp4n-jvhbm   36s
-simple-udp-xvp4n-x6z5m   36s
+NAME                     STATE     ADDRESS            PORT   NODE      AGE
+simple-udp-llg4x-rx6rc   Ready     192.168.122.205    7752   minikube   9m
+simple-udp-llg4x-v6g2r   Ready     192.168.122.205    7623   minikube   9m
 ```
 
 For the full details of the YAML file head to the [Fleet Specification Guide]({{< ref "/docs/Reference/fleet.md#fleet-specification" >}})
@@ -146,12 +146,12 @@ Run `kubectl scale fleet simple-udp --replicas=5` to change Replicas count from 
 If we now run `kubectl get gameservers` we should see 5 `GameServers` prefixed by `simple-udp`.
 
 ```
-NAME                     AGE
-simple-udp-xvp4n-jvhbm   11m
-simple-udp-xvp4n-x6z5m   11m
-simple-udp-xvp4n-z8znu   36s
-simple-udp-xvp4n-a6z0e   36s
-simple-udp-xvp4n-i6bnm   36s
+NAME                     STATE    ADDRESS           PORT    NODE       AGE
+simple-udp-sdhzn-kcmh6   Ready    192.168.122.205   7191    minikube   52m
+simple-udp-sdhzn-pdpk5   Ready    192.168.122.205   7752    minikube   53m
+simple-udp-sdhzn-r4d6x   Ready    192.168.122.205   7623    minikube   52m
+simple-udp-sdhzn-wng5k   Ready    192.168.122.205   7709    minikube   53m
+simple-udp-sdhzn-wnhsw   Ready    192.168.122.205   7478    minikube   52m
 ```
 
 ### 4. Allocate a Game Server from the Fleet
@@ -238,12 +238,12 @@ kubectl get gs
 This will get you a list of all the current `GameSevers` and their `Status.State`.
 
 ```
-NAME                     STATE       ADDRESS           PORT      NODE       AGE
-simple-udp-sdhzn-kcmh6   Ready       192.168.122.205   7191      minikube   52m
-simple-udp-sdhzn-pdpk5   Ready       192.168.122.205   7752      minikube   53m
-simple-udp-sdhzn-r4d6x   Allocated   192.168.122.205   7623      minikube   52m
-simple-udp-sdhzn-wng5k   Ready       192.168.122.205   7709      minikube   53m
-simple-udp-sdhzn-wnhsw   Ready       192.168.122.205   7478      minikube   52m
+NAME                     STATE       ADDRESS           PORT   NODE      AGE
+simple-udp-sdhzn-kcmh6   Ready       192.168.122.205   7191   minikube  52m
+simple-udp-sdhzn-pdpk5   Ready       192.168.122.205   7752   minikube  53m
+simple-udp-sdhzn-r4d6x   Allocated   192.168.122.205   7623   minikube  52m
+simple-udp-sdhzn-wng5k   Ready       192.168.122.205   7709   minikube  53m
+simple-udp-sdhzn-wnhsw   Ready       192.168.122.205   7478   minikube  52m
 ```
 {{% /feature %}}
 
@@ -345,18 +345,18 @@ allocated a `GameServer` out of the fleet, and you can now connect your players 
 A handy trick for checking to see how many `GameServers` you have `Allocated` vs `Ready`, run the following:
 
 ```
-kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+kubectl get gs
 ```
 
 This will get you a list of all the current `GameSevers` and their `Status > State`.
 
 ```
-NAME                     STATUS      IP               PORT
-simple-udp-tfqn7-c9tqz   Ready       192.168.39.150   [map[name:default port:7136]]
-simple-udp-tfqn7-g8fhq   Allocated   192.168.39.150   [map[name:default port:7148]]
-simple-udp-tfqn7-p8wnl   Ready       192.168.39.150   [map[name:default port:7453]]
-simple-udp-tfqn7-t6bwp   Ready       192.168.39.150   [map[name:default port:7228]]
-simple-udp-tfqn7-wkb7b   Ready       192.168.39.150   [map[name:default port:7226]]
+NAME                     STATE       ADDRESS          PORT   NODE        AGE
+simple-udp-tfqn7-c9tqz   Ready       192.168.39.150   7136   minikube    52m
+simple-udp-tfqn7-g8fhq   Allocated   192.168.39.150   7148   minikube    53m
+simple-udp-tfqn7-p8wnl   Ready       192.168.39.150   7453   minikube    52m
+simple-udp-tfqn7-t6bwp   Ready       192.168.39.150   7228   minikube    53m
+simple-udp-tfqn7-wkb7b   Ready       192.168.39.150   7226   minikube    52m
 ```
 
 ### 5. Scale down the Fleet
@@ -379,14 +379,14 @@ Run `kubectl scale fleet simple-udp --replicas=0` to change Replicas count from 
 
 It may take a moment for all the `GameServers` to shut down, so let's watch them all and see what happens:
 ```
-watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+watch kubectl get gs
 ```
 
 Eventually, one by one they will be removed from the list, and you should simply see:
 
 ```
-NAME                     STATUS      IP               PORT
-simple-udp-tfqn7-g8fhq   Allocated   192.168.39.150   [map[name:default port:7148]]
+NAME                     STATUS      ADDRESS          PORT    NODE       AGE
+simple-udp-tfqn7-g8fhq   Allocated   192.168.39.150   7148    minikube   55m
 ```
 
 That lone `Allocated` `GameServer` is left all alone, but still running!
@@ -443,15 +443,15 @@ kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/{
 
 We should now have four `Ready` `GameServers` and one `Allocated`.
 
-We can check this by running `kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports`.
+We can check this by running `kubectl get gs`.
 
 ```
-NAME                     STATUS      IP               PORT
-simple-udp-tfqn7-c9tz7   Ready       192.168.39.150   [map[name:default port:7136]]
-simple-udp-tfqn7-g8fhq   Allocated   192.168.39.150   [map[name:default port:7148]]
-simple-udp-tfqn7-n0wnl   Ready       192.168.39.150   [map[name:default port:7453]]
-simple-udp-tfqn7-hiiwp   Ready       192.168.39.150   [map[name:default port:7228]]
-simple-udp-tfqn7-w8z7b   Ready       192.168.39.150   [map[name:default port:7226]]
+NAME                     STATE       ADDRESS          PORT   NODE       AGE 
+simple-udp-tfqn7-c9tz7   Ready       192.168.39.150   7136   minikube   5m       
+simple-udp-tfqn7-g8fhq   Allocated   192.168.39.150   7148   minikube   5m   
+simple-udp-tfqn7-n0wnl   Ready       192.168.39.150   7453   minikube   5m   
+simple-udp-tfqn7-hiiwp   Ready       192.168.39.150   7228   minikube   5m   
+simple-udp-tfqn7-w8z7b   Ready       192.168.39.150   7226   minikube   5m   
 ```
 
 In production, we'd likely be changing a `containers > image` configuration to update our `Fleet`
@@ -463,7 +463,7 @@ with a Container Port of `6000`.
 
 > NOTE: This will make it such that you can no longer connect to the simple-udp game server.  
 
-Run `watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,CONTAINERPORT:.spec.ports[0].containerPort`
+Run `watch kubectl get gs`
 until you can see that there are
 one of `7654`, which is the `Allocated` `GameServer`, and four instances to `6000` which
 is the new configuration.

--- a/site/content/en/docs/Getting Started/create-fleetautoscaler.md
+++ b/site/content/en/docs/Getting Started/create-fleetautoscaler.md
@@ -150,16 +150,16 @@ Last Scale Time has been updated, and a scaling event has been logged.
 Double-check the actual number of game server instances and status by running
 
 ```
-kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+kubectl get gs
 ``` 
 
 This will get you a list of all the current `GameSevers` and their `Status > State`.
 
 ```
-NAME                     STATUS      IP             PORT
-simple-udp-mzhrl-hz8wk   Allocated   10.30.64.99    [map[name:default port:7131]]
-simple-udp-mzhrl-k6jg5   Ready       10.30.64.100   [map[name:default port:7243]]
-simple-udp-mzhrl-n2sk2   Ready       10.30.64.168   [map[name:default port:7658]]
+NAME                     STATE       ADDRESS        PORT     NODE        AGE
+simple-udp-mzhrl-hz8wk   Allocated   10.30.64.99    7131     minikube    5m
+simple-udp-mzhrl-k6jg5   Ready       10.30.64.100   7243     minikube    5m  
+simple-udp-mzhrl-n2sk2   Ready       10.30.64.168   7658     minikube    5m
 ``` 
 
 ### 5. Shut the allocated instance down
@@ -223,15 +223,15 @@ might stay a bit in 'Unhealthy' state (and its pod in 'Terminating' until it get
 Double-check the actual number of game server instances and status by running
 
 ```
-kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+kubectl get gs
 ``` 
 
 This will get you a list of all the current `GameSevers` and their `Status > State`.
 
 ```
-NAME                     STATUS    IP             PORT
-simple-udp-mzhrl-k6jg5   Ready     10.30.64.100   [map[name:default port:7243]]
-simple-udp-mzhrl-t7944   Ready     10.30.64.168   [map[port:7561 name:default]]
+NAME                     STATE     ADDRESS        PORT    NODE       AGE
+simple-udp-mzhrl-k6jg5   Ready     10.30.64.100   7243    minikube   5m
+simple-udp-mzhrl-t7944   Ready     10.30.64.168   7561    minikube   5m
 ``` 
 
 ### 7. Change autoscaling parameters
@@ -240,18 +240,18 @@ We can also change the configuration of the `FleetAutoscaler` of the running `Fl
 applied live, without interruptions of service.
 
 Run `kubectl edit fleetautoscaler simple-udp-autoscaler` and set the `bufferSize` field to `5`. 
-
-Let's look at the list of game servers again. Run `watch kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports`
+]
+Let's look at the list of game servers again. Run `watch kubectl get gs`
 until you can see that are 5 ready server instances:
 
 ```
-NAME                     STATUS    IP             PORT
-simple-udp-mzhrl-7jpkp   Ready     10.30.64.100   [map[name:default port:7019]]
-simple-udp-mzhrl-czt8v   Ready     10.30.64.168   [map[name:default port:7556]]
-simple-udp-mzhrl-k6jg5   Ready     10.30.64.100   [map[name:default port:7243]]
-simple-udp-mzhrl-nb8h2   Ready     10.30.64.168   [map[name:default port:7357]]
-simple-udp-mzhrl-qspb6   Ready     10.30.64.99    [map[name:default port:7859]]
-simple-udp-mzhrl-zg9rq   Ready     10.30.64.99    [map[name:default port:7745]]
+NAME                     STATE     ADDRESS        PORT    NODE         AGE
+simple-udp-mzhrl-7jpkp   Ready     10.30.64.100   7019    minikube     5m
+simple-udp-mzhrl-czt8v   Ready     10.30.64.168   7556    minikube     5m
+simple-udp-mzhrl-k6jg5   Ready     10.30.64.100   7243    minikube     5m
+simple-udp-mzhrl-nb8h2   Ready     10.30.64.168   7357    minikube     5m
+simple-udp-mzhrl-qspb6   Ready     10.30.64.99    7859    minikube     5m
+simple-udp-mzhrl-zg9rq   Ready     10.30.64.99    7745    minikube     5m
 ```
 
 ## Next Steps

--- a/site/content/en/docs/Getting Started/create-gameserver.md
+++ b/site/content/en/docs/Getting Started/create-gameserver.md
@@ -49,15 +49,15 @@ kubectl get gameservers
 It should look something like this:
 
 ```
-NAME         AGE
-simple-udp   5m
+NAME             STATE     ADDRESS          PORT   NODE     AGE
+simple-udp       Ready     192.168.99.100   7614   minikube  5m
 ```
 
 You can also see the [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod/) that got created by running `kubectl get pods`, the Pod will be prefixed by `simple-udp`.
 
 ```
-NAME                                     READY     STATUS    RESTARTS   AGE
-simple-udp-vwxpt                         2/2       Running   0          5m
+NAME                READY     STATUS    RESTARTS   AGE
+simple-udp-vwxpt    2/2       Running   0          5m
 ```
 
 As you can see above it says `READY: 2/2` this means there are two containers running in this Pod, this is because Agones injected the SDK sidecar for readiness and health checking of your Game Server.
@@ -134,14 +134,14 @@ You might also be interested to see the `Events` section, which outlines when va
 Let's retrieve the IP address and the allocated port of your Game Server :
 
 ```
-kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+kubectl get gs
 ```
 
 This should ouput your Game Server IP address and ports, eg:
 
 ```
-NAME         STATUS    IP               PORT
-simple-udp   Ready     192.168.99.100   [map[name:default port:7614]]
+NAME         STATE     ADDRESS          PORT   NODE       AGE
+simple-udp   Ready     192.168.99.100   7614   minikube   5m
 ```
 
 ### 3. Connect to the GameServer

--- a/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
+++ b/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
@@ -204,11 +204,11 @@ Double-check the actual number of game server instances and status by running:
 This will get you a list of all the current `GameSevers` and their `Status > State`.
 
 ```
-NAME                     STATUS      IP              PORT
-simple-udp-dmkp4-8pkk2   Ready       35.247.13.175   [map[name:default port:7386]]
-simple-udp-dmkp4-b7x87   Allocated   35.247.13.175   [map[name:default port:7219]]
-simple-udp-dmkp4-r4qtt   Allocated   35.247.13.175   [map[name:default port:7220]]
-simple-udp-dmkp4-rsr6n   Ready       35.247.13.175   [map[name:default port:7297]]
+NAME                     STATE       ADDRESS         PORT     NODE        AGE
+simple-udp-dmkp4-8pkk2   Ready       35.247.13.175   7386     minikube     5m
+simple-udp-dmkp4-b7x87   Allocated   35.247.13.175   7219     minikube     5m
+simple-udp-dmkp4-r4qtt   Allocated   35.247.13.175   7220     minikube     5m
+simple-udp-dmkp4-rsr6n   Ready       35.247.13.175   7297     minikube     5m
 ```
 
 #### 7. Check down scaling using Webhook Autoscaler policy
@@ -242,9 +242,9 @@ kubectl get gs -n default
 ```
 
 ```
-NAME                     STATUS      IP               PORT
-simple-udp-884fg-6q5sk   Ready       35.247.117.202   7373
-simple-udp-884fg-b7l58   Allocated   35.247.117.202   7766
+NAME                     STATUS      ADDRESS          PORT     NODE       AGE
+simple-udp-884fg-6q5sk   Ready       35.247.117.202   7373     minikube   5m
+simple-udp-884fg-b7l58   Allocated   35.247.117.202   7766     minikube   5m
 ```
 
 #### 8. Cleanup
@@ -404,11 +404,9 @@ Double-check the actual number of game server instances and status by running:
 This will get you a list of all the current `GameSevers` and their `Status > State`.
 
 ```
-NAME                     STATE       ADDRESS         PORT      NODE                                      AGE
-simple-udp-njmr7-2t4nx   Ready       35.203.159.68   7330      gke-test-cluster2-default-55044752-zt63   1m
-simple-udp-njmr7-65rp6   Allocated   35.203.159.68   7294      gke-test-cluster2-default-55044752-zt63   4m
-simple-udp-njmr7-klgtt   Ready       35.203.159.68   7323      gke-test-cluster2-default-55044752-zt63   1m
-simple-udp-njmr7-lglsr   Allocated   35.203.159.68   7009      gke-test-cluster2-default-55044752-zt63   4m
+NAME                     STATE       ADDRESS         PORT      NODE      AGE
+simple-udp-njmr7-2t4nx   Ready       35.203.159.68   7330      minikube   1m
+simple-udp-njmr7-65rp6   Allocated   35.203.159.68   7294      minikube   4m
 ```
 
 #### 8. Cleanup

--- a/site/content/en/docs/Tutorials/allocator-service-go.md
+++ b/site/content/en/docs/Tutorials/allocator-service-go.md
@@ -265,14 +265,14 @@ status:
 ### 9. Check Game Servers
 Let's make sure that we have one or more Game Servers in a ready state by running this command:
 ```
-kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
+kubectl get gs
 ```
 
 For a fleet of 2 replicas, you should see 2 Game Servers with a Status of Ready:
 ```
-NAME                     STATUS    IP               PORT
-simple-udp-s2snf-765bc   Ready     35.231.204.26    [map[name:default port:7260]]
-simple-udp-s2snf-vf6l8   Ready     35.196.162.169   [map[name:default port:7591]]
+NAME                     STATE     ADDRESS           PORT    NODE       AGE                                
+simple-udp-s2snf-765bc   Ready     35.231.204.26     7260    minikube   5m
+simple-udp-s2snf-vf6l8   Ready     35.196.162.169    7591    minikube   5m
 ```
 
 If there is no fleet, please review [Create a Game Server Fleet]({{< relref "../Getting Started/create-fleet.md" >}}).
@@ -298,9 +298,9 @@ curl: (35) error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake fai
 
 Check the Game Servers again, and notice the Allocated Status.  You should see something like this:
 ```
-NAME                     STATUS      IP               PORT
-simple-udp-s2snf-765bc   Allocated   35.231.204.26    [map[name:default port:7260]]
-simple-udp-s2snf-vf6l8   Ready       35.196.162.169   [map[name:default port:7591]]
+NAME                     STATUS      ADDRESS          PORT    NODE      AGE
+simple-udp-s2snf-765bc   Allocated   35.231.204.26    7260    minikube   5m
+simple-udp-s2snf-vf6l8   Ready       35.196.162.169   7591    minikube   5m
 ```
 
 Congratulations, your call to the API has allocated a Game Server from your simple-udp Fleet!


### PR DESCRIPTION
Issue #521 

Replace custom kubectl commands 
`kubectl get gs -o=custom-columns=NAME:.metadata.name,STATUS:.status.state,IP:.status.address,PORT:.status.ports
`

with `kubectl get gs`