### PR TITLE
test: make e2e test logs more readable

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	e2eframework "agones.dev/agones/test/e2e/framework"
+	"github.com/sirupsen/logrus"
 )
 
 const defaultNs = "default"
@@ -40,6 +41,12 @@ func TestMain(m *testing.M) {
 	stressTestLevel := flag.Int("stress", 0, "enable stress test at given level 0-100")
 
 	flag.Parse()
+
+	logrus.SetFormatter(&logrus.TextFormatter{
+		EnvironmentOverrideColors: true,
+		FullTimestamp:             true,
+		TimestampFormat:           "2006-01-02 15:04:06.000",
+	})
 
 	var (
 		err      error


### PR DESCRIPTION
This always emits time, log and message first.

```
time="2019-02-11 15:12:19.219" level=info msg="starting scale up/down test" deadline="2019-02-11 15:13:46.219007 -0800 PST m=+60.929866783" fleetCount=2 fleetSize=10 repeatCount=3
```

Optionally if `CLICOLOR_FORCE=1` is set in the environment, the output will be colored and more compact.