### PR TITLE
CloudBuild for a "development" subdomain

### DIFF
--- a/site/cloudbuild.yaml
+++ b/site/cloudbuild.yaml
@@ -32,17 +32,33 @@ steps:
   args: ["pull-build-image"] # since we are past CI build, we can assume that the build image exists.
 
 #
-# Build site and deploy
+# Build production site and deploy
 #
 
 - name: "make-docker" # build production version of the site
   dir: "build"
   args: ["site-static", "site-gen-app-yaml", "ENV=HUGO_ENV=production"]
 - name: "ubuntu" # fake a new gopath
-  args: ["bash", "-c", "mkdir -p ./go/src && mv ./site ./go/src && cp -r ./vendor/gopkg.in ./go/src && ls -a ./go/src/site"]
+  args: ["bash", "-c", "mkdir -p ./go/src && cp -r ./site ./go/src && cp -r ./vendor/gopkg.in ./go/src && ls -a ./go/src/site"]
 - name: "gcr.io/cloud-builders/gcloud" # deploy the website
   dir: "go/src/site"
   args: ["app", "deploy", ".app.yaml", "--promote", "--version=$SHORT_SHA"]
   env:
     - GOPATH=/workspace/go
+
+#
+# Build development site and deploy
+#
+
+- name: "make-docker" # build a preview of the website
+  dir: "build"
+  args: ["site-static-preview", "site-gen-app-yaml", "SERVICE=development"]
+- name: "ubuntu" # fake a new gopath
+  args: ["bash", "-c", "rm -r ./go/src && mkdir -p ./go/src && cp -r ./site ./go/src && cp -r ./vendor/gopkg.in ./go/src && ls -a ./go/src/site"]
+- name: "gcr.io/cloud-builders/gcloud" # deploy the preview of the website
+  dir: "go/src/site"
+  args: ["app", "deploy", ".app.yaml", "--promote", "--version=$SHORT_SHA"]
+  env:
+    - GOPATH=/workspace/go
+
 tags: ["site"]


### PR DESCRIPTION
Once this is live, we can setup a development.agones.dev that has the latest version of site from master live at all times.

This also makes documentation for release candidates easier, as we can point them at this development release site.