### PR TITLE
Improve allocation performance

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -50,7 +50,7 @@ GO_BUILD_TAGS ?= none
 
 # Specify stress test level 1..100
 # STRESS_TEST_LEVEL=n requires capacity between 50*n up to 100*n simple-udp Game Servers.
-STRESS_TEST_LEVEL=20
+STRESS_TEST_LEVEL ?= 20
 
 # kind cluster name to use
 KIND_PROFILE ?= agones

--- a/build/gke-test-cluster/cluster.yml.jinja
+++ b/build/gke-test-cluster/cluster.yml.jinja
@@ -37,7 +37,7 @@ resources:
         - name: "agones-system"
           initialNodeCount: 1
           config:
-            machineType: n1-standard-2
+            machineType: n1-standard-4
             oauthScopes:
               - https://www.googleapis.com/auth/compute
               - https://www.googleapis.com/auth/devstorage.read_only

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -70,6 +70,9 @@ const (
 	logSizeLimitMBFlag           = "log-size-limit-mb"
 	kubeconfigFlag               = "kubeconfig"
 	defaultResync                = 30 * time.Second
+	// topNGSForAllocation is used by the GameServerAllocation controller
+	// to reduce the contention while allocating gameservers.
+	topNGSForAllocation = 100
 )
 
 var (
@@ -187,8 +190,8 @@ func main() {
 	fleetController := fleets.NewController(wh, health, kubeClient, extClient, agonesClient, agonesInformerFactory)
 	faController := fleetallocation.NewController(wh, allocationMutex,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
-	gasController := gameserverallocations.NewController(wh, health, allocationMutex, kubeClient,
-		kubeInformerFactory, extClient, agonesClient, agonesInformerFactory)
+	gasController := gameserverallocations.NewController(wh, health, kubeClient,
+		kubeInformerFactory, extClient, agonesClient, agonesInformerFactory, topNGSForAllocation)
 	fasController := fleetautoscalers.NewController(wh, health,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
 

--- a/pkg/apis/stable/v1alpha1/gameserverallocation.go
+++ b/pkg/apis/stable/v1alpha1/gameserverallocation.go
@@ -26,6 +26,9 @@ const (
 	GameServerAllocationAllocated GameServerAllocationState = "Allocated"
 	// GameServerAllocationUnAllocated when the allocation is unsuccessful
 	GameServerAllocationUnAllocated GameServerAllocationState = "UnAllocated"
+	// GameServerAllocationContention when the allocation is unsuccessful
+	// because of contention
+	GameServerAllocationContention GameServerAllocationState = "Contention"
 )
 
 // GameServerAllocationState is the Allocation state

--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -213,6 +213,8 @@ status:
 
 If you look at the `status` section, there are several things to take note of. The `state` value will tell if
 a `GameServer` was allocated or not. If a `GameServer` could not be found, this will be set to `UnAllocated`.
+{{% feature publishVersion="0.9.0" %}}If there are too many concurrent requests overwhelmed the system, `state` will be set to 
+`Contention`even though there are available `GameServer`.{{% /feature %}}
 
 However, we see that the `status.state` value was set to `Allocated`. 
 This means you have been successfully allocated a `GameServer` out of the fleet, and you can now connect your players to it!

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -55,7 +55,7 @@ func TestCreateConnect(t *testing.T) {
 		t.Fatalf("Could ping GameServer: %v", err)
 	}
 
-	assert.Equal(t, reply, "ACK: Hello World !\n")
+	assert.Equal(t, "ACK: Hello World !\n", reply)
 }
 
 // nolint:dupl


### PR DESCRIPTION
Remove the call to sync the gameserver cache during each allocation request and replaced it with using local (ready gameservers) cache. 