### PR TITLE
Switch to htmltest link checker -- and fix issues

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -19,7 +19,7 @@
 FROM gcr.io/agones-images/grpc-cxx:1.16.1
 
 RUN apt-get update && \
-    apt-get install -y wget psmisc rsync make python bash-completion zip nano jq graphviz linkchecker \
+    apt-get install -y wget psmisc rsync make python bash-completion zip nano jq graphviz \
             gettext-base plantuml && \
     apt-get clean
 
@@ -125,6 +125,13 @@ RUN mkdir /tmp/hugo && \
 
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
     apt-get install -y nodejs
+
+# html checker
+RUN mkdir /tmp/htmltest && \
+    wget -O /tmp/htmltest/htmltest.tar.gz https://github.com/wjdp/htmltest/releases/download/v0.10.1/htmltest_0.10.1_linux_amd64.tar.gz && \
+    tar -zxvf /tmp/htmltest/htmltest.tar.gz -C /tmp/htmltest && \
+    mv /tmp/htmltest/htmltest /usr/local/bin && \
+    rm -r /tmp/htmltest
 
 # make sure we keep the path to go
 RUN echo "export PATH=/usr/local/go/bin:/go/bin/:\$PATH" >> /root/.bashrc

--- a/docs/governance/templates/release_issue.md
+++ b/docs/governance/templates/release_issue.md
@@ -19,6 +19,7 @@ and copy it into a release issue. Fill in relevent values, found inside {}
 - [ ] Create a *draft* release with the [release template][release-template]
   - [ ] Make a `tag` with the release version.
 - [ ] Site updated
+  - [ ] Review all `link_test` and `data-proofer-ignore` attributes and remove for link testing
   - [ ] If full release, review and remove all instances of the `feature` shortcode
   - [ ] If full release, update to the new release branch {version}+0.1.
   - [ ] If full release, update site with the new release version (`release-version` in config.toml) to {version}+0.1

--- a/site/content/en/docs/Contribute/_index.md
+++ b/site/content/en/docs/Contribute/_index.md
@@ -25,6 +25,7 @@ with the Docsy theme for open source documentation.
 
 - [Hugo Documentation](https://gohugo.io/documentation/)
 - [Docsy Guide](https://github.com/google/docsy)
+- [Link Checker](https://github.com/wjdp/htmltest)
 
 ## Documentation for upcoming features
 

--- a/site/content/en/docs/Examples/_index.md
+++ b/site/content/en/docs/Examples/_index.md
@@ -15,4 +15,4 @@ weight: 120
 
 - {{< ghlink href="examples/simple-udp" >}}Simple UDP{{< /ghlink >}} (Go) - simple server and client that send UDP packets back and forth.
 - {{< ghlink href="examples/cpp-simple" >}}CPP Simple{{< /ghlink >}} (C++) - C++ example that starts up, stays healthy and then shuts down after 60 seconds.
-- {{< ghlink href="examples/xonotic" >}}Xonotic{{< /ghlink >}} - Wraps the SDK around the open source FPS game {{< ghlink href="http://www.xonotic.org" >}}Xonotic{{< /ghlink >}} and hosts it on Agones.
+- {{< ghlink href="examples/xonotic" >}}Xonotic{{< /ghlink >}} - Wraps the SDK around the open source FPS game [Xonotic](http://www.xonotic.org) and hosts it on Agones.

--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -66,7 +66,7 @@ simple-udp-llg4x-rx6rc   Ready     192.168.122.205    7752   minikube   9m
 simple-udp-llg4x-v6g2r   Ready     192.168.122.205    7623   minikube   9m
 ```
 
-For the full details of the YAML file head to the [Fleet Specification Guide]({{< ref "/docs/Reference/fleet.md#fleet-specification" >}})
+For the full details of the YAML file head to the [Fleet Specification Guide]({{< ref "/docs/Reference/fleet.md" >}})
 
 ### 2. Fetch the Fleet status
 

--- a/site/content/en/docs/Guides/Client SDKs/cpp.md
+++ b/site/content/en/docs/Guides/Client SDKs/cpp.md
@@ -65,7 +65,7 @@ grpc::Status status = sdk->Shutdown();
 if (!status.ok()) { ... }
 ```
 
-To [set a Label]({{< relref "_index.md#setlabelkey-value" >}}) on the backing `GameServer` call
+To [set a Label]({{< relref "_index.md#setlabel-key-value" >}}) on the backing `GameServer` call
 `sdk->SetLabel(key, value)`.
 
 This will return a grpc::Status object, from which we can call `status.ok()` to determine
@@ -78,7 +78,7 @@ grpc::Status status = sdk->SetLabel("test-label", "test-value");
 if (!status.ok()) { ... }
 ```
 
-To [set an Annotation]({{< relref "_index.md#setannotationkey-value" >}}) on the backing `GameServer` call
+To [set an Annotation]({{< relref "_index.md#setannotation-key-value" >}}) on the backing `GameServer` call
 `sdk->SetAnnotation(key, value)`.
 
 This will return a grpc::Status object, from which we can call `status.ok()` to determine
@@ -104,7 +104,7 @@ grpc::Status status = sdk->GameServer(&gameserver);
 if (!status.ok()) {...}
 ```
 
-To get [updates on the backing `GameServer`]({{< relref "_index.md#watchgameserverfunctiongameserver" >}}) as they happen, 
+To get [updates on the backing `GameServer`]({{< relref "_index.md#watchgameserver-function-gameserver" >}}) as they happen, 
 call `sdk->WatchGameServer([](stable::agones::dev::sdk::GameServer gameserver){...})`.
 
 This will call the passed in `std::function`

--- a/site/content/en/docs/Guides/Client SDKs/rest.md
+++ b/site/content/en/docs/Guides/Client SDKs/rest.md
@@ -71,7 +71,7 @@ $ curl -d "{}" -H "Content-Type: application/json" -X POST http://localhost:5935
 
 Apply a Label with the prefix "stable.agones.dev/sdk-" to the backing `GameServer` metadata. 
 
-See the SDK [SetLabel]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabelkey-value" >}}) documentation for restrictions.
+See the SDK [SetLabel]({{< ref "/docs/Guides/Client SDKs/_index.md#setlabel-key-value" >}}) documentation for restrictions.
 
 #### Example
 

--- a/site/content/en/docs/Guides/gameserver-lifecycle.md
+++ b/site/content/en/docs/Guides/gameserver-lifecycle.md
@@ -8,7 +8,7 @@ description: >
   when being started and match made.
 ---
 
-![Lifecyle Sequence Diagram](../../../../diagrams/gameserver-lifecycle.puml.png)
+![Lifecyle Sequence Diagram](../../../diagrams/gameserver-lifecycle.puml.png)
 
 ## Next Steps:
 

--- a/site/content/en/docs/Guides/metrics.md
+++ b/site/content/en/docs/Guides/metrics.md
@@ -193,7 +193,7 @@ Finally to access dashboards run
 kubectl port-forward deployments/grafana 3000 -n metrics
 ```
 
-Open a web browser to [http://127.0.0.1:3000](http://127.0.0.1:3000), you should see Agones [dashboards](#grafana-dashboards) after login as admin.
+Open a web browser to [http://localhost:3000](http://localhost:3000), you should see Agones [dashboards](#grafana-dashboards) after login as admin.
 
 > Makefile targets `make grafana-portforward`,`make kind-grafana-portforward` and `make minikube-grafana-portforward`.
 

--- a/site/content/en/docs/Installation/helm.md
+++ b/site/content/en/docs/Installation/helm.md
@@ -157,25 +157,26 @@ The following tables lists the configurable parameters of the Agones chart and t
 | `agones.metrics.stackdriverProjectID`               | This overrides the default gcp project id for use with stackdriver            | ``                 |
 | `agones.registerWebhooks`                           | Registers the webhooks used for the admission controller                                        | `true`                 |
 | `agones.registerServiceAccounts`                    | Attempts to create service accounts for the controllers                                         | `true`                 |
-| `agones.controller.nodeSelector`                    | Controller [node labels](nodeSelector) for pod assignment                                       | `{}`                   |
+| `agones.controller.nodeSelector`                    | Controller [node labels][nodeSelector] for pod assignment                                       | `{}`                   |
 | `agones.controller.tolerations`                     | Controller [toleration][toleration] labels for pod assignment                                   | `[]`                   |
-| `agones.controller.affinity`                        | Controller [affinity](affinity) settings for pod assignment                                     | `{}`                   |
+| `agones.controller.affinity`                        | Controller [affinity][affinity] settings for pod assignment                                     | `{}`                   |
 | `agones.ping.resources`                             | Ping pods resource requests/limit                                                               | `{}`                   |
-| `agones.ping.nodeSelector`                          | Ping [node labels](nodeSelector) for pod assignment                                             | `{}`                   |
+| `agones.ping.nodeSelector`                          | Ping [node labels][nodeSelector] for pod assignment                                             | `{}`                   |
 | `agones.ping.tolerations`                           | Ping [toleration][toleration] labels for pod assignment                                         | `[]`                   |
-| `agones.ping.affinity`                              | Ping [affinity](affinity) settings for pod assignment                                           | `{}`                   |
+| `agones.ping.affinity`                              | Ping [affinity][affinity] settings for pod assignment                                           | `{}`                   |
 | `agones.controller.numWorkers`                      | Number of workers to spin per resource type                                                     | `64`                   |
 | `agones.controller.apiServerQPS`                    | Maximum sustained queries per second that controller should be making against API Server        | `100`                  |
 | `agones.controller.apiServerQPSBurst`               | Maximum burst queries per second that controller should be making against API Server            | `200`                  |
 
 [toleration]: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+[nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+[affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+
 {{% /feature %}}
 
 [constraints]: https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/
 [ping]: {{< ref "/docs/Guides/ping-service.md" >}}
 [service]: https://kubernetes.io/docs/concepts/services-networking/service/
-[nodeSelector]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-[affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -186,7 +186,7 @@ $ kubectl scale fleet simple-udp --replicas=10
 fleet.stable.agones.dev/simple-udp scaled
 ```
 
-You can also use [Kubernetes API](../Guides/access-api.md) to get or update the Replicas count:
+You can also use [Kubernetes API]({{< ref "/docs/Guides/access-api.md" >}}) to get or update the Replicas count:
 ```
 curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/fleets/simple-udp/scale
 ...

--- a/site/htmltest.yaml
+++ b/site/htmltest.yaml
@@ -1,0 +1,20 @@
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TestFilesConcurrently: false
+IgnoreInternalEmptyHash: true
+OutputDir: /go/src/agones.dev/agones/site
+OutputLogFile: .htmltest.log
+IgnoreURLs:
+  - http://localhost

--- a/site/layouts/partials/page-meta-lastmod.html
+++ b/site/layouts/partials/page-meta-lastmod.html
@@ -1,0 +1,1 @@
+{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a data-proofer-ignore href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}

--- a/site/layouts/partials/page-meta-links.html
+++ b/site/layouts/partials/page-meta-links.html
@@ -1,0 +1,11 @@
+{{ if .Path }}
+{{ $gh_repo := ($.Param "github_repo") }}
+{{ if $gh_repo }}
+<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+{{ $editURL := printf "%s/edit/master/site/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+</div>
+{{ end }}
+{{ end }}

--- a/site/layouts/partials/pager.html
+++ b/site/layouts/partials/pager.html
@@ -1,0 +1,7 @@
+<ul class="list-unstyled d-flex justify-content-between align-items-center mb-0 pt-5">
+  <li>
+    <a {{if .PrevInSection}}href="{{.PrevInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .PrevInSection}} disabled{{end}}"><span class="mr-1">←</span> {{ T "ui_pager_prev" }}</a>
+  </li>
+    <a {{if .NextInSection}}href="{{.NextInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .NextInSection}} disabled{{end}}">{{ T "ui_pager_next" }} <span class="ml-1">→</span></a>
+  </li>
+</ul>

--- a/site/layouts/shortcodes/ghlink.html
+++ b/site/layouts/shortcodes/ghlink.html
@@ -1,2 +1,3 @@
-{{- $branch := .Get "branch" | default $.Page.Site.Params.release_branch }}
-<a href="{{$.Page.Site.Params.github_repo}}/blob/{{ $branch }}/{{.Get "href"}}" target="_blank">{{.Inner}}</a>
+{{- $branch := .Get "branch" | default (getenv "RELEASE_BRANCH") | default $.Page.Site.Params.release_branch }}
+{{- $test := eq (.Get "link_test") "true" | default true }}
+<a href="{{$.Page.Site.Params.github_repo}}/blob/{{ $branch }}/{{.Get "href"}}" target="_blank" {{if not $test}}data-proofer-ignore{{end}}>{{.Inner}}</a>

--- a/site/layouts/shortcodes/release-branch.html
+++ b/site/layouts/shortcodes/release-branch.html
@@ -1,1 +1,2 @@
-{{ $.Page.Site.Params.release_branch }}
+{{- $branch := getenv "RELEASE_BRANCH" | default $.Page.Site.Params.release_branch }}
+{{- $branch }}

--- a/site/static/favicons/_head.html
+++ b/site/static/favicons/_head.html
@@ -1,5 +1,0 @@
-<link rel="icon" type="image/png" href="/iconx/favicon-16x16.png" sizes="16x16">
-<link rel="icon" type="image/png" href="/iconx/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/iconx/android-192x192.png" sizes="192x192">
-<link rel="apple-touch-icon" href="/iconx/apple-touch-icon-180x180.png" sizes="180x180">
-<meta name="msapplication-config" content="/iconx/browserconfig.xml">

--- a/site/themes/docsy/layouts/partials/pager.html
+++ b/site/themes/docsy/layouts/partials/pager.html
@@ -2,7 +2,6 @@
   <li>
     <a href="{{if .PrevInSection}}{{.PrevInSection.RelPermalink}}{{end}}" class="btn btn-primary {{if not .PrevInSection}} disabled{{end}}"><span class="mr-1">←</span> {{ T "ui_pager_prev" }}</a>
   </li>
- 
     <a href="{{if .NextInSection}}{{.NextInSection.RelPermalink}}{{end}}" class="btn btn-primary {{if not .NextInSection}} disabled{{end}}">{{ T "ui_pager_next" }} <span class="ml-1">→</span></a>
   </li>
 </ul>


### PR DESCRIPTION
Made switch to [htmltest](https://github.com/wjdp/htmltest) because previous link checker didn't find lots of missing images, anchors that didn't exist, external URL checks, etc. These have all been fixed now.

This checker is _brutally_ efficient at finding issues, although because it checks external URLs, it can not be the fastest. I've integrated the external URL cache into `make site-test`, which, when populated, runs the test in several seconds, which makes local testing nice.