### PR TITLE
Remove deprecation from FleetAllocation

### DIFF
--- a/examples/fleetallocation.yaml
+++ b/examples/fleetallocation.yaml
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 #
-# (Deprecated: See GameServerAllocation for a replacement)
-#
 # Full example of a FleetAllocation - this is used to allocate a GameServer
 # out of a Fleet so it can be handed to a set of players to play on.
 #

--- a/examples/gameserverallocation.yaml
+++ b/examples/gameserverallocation.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 #
+# (GameServerAllocation is currently experimental, and likely to change in upcoming releases)
+#
 # Full example of a GameServerAllocation. This is used to allocate
 # A GameServer out of a set of GameServers. This could be a Fleet,
 # multiple Fleets, or a self managed group of GameServers.

--- a/examples/simple-udp/fleetallocation.yaml
+++ b/examples/simple-udp/fleetallocation.yaml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# (Deprecated; Look at gameserverallocation.yaml instead)
-
 apiVersion: "stable.agones.dev/v1alpha1"
 kind: FleetAllocation
 metadata:

--- a/examples/simple-udp/gameserverallocation.yaml
+++ b/examples/simple-udp/gameserverallocation.yaml
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usually you would define a Fleet rather than a GameServerSet
-# directly. This is here mostly for testing purposes
+# (GameServerAllocation is currently experimental, and likely to change in upcoming releases)
 
 apiVersion: "stable.agones.dev/v1alpha1"
 kind: GameServerAllocation

--- a/examples/xonotic/fleetallocation.yaml
+++ b/examples/xonotic/fleetallocation.yaml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# (Deprecated; Look at gameserverallocation.yaml instead)
-
 apiVersion: "stable.agones.dev/v1alpha1"
 kind: FleetAllocation
 metadata:

--- a/examples/xonotic/gameserverallocation.yaml
+++ b/examples/xonotic/gameserverallocation.yaml
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usually you would define a Fleet rather than a GameServerSet
-# directly. This is here mostly for testing purposes
+# (GameServerAllocation is currently experimental, and likely to change in upcoming releases)
 
 apiVersion: "stable.agones.dev/v1alpha1"
 kind: GameServerAllocation

--- a/pkg/apis/stable/v1alpha1/fleetallocation.go
+++ b/pkg/apis/stable/v1alpha1/fleetallocation.go
@@ -20,7 +20,6 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // FleetAllocation is the data structure for allocating against a Fleet
-// Deprecated: Please use GameServerAllocation instead.
 type FleetAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -165,6 +165,9 @@ do this through `kubectl` as well, and ask it to return the response in yaml so 
 {{% feature publishVersion="0.8.0" %}}
 #### GameServerAllocation
 
+> GameServerAllocation will eventually replace FleetAllocation, but is currently experimental, and likely to change in upcoming releases.
+  However, we welcome you to test it out in its current format and provide feedback.
+
 We can do allocation of a GameServer for usage through a `GameServerAllocation`, which will both 
 return to us the details of a `GameServer` (assuming one is available), and also move it to the `Allocated` state,
 which demarcates that it has players on it, and should not be removed until `SDK.Shutdown()` is called, or it is manually deleted.
@@ -249,10 +252,6 @@ simple-udp-sdhzn-wnhsw   Ready       192.168.122.205   7478   minikube  52m
 
 {{% feature publishVersion="0.8.0" %}}
 #### FleetAllocation
-
-> Fleet Allocation is **deprecated** in version 0.8.0, and will be removed in the 0.10.0 release.
-  Migrate to using GameServer Allocation instead.
-{{% /feature %}}
 
 We can do allocation of a GameServer for usage through a `FleetAllocation`, which will both return to us a `GameServer` (assuming one is available)
 and also move it to the `Allocated` state.

--- a/site/content/en/docs/Reference/fleet.md
+++ b/site/content/en/docs/Reference/fleet.md
@@ -76,6 +76,9 @@ The `spec` field is the actual `Fleet` specification and it is composed as follo
 {{% feature publishVersion="0.8.0" %}}
 ## GameServer Allocation Specification
 
+> GameServerAllocation will eventually replace FleetAllocation, but is currently experimental, and likely to change in upcoming releases.
+  However, we welcome you to test it out in its current format and provide feedback.
+
 A `GameServerAllocation` is used to atomically allocate a GameServer out of a set of GameServers. 
 This could be a single Fleet, multiple Fleets, or a self managed group of GameServers.
 
@@ -140,11 +143,6 @@ The `spec` field is the actual `GameServerAllocation` specification and it is co
 {{% /feature %}}
 
 # Fleet Allocation Specification
-
-{{% feature publishVersion="0.8.0" %}}
-> Fleet Allocation is **deprecated** in version 0.8.0, and will be removed in the 0.10.0 release.
-  Migrate to using GameServer Allocation instead.
-{{% /feature %}}
 
 A `FleetAllocation` is used to allocate a `GameServer` out of an existing `Fleet`
 


### PR DESCRIPTION
Since #600 is in the wings for next release, which is another breaking change, let's keep FleetAllocation stable for another release and mark GameServerAllocation as experimental to manage expectations appropriately.