### PR TITLE
Remove -v from Go testing - becomes too noisy

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -135,7 +135,7 @@ ifdef NO_RACE_DETECTOR
   RACE_DETECTOR_ARGS=
 endif
 
-GO_TEST=$(DOCKER_RUN) go test -v $(RACE_DETECTOR_ARGS)
+GO_TEST=$(DOCKER_RUN) go test $(RACE_DETECTOR_ARGS)
 GO_E2E_TEST_ARGS=--kubeconfig /root/.kube/$(kubeconfig_file)
 
 go_build_base_path=$(mount_path)


### PR DESCRIPTION
It became super noisy to get all the verbose output in the CI system - so going back to a more quiet system.