### PR TITLE
Remove the mutex usage for Delete GS in both GS and GSS controllers

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -674,12 +674,9 @@ func (c *Controller) syncGameServerShutdownState(gs *v1alpha1.GameServer) error 
 	}
 
 	c.logger.WithField("gs", gs).Info("Syncing Shutdown State")
-	// be explicit about where to delete. We only need to wait for the Pod to be removed, which we handle with our
-	// own finalizer.
+	// be explicit about where to delete.
 	p := metav1.DeletePropagationBackground
-	c.allocationMutex.Lock()
 	err := c.gameServerGetter.GameServers(gs.ObjectMeta.Namespace).Delete(gs.ObjectMeta.Name, &metav1.DeleteOptions{PropagationPolicy: &p})
-	c.allocationMutex.Unlock()
 	if err != nil {
 		return errors.Wrapf(err, "error deleting Game Server %s", gs.ObjectMeta.Name)
 	}


### PR DESCRIPTION
AllocationMutex usage is unnecessary for Delete GS since the Shutdown state of GS prevents race conditions. Also remove direct Delete of GS and change it with setting the status of GS to Shutdown and let the GS controller to take care of it.