### PR TITLE
2 Hotfixes: Allow Helm to reference image digests and inject licenses

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -277,8 +277,12 @@ lint: $(ensure-build-image)
 	docker run -t -e "TERM=xterm-256color" --rm $(common_mounts) -w $(mount_path) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
 		"golangci-lint run ./examples/... && golangci-lint run --deadline $(LINT_TIMEOUT) ./..."
 
+# Extract licenses from source tree
+build-licenses:
+	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/extract-licenses.sh
+
 # Build the image for the gameserver controller
-build-controller-image: $(ensure-build-image) build-controller-binary
+build-controller-image: $(ensure-build-image) build-controller-binary build-licenses
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_tag) $(DOCKER_BUILD_ARGS)
 
 # push the gameservers controller image
@@ -286,7 +290,7 @@ push-controller-image: $(ensure-build-image)
 	docker push $(controller_tag)
 
 # build the static binary for the gamesever sidecar
-build-agones-sdk-binary: $(ensure-build-image) build-agones-sdk-binary-linux build-agones-sdk-binary-windows build-agones-sdk-binary-darwin 
+build-agones-sdk-binary: $(ensure-build-image) build-agones-sdk-binary-linux build-agones-sdk-binary-windows build-agones-sdk-binary-darwin
 	$(ZIP_SDK) \
 		agonessdk-server-$(VERSION).zip sdk-server.darwin.amd64 sdk-server.linux.amd64 sdk-server.windows.amd64.exe
 
@@ -306,7 +310,7 @@ build-agones-sdk-binary-windows: $(ensure-build-image)
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server
 
 # Build the image for the gameserver sidecar
-build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary
+build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
 
 # Build a static binary for the ping service
@@ -320,7 +324,7 @@ push-ping-image: $(ensure-build-image)
 	docker push $(ping_tag)
 
 # Build the image for the ping service
-build-ping-image: $(ensure-build-image) build-ping-binary
+build-ping-image: $(ensure-build-image) build-ping-binary build-licenses
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_tag) $(DOCKER_BUILD_ARGS)
 
 # Build the cpp sdk linux archive
@@ -623,7 +627,7 @@ minikube-test-e2e: minikube-agones-profile test-e2e
 minikube-stress-test-e2e: DOCKER_RUN_ARGS=--network=host -v $(minikube_cert_mount)
 minikube-stress-test-e2e: minikube-agones-profile stress-test-e2e
 
-# prometheus on minkube 
+# prometheus on minkube
 # we have to disable PVC as it's not supported on minkube.
 minikube-setup-prometheus:
 	$(MAKE) setup-prometheus \
@@ -651,7 +655,7 @@ minikube-prometheus-portforward:
 	$(MAKE) prometheus-portforward \
 		DOCKER_RUN_ARGS="--network=host -v $(minikube_cert_mount)"
 
-#   _  ___           _ 
+#   _  ___           _
 #  | |/ (_)_ __   __| |
 #  | ' /| | '_ \ / _` |
 #  | . \| | | | | (_| |
@@ -659,9 +663,9 @@ minikube-prometheus-portforward:
 
 # creates a kind cluster for use with agones
 # Kind stand for Kubernetes IN Docker
-# You can change the cluster name using KIND_PROFILE env var                                   
+# You can change the cluster name using KIND_PROFILE env var
 kind-test-cluster: DOCKER_RUN_ARGS+=--network=host
-kind-test-cluster: $(ensure-build-image) 
+kind-test-cluster: $(ensure-build-image)
 	@if [ -z $$(kind get clusters | grep $(KIND_PROFILE)) ]; then\
 		echo "Could not find $(KIND_PROFILE) cluster. Creating...";\
 		kind create cluster --name $(KIND_PROFILE) --image kindest/node:v1.11.3 --wait 5m;\
@@ -680,7 +684,7 @@ kind-shell: $(ensure-build-image)
 
 # installs the current dev version of agones
 # you should build-images and kind-push first.
-kind-install: 
+kind-install:
 	$(MAKE) install DOCKER_RUN_ARGS="--network=host" ALWAYS_PULL_SIDECAR=false \
 		IMAGE_PULL_POLICY=IfNotPresent PING_SERVICE_TYPE=NodePort \
 		KUBECONFIG="$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")"
@@ -698,12 +702,12 @@ kind-push:
 	rm -f $$BUNDLE_FILE
 
 # Runs e2e tests against our kind cluster
-kind-test-e2e: 
+kind-test-e2e:
 	$(MAKE) KUBECONFIG="$(shell kind get kubeconfig-path --name="$(KIND_PROFILE)")" \
 		DOCKER_RUN_ARGS=--network=host \
 		test-e2e
 
-# prometheus on kind 
+# prometheus on kind
 # we have to disable PVC as it's not supported on kind.
 kind-setup-prometheus:
 	$(MAKE) setup-prometheus \

--- a/build/extract-licenses.sh
+++ b/build/extract-licenses.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+append_license() {
+  lib=$1
+  path=$2
+  echo "================================================================================" >> ${TMP_LICENSES}
+  echo "= ${lib} licensed under: =" >> ${TMP_LICENSES}
+  echo >> ${TMP_LICENSES}
+  cat "$path" >> ${TMP_LICENSES}
+  echo >> ${TMP_LICENSES}
+  echo "= ${path} MD5 $(cat "${path}" | md5sum | awk '{print $1}')" >> ${TMP_LICENSES}
+  echo "================================================================================" >> ${TMP_LICENSES}
+  echo >> ${TMP_LICENSES}
+
+}
+
+SRC_ROOT=$(dirname "${BASH_SOURCE}")/..
+TMP_LICENSES=/tmp/LICENSES
+
+cd ${SRC_ROOT}
+
+# Clear file
+echo > ${TMP_LICENSES}
+
+append_license "Agones" "LICENSE"
+
+while read -r entry; do
+  LIBRARY=${entry#vendor\/}
+  LIBRARY=$(expr match "$LIBRARY" '\(.*\)/LICENSE.*\?')
+  append_license ${LIBRARY} ${entry}
+done <<< "$(find vendor/ -regextype posix-extended -iregex '.*LICENSE(\.txt)?')"
+
+for ddir in ${SRC_ROOT}/cmd/controller/bin/ ${SRC_ROOT}/cmd/ping/bin/ ${SRC_ROOT}/cmd/sdk-server/bin/ ; do
+  mkdir -p ${ddir}
+  cp ${TMP_LICENSES} ${ddir}
+done
+

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -1,9 +1,24 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine:3.8
 
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
-COPY  --chown=agones:root ./bin/controller /home/agones/controller
+COPY --chown=agones:root ./bin/controller /home/agones/controller
+COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
 
 USER agones
 ENTRYPOINT ["/home/agones/controller"]

--- a/cmd/ping/Dockerfile
+++ b/cmd/ping/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --update add ca-certificates && \
     adduser -D agones
 
 COPY --chown=agones:root ./bin/ping /home/agones/ping
+COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
 
 USER agones
 ENTRYPOINT ["/home/agones/ping"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -1,9 +1,24 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine:3.8
 
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
 COPY --chown=agones:root ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
+COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
 
 USER agones
 ENTRYPOINT ["/home/agones/sdk-server"]

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: {{ .Values.agones.serviceaccount.controller }}
       containers:
       - name: agones-controller
-        image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ .Values.agones.image.tag }}"
+        image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ default .Values.agones.image.tag .Values.agones.image.controller.tag }}"
         imagePullPolicy: {{ .Values.agones.image.controller.pullPolicy }}
         env:
         # minimum port that can be exposed to GameServer traffic
@@ -79,7 +79,7 @@ spec:
         - name: MAX_PORT
           value: {{ .Values.gameservers.maxPort | quote }}
         - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
-          value: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.sdk.name}}:{{ .Values.agones.image.tag }}"
+          value: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.sdk.name}}:{{ default .Values.agones.image.tag .Values.agones.image.sdk.tag }}"
         - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
           value: {{ .Values.agones.image.sdk.alwaysPull | quote }}
         - name: SIDECAR_CPU_REQUEST

--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       containers:
         - name: agones-ping
-          image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.ping.name}}:{{ .Values.agones.image.tag }}"
+          image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.ping.name}}:{{ default .Values.agones.image.tag .Values.agones.image.ping.tag }}"
           imagePullPolicy: {{ .Values.agones.image.ping.pullPolicy }}
 {{- if .Values.agones.ping.resources }}
           resources:


### PR DESCRIPTION
This PR allows Helm to reference image digests by allowing the injection of them for each image and also automates the extraction and copying of all licences into the images under /home/agones/LICENSES.

I'm going to monitor the bot for any test failures. I also left no trailing spaces in any of the files I touched! die spaces, die! 