### PR TITLE
Refactor AllocationCounter to GameServerCounter

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -184,6 +184,8 @@ func main() {
 
 	allocationMutex := &sync.Mutex{}
 
+	gsCounter := gameservers.NewPerNodeCounter(kubeInformerFactory, agonesInformerFactory)
+
 	gsController := gameservers.NewController(wh, health,
 		ctlConf.MinPort, ctlConf.MaxPort, ctlConf.SidecarImage, ctlConf.AlwaysPullSidecar,
 		ctlConf.SidecarCPURequest, ctlConf.SidecarCPULimit,
@@ -193,13 +195,13 @@ func main() {
 	fleetController := fleets.NewController(wh, health, kubeClient, extClient, agonesClient, agonesInformerFactory)
 	faController := fleetallocation.NewController(wh, allocationMutex,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
-	gasController := gameserverallocations.NewController(wh, health, kubeClient,
-		kubeInformerFactory, extClient, agonesClient, agonesInformerFactory, topNGSForAllocation)
+	gasController := gameserverallocations.NewController(wh, health, gsCounter, topNGSForAllocation,
+		kubeClient, extClient, agonesClient, agonesInformerFactory)
 	fasController := fleetautoscalers.NewController(wh, health,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
 
 	rs = append(rs,
-		httpsServer, gsController, gsSetController, fleetController, faController, fasController, gasController, server)
+		httpsServer, gsCounter, gsController, gsSetController, fleetController, faController, fasController, gasController, server)
 
 	stop := signals.NewStopChannel()
 

--- a/pkg/gameserverallocations/find.go
+++ b/pkg/gameserverallocations/find.go
@@ -14,12 +14,14 @@
 
 package gameserverallocations
 
+import "agones.dev/agones/pkg/gameservers"
+
 // packedComparator prioritises Nodes with GameServers that are allocated, and then Nodes with the most
 // Ready GameServers -- this will bin pack allocated game servers together.
-func packedComparator(bestCount, currentCount NodeCount) bool {
-	if currentCount.allocated == bestCount.allocated && currentCount.ready > bestCount.ready {
+func packedComparator(bestCount, currentCount gameservers.NodeCount) bool {
+	if currentCount.Allocated == bestCount.Allocated && currentCount.Ready > bestCount.Ready {
 		return true
-	} else if currentCount.allocated > bestCount.allocated {
+	} else if currentCount.Allocated > bestCount.Allocated {
 		return true
 	}
 
@@ -28,6 +30,6 @@ func packedComparator(bestCount, currentCount NodeCount) bool {
 
 // distributedComparator is the inverse of the packed comparator,
 // looking to distribute allocated gameservers on as many nodes as possible.
-func distributedComparator(bestCount, currentCount NodeCount) bool {
+func distributedComparator(bestCount, currentCount gameservers.NodeCount) bool {
 	return !packedComparator(bestCount, currentCount)
 }


### PR DESCRIPTION
Precursor to #638 - this moves the AllocationCounter code to a more central GameServerCounter (which I think is a better name) that tracks the number of Ready and Allocated GameServers that are
available on each node.

These details are useful for sorting for `Packed` scheduling strategies.

Once this PR is completed, we can use this Count() values provided by this controller in the GameServerSet scale down logic, to ensure that GameServers on the least used nodes are removed first when using a Packed strategy.