### PR TITLE
Added very simple stress test which scales fleets up/down and basic stress test harness

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -48,6 +48,10 @@ GCP_BUCKET_CHARTS ?= agones-chart
 MINIKUBE_PROFILE ?= agones
 GO_BUILD_TAGS ?= none
 
+# Specify stress test level 1..100
+# STRESS_TEST_LEVEL=n requires capacity between 50*n up to 100*n simple-udp Game Servers.
+STRESS_TEST_LEVEL=20
+
 # kind cluster name to use
 KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=kind-$(KIND_PROFILE)-control-plane
@@ -216,6 +220,16 @@ test-e2e: $(ensure-build-image)
 	$(GO_TEST) $(agones_package)/test/e2e $(ARGS) $(GO_E2E_TEST_ARGS) \
 		--gameserver-image=$(GS_TEST_IMAGE) \
 		--pullsecret=$(IMAGE_PULL_SECRET)
+
+# Runs end-to-end stress tests on the current configured cluster
+# For minikube user the minikube-stress-test-e2e targets
+stress-test-e2e: $(ensure-build-image)
+	$(GO_TEST) $(agones_package)/test/e2e $(ARGS) $(GO_E2E_TEST_ARGS) \
+		-timeout 1h \
+		-run '.*StressTest.*' \
+		--gameserver-image=$(GS_TEST_IMAGE) \
+		--pullsecret=$(IMAGE_PULL_SECRET) \
+		--stress $(STRESS_TEST_LEVEL)
 
 # Run test on install yaml - make sure there is no change
 # mostly this is for CI
@@ -609,6 +623,10 @@ minikube-transfer-image:
 # Runs e2e tests against our minikube
 minikube-test-e2e: DOCKER_RUN_ARGS=--network=host -v $(minikube_cert_mount)
 minikube-test-e2e: minikube-agones-profile test-e2e
+
+# Runs stress tests against our minikube
+minikube-stress-test-e2e: DOCKER_RUN_ARGS=--network=host -v $(minikube_cert_mount)
+minikube-stress-test-e2e: minikube-agones-profile stress-test-e2e
 
 # prometheus on minkube 
 # we have to disable PVC as it's not supported on minkube.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -48,10 +48,11 @@ type Framework struct {
 	AgonesClient    versioned.Interface
 	GameServerImage string
 	PullSecret      string
+	StressTestLevel int
 }
 
 // New setups a testing framework using a kubeconfig path and the game server image to use for testing.
-func New(kubeconfig, gsimage string, pullSecret string) (*Framework, error) {
+func New(kubeconfig, gsimage string, pullSecret string, stressTestLevel int) (*Framework, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "build config from flags failed")
@@ -72,6 +73,7 @@ func New(kubeconfig, gsimage string, pullSecret string) (*Framework, error) {
 		AgonesClient:    agonesClient,
 		GameServerImage: gsimage,
 		PullSecret:      pullSecret,
+		StressTestLevel: stressTestLevel,
 	}, nil
 }
 
@@ -137,7 +139,7 @@ func (f *Framework) WaitForFleetCondition(t *testing.T, flt *v1alpha1.Fleet, con
 	})
 	if err != nil {
 		logrus.WithField("fleet", flt.Name).WithError(err).Info("error waiting for fleet condition")
-		t.Fatal("error waiting for fleet condition")
+		t.Fatalf("error waiting for fleet condition on fleet %v", flt.Name)
 	}
 }
 

--- a/test/e2e/framework/perf.go
+++ b/test/e2e/framework/perf.go
@@ -1,0 +1,65 @@
+package framework
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// PerfResults aggregates performance test results.
+// The AddSample() method is safe for concurrent use by multiple goroutines.
+type PerfResults struct {
+	mu      sync.Mutex
+	samples []time.Duration
+
+	firstSampleTime time.Time
+	lastSampleTime  time.Time
+}
+
+// AddSample adds a single time measurement.
+func (p *PerfResults) AddSample(d time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	n := time.Now()
+	if len(p.samples) == 0 {
+		p.firstSampleTime = n
+	}
+	p.lastSampleTime = n
+	p.samples = append(p.samples, d)
+}
+
+// Report outputs performance report to log.
+func (p *PerfResults) Report(name string) {
+	if len(p.samples) == 0 {
+		return
+	}
+
+	sort.Slice(p.samples, func(i, j int) bool {
+		return p.samples[i] < p.samples[j]
+	})
+
+	var sum time.Duration
+	for _, s := range p.samples {
+		sum += s
+	}
+
+	avg := time.Duration(int64(sum) / int64(len(p.samples)))
+	logrus.
+		WithField("avg", avg).
+		WithField("count", len(p.samples)).
+		WithField("min", p.samples[0].Seconds()).
+		WithField("max", p.samples[len(p.samples)-1].Seconds()).
+		WithField("p50", p.samples[len(p.samples)*500/1001].Seconds()).
+		WithField("p90", p.samples[len(p.samples)*900/1001].Seconds()).
+		WithField("p95", p.samples[len(p.samples)*950/1001].Seconds()).
+		WithField("p99", p.samples[len(p.samples)*990/1001].Seconds()).
+		WithField("p999", p.samples[len(p.samples)*999/1001].Seconds()).
+		WithField("duration", p.lastSampleTime.Sub(p.firstSampleTime).Seconds()).
+		Info(name)
+
+	// TODO - use something like Fortio ("fortio.org/fortio/stats") to
+	// generate histogram for long-term storage and analysis.
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 		"gameserver image to use for those tests, gcr.io/agones-images/udp-server:0.6")
 	pullSecret := flag.String("pullsecret", "",
 		"optional secret to be used for pulling the gameserver and/or Agones SDK sidecar images")
+	stressTestLevel := flag.Int("stress", 0, "enable stress test at given level 0-100")
 
 	flag.Parse()
 
@@ -45,7 +46,7 @@ func TestMain(m *testing.M) {
 		exitCode int
 	)
 
-	if framework, err = e2eframework.New(*kubeconfig, *gsimage, *pullSecret); err != nil {
+	if framework, err = e2eframework.New(*kubeconfig, *gsimage, *pullSecret, *stressTestLevel); err != nil {
 		log.Printf("failed to setup framework: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
The same test is used during regular e2e tests, except it runs just a few iterations on smaller fleets.

To run stress test simply invoke `make stress-test-e2e` optionally passing `STRESS_TEST_LEVEL`, which controls the fleet sizes to be used (1..100, defaults to 20). Depending on stress test level, you may need a cluster with lots of capacity.

By convention 'make stress-test-e2e' runs all test cases whose names include 'StressTest' and ignores everything else.