### PR TITLE
Add GameServer Name length validation

### DIFF
--- a/pkg/apis/stable/v1alpha1/fleet.go
+++ b/pkg/apis/stable/v1alpha1/fleet.go
@@ -148,7 +148,7 @@ func (f *Fleet) Validate() ([]metav1.StatusCause, bool) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Field:   fmt.Sprintf("Name"),
-			Message: fmt.Sprintf("Length of Fleet '%s' name should be no more than 63.", f.ObjectMeta.Name),
+			Message: fmt.Sprintf("Length of Fleet '%s' name should be no more than 63 characters.", f.ObjectMeta.Name),
 		})
 	}
 

--- a/pkg/apis/stable/v1alpha1/fleet_test.go
+++ b/pkg/apis/stable/v1alpha1/fleet_test.go
@@ -112,6 +112,12 @@ func TestFleetName(t *testing.T) {
 	assert.False(t, ok)
 	assert.Len(t, causes, 1)
 	assert.Equal(t, "Name", causes[0].Field)
+
+	f.Name = ""
+	f.GenerateName = string(bytes)
+	causes, ok = f.Validate()
+	assert.True(t, ok)
+	assert.Len(t, causes, 0)
 }
 
 func TestSumStatusReplicas(t *testing.T) {

--- a/pkg/apis/stable/v1alpha1/fleetallocation.go
+++ b/pkg/apis/stable/v1alpha1/fleetallocation.go
@@ -59,7 +59,7 @@ type FleetAllocationStatus struct {
 }
 
 // ValidateUpdate validates when an update occurs
-func (fa *FleetAllocation) ValidateUpdate(new *FleetAllocation) (bool, []metav1.StatusCause) {
+func (fa *FleetAllocation) ValidateUpdate(new *FleetAllocation) ([]metav1.StatusCause, bool) {
 	var causes []metav1.StatusCause
 
 	if fa.Spec.FleetName != new.Spec.FleetName {
@@ -70,5 +70,5 @@ func (fa *FleetAllocation) ValidateUpdate(new *FleetAllocation) (bool, []metav1.
 		})
 	}
 
-	return len(causes) == 0, causes
+	return causes, len(causes) == 0
 }

--- a/pkg/apis/stable/v1alpha1/fleetallocation_test.go
+++ b/pkg/apis/stable/v1alpha1/fleetallocation_test.go
@@ -29,13 +29,13 @@ func TestFleetAllocationValidateupdate(t *testing.T) {
 		},
 	}
 
-	valid, causes := fa.ValidateUpdate(fa.DeepCopy())
+	causes, valid := fa.ValidateUpdate(fa.DeepCopy())
 	assert.True(t, valid)
 	assert.Len(t, causes, 0)
 
 	faCopy := fa.DeepCopy()
 	faCopy.Spec.FleetName = "notthesame"
-	valid, causes = fa.ValidateUpdate(faCopy)
+	causes, valid = fa.ValidateUpdate(faCopy)
 
 	assert.False(t, valid)
 	assert.Len(t, causes, 1)

--- a/pkg/apis/stable/v1alpha1/gameserverallocation.go
+++ b/pkg/apis/stable/v1alpha1/gameserverallocation.go
@@ -105,7 +105,7 @@ func (gsa *GameServerAllocation) ApplyDefaults() {
 }
 
 // ValidateUpdate validates when an update occurs
-func (gsa *GameServerAllocation) ValidateUpdate(new *GameServerAllocation) (bool, []metav1.StatusCause) {
+func (gsa *GameServerAllocation) ValidateUpdate(new *GameServerAllocation) ([]metav1.StatusCause, bool) {
 	var causes []metav1.StatusCause
 
 	if !equality.Semantic.DeepEqual(gsa.Spec, new.Spec) {
@@ -116,5 +116,5 @@ func (gsa *GameServerAllocation) ValidateUpdate(new *GameServerAllocation) (bool
 		})
 	}
 
-	return len(causes) == 0, causes
+	return causes, len(causes) == 0
 }

--- a/pkg/apis/stable/v1alpha1/gameserverallocation_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserverallocation_test.go
@@ -37,16 +37,16 @@ func TestGameServerAllocationValidateUpdate(t *testing.T) {
 	new := &GameServerAllocation{Spec: GameServerAllocationSpec{Scheduling: Packed}}
 	old := &GameServerAllocation{Spec: GameServerAllocationSpec{Scheduling: Distributed}}
 
-	ok, result := old.ValidateUpdate(old)
+	causes, ok := old.ValidateUpdate(old)
 	assert.True(t, ok)
-	assert.Empty(t, result)
+	assert.Empty(t, causes)
 
-	ok, result = old.ValidateUpdate(new)
+	causes, ok = old.ValidateUpdate(new)
 	assert.False(t, ok)
-	assert.Len(t, result, 1)
+	assert.Len(t, causes, 1)
 
-	assert.Equal(t, metav1.CauseTypeFieldValueInvalid, result[0].Type)
-	assert.Equal(t, "spec", result[0].Field)
+	assert.Equal(t, metav1.CauseTypeFieldValueInvalid, causes[0].Type)
+	assert.Equal(t, "spec", causes[0].Field)
 }
 
 func TestGameServerAllocationSpecPreferredSelectors(t *testing.T) {

--- a/pkg/apis/stable/v1alpha1/gameserverset.go
+++ b/pkg/apis/stable/v1alpha1/gameserverset.go
@@ -97,7 +97,7 @@ func (gsSet *GameServerSet) Validate() ([]metav1.StatusCause, bool) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Field:   "Name",
-			Message: fmt.Sprintf("Length of GameServerSet '%s' name should be no more than 63.", gsSet.ObjectMeta.Name),
+			Message: fmt.Sprintf("Length of GameServerSet '%s' name should be no more than 63 characters.", gsSet.ObjectMeta.Name),
 		})
 	}
 

--- a/pkg/apis/stable/v1alpha1/gameserverset_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserverset_test.go
@@ -97,4 +97,10 @@ func TestGameServerSetValidateUpdate(t *testing.T) {
 	assert.False(t, ok)
 	assert.Len(t, causes, 1)
 	assert.Equal(t, "Name", causes[0].Field)
+
+	newGSS.Name = ""
+	newGSS.GenerateName = string(bytes)
+	causes, ok = newGSS.Validate()
+	assert.True(t, ok)
+	assert.Len(t, causes, 0)
 }

--- a/pkg/fleetallocation/controller.go
+++ b/pkg/fleetallocation/controller.go
@@ -237,7 +237,7 @@ func (c *Controller) mutationValidationHandler(review admv1beta1.AdmissionReview
 		return review, errors.Wrapf(err, "error unmarshalling old FleetAllocation json: %s", review.Request.Object.Raw)
 	}
 
-	if ok, causes := oldFA.ValidateUpdate(newFA); !ok {
+	if causes, ok := oldFA.ValidateUpdate(newFA); !ok {
 		review.Response.Allowed = false
 		details := metav1.StatusDetails{
 			Name:   review.Request.Name,

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -220,7 +220,7 @@ func (c *Controller) mutationValidationHandler(review admv1beta1.AdmissionReview
 		return review, errors.Wrapf(err, "error unmarshalling old GameServerAllocation json: %s", review.Request.Object.Raw)
 	}
 
-	if ok, causes := oldGSA.ValidateUpdate(newGSA); !ok {
+	if causes, ok := oldGSA.ValidateUpdate(newGSA); !ok {
 		review.Response.Allowed = false
 		details := metav1.StatusDetails{
 			Name:   review.Request.Name,

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -252,7 +252,7 @@ func (c *Controller) creationValidationHandler(review admv1beta1.AdmissionReview
 		return review, errors.Wrapf(err, "error unmarshalling original GameServer json: %s", obj.Raw)
 	}
 
-	ok, causes := gs.Validate()
+	causes, ok := gs.Validate()
 	if !ok {
 		review.Response.Allowed = false
 		details := metav1.StatusDetails{

--- a/site/content/en/docs/Reference/gameserver.md
+++ b/site/content/en/docs/Reference/gameserver.md
@@ -74,6 +74,8 @@ Since Agones defines a new [Custom Resources Definition (CRD)](https://kubernete
 You can use the metadata field to target a specific [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 
 but also attach specific [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) and [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) to your resource. This is a very common pattern in the Kubernetes ecosystem.
 
+The length of the `name` field of the Gameserver should not exceed 63 characters.
+
 The `spec` field is the actual GameServer specification and it is composed as follow:
 
 - `container` is the name of container running the GameServer in case you have more than one container defined in the [pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/). If you do,  this is a mandatory field. For instance this is useful if you want to run a sidecar to ship logs.


### PR DESCRIPTION
Fixed return order for other Validate() functions.
Need this change to comply with Label Requirements for Pod.
`generateName` truncates the name to 63 bytes and works as expected - creates valid gs with smaller name.

Closes #541.