### PR TITLE
Changed how GameServer POD names are generated

### DIFF
--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -333,10 +333,10 @@ func (gs *GameServer) Pod(sidecars ...corev1.Container) (*corev1.Pod, error) {
 
 // podObjectMeta configures the pod ObjectMeta details
 func (gs *GameServer) podObjectMeta(pod *corev1.Pod) {
-	// Switch to GenerateName, so that we always get a Unique name for the Pod, and there
-	// can be no collisions
-	pod.ObjectMeta.GenerateName = gs.ObjectMeta.Name + "-"
-	pod.ObjectMeta.Name = ""
+	pod.ObjectMeta.GenerateName = ""
+	// Pods inherit the name of their gameserver. It's safe since there's
+	// a guarantee that pod won't outlive its parent.
+	pod.ObjectMeta.Name = gs.ObjectMeta.Name
 	// Pods for GameServers need to stay in the same namespace
 	pod.ObjectMeta.Namespace = gs.ObjectMeta.Namespace
 	// Make sure these are blank, just in case

--- a/pkg/apis/stable/v1alpha1/gameserver_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserver_test.go
@@ -261,7 +261,7 @@ func TestGameServerPod(t *testing.T) {
 
 	pod, err := fixture.Pod()
 	assert.Nil(t, err, "Pod should not return an error")
-	assert.Equal(t, fixture.ObjectMeta.Name+"-", pod.ObjectMeta.GenerateName)
+	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 	assert.Equal(t, fixture.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
 	assert.Equal(t, "gameserver", pod.ObjectMeta.Labels[stable.GroupName+"/role"])
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Labels[GameServerPodLabel])
@@ -277,7 +277,7 @@ func TestGameServerPod(t *testing.T) {
 	fixture.Spec.Template.Spec.ServiceAccountName = "other-agones-sdk"
 	pod, err = fixture.Pod(sidecar)
 	assert.Nil(t, err, "Pod should not return an error")
-	assert.Equal(t, fixture.ObjectMeta.Name+"-", pod.ObjectMeta.GenerateName)
+	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 	assert.Len(t, pod.Spec.Containers, 2, "Should have two containers")
 	assert.Equal(t, "other-agones-sdk", pod.Spec.ServiceAccountName)
 	assert.Equal(t, "container", pod.Spec.Containers[0].Name)
@@ -290,7 +290,7 @@ func TestGameServerPodObjectMeta(t *testing.T) {
 		Spec: GameServerSpec{Container: "goat"}}
 
 	f := func(t *testing.T, gs *GameServer, pod *corev1.Pod) {
-		assert.Equal(t, gs.ObjectMeta.Name+"-", pod.ObjectMeta.GenerateName)
+		assert.Equal(t, gs.ObjectMeta.Name, pod.ObjectMeta.Name)
 		assert.Equal(t, gs.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
 		assert.Equal(t, GameServerLabelRole, pod.ObjectMeta.Labels[RoleLabel])
 		assert.Equal(t, "gameserver", pod.ObjectMeta.Labels[stable.GroupName+"/role"])

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -481,6 +481,10 @@ func (c *Controller) createGameServerPod(gs *v1alpha1.GameServer) (*v1alpha1.Gam
 
 	c.logger.WithField("pod", pod).Info("creating Pod for GameServer")
 	pod, err = c.podGetter.Pods(gs.ObjectMeta.Namespace).Create(pod)
+	if k8serrors.IsAlreadyExists(err) {
+		c.recorder.Event(gs, corev1.EventTypeNormal, string(gs.Status.State), "Pod already exists, reused")
+		return gs, nil
+	}
 	if err != nil {
 		if k8serrors.IsInvalid(err) {
 			c.logger.WithField("pod", pod).WithField("gameserver", gs).Errorf("Pod created is invalid")

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -81,7 +81,7 @@ func TestControllerSyncGameServer(t *testing.T) {
 			pod := ca.GetObject().(*corev1.Pod)
 			pod.Spec.NodeName = node.ObjectMeta.Name
 			podCreated = true
-			assert.Equal(t, fixture.ObjectMeta.Name+"-", pod.ObjectMeta.GenerateName)
+			assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 			watchPods.Add(pod)
 			// wait for the change to propagate
 			assert.True(t, cache.WaitForCacheSync(context.Background().Done(), mocks.KubeInformerFactory.Core().V1().Pods().Informer().HasSynced))
@@ -694,7 +694,7 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 			ca := action.(k8stesting.CreateAction)
 			pod := ca.GetObject().(*corev1.Pod)
 
-			assert.Equal(t, fixture.ObjectMeta.Name+"-", pod.ObjectMeta.GenerateName)
+			assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 			assert.Equal(t, fixture.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
 			assert.Equal(t, "gameserver", pod.ObjectMeta.Labels[stable.GroupName+"/role"])
 			assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Labels[v1alpha1.GameServerPodLabel])


### PR DESCRIPTION
Instead of generating name based on GS prefix, we take GS name as-is.
This is safe, since Pods are owned by Gameservers, so their lifetime is a subset of that of GS, thus we won't have accidental pod name collisions.

This fixes #490 