### PR TITLE
E2E Cleanup: Implement SendGameServerUDP

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -259,8 +259,16 @@ func (f *Framework) CleanUp(ns string) error {
 		DeleteCollection(deleteOptions, listOptions)
 }
 
-// PingGameServer pings a gameserver and returns its reply
-func PingGameServer(msg, address string) (reply string, err error) {
+// SendGameServerUDP sends a message to a gameserver and returns its reply
+// assumes the first port is the port to send the message to
+func SendGameServerUDP(gs *v1alpha1.GameServer, msg string) (string, error) {
+	address := fmt.Sprintf("%s:%d", gs.Status.Address, gs.Status.Ports[0].Port)
+	return SendUDP(address, msg)
+}
+
+// SendUDP sends a message to an address, and returns its reply if
+// it returns one in 30 seconds
+func SendUDP(address, msg string) (string, error) {
 	conn, err := net.Dial("udp", address)
 	if err != nil {
 		return "", err

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -48,8 +47,7 @@ func TestCreateConnect(t *testing.T) {
 	assert.NotEmpty(t, readyGs.Status.NodeName)
 	assert.Equal(t, readyGs.Status.State, v1alpha1.GameServerStateReady)
 
-	reply, err := e2eframework.PingGameServer("Hello World !", fmt.Sprintf("%s:%d", readyGs.Status.Address,
-		readyGs.Status.Ports[0].Port))
+	reply, err := e2eframework.SendGameServerUDP(readyGs, "Hello World !")
 
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -68,8 +66,7 @@ func TestSDKSetLabel(t *testing.T) {
 	}
 
 	assert.Equal(t, readyGs.Status.State, v1alpha1.GameServerStateReady)
-	reply, err := e2eframework.PingGameServer("LABEL", fmt.Sprintf("%s:%d", readyGs.Status.Address,
-		readyGs.Status.Ports[0].Port))
+	reply, err := e2eframework.SendGameServerUDP(readyGs, "LABEL")
 
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)
@@ -105,8 +102,7 @@ func TestHealthCheckDisable(t *testing.T) {
 	}
 	defer framework.AgonesClient.StableV1alpha1().GameServers(defaultNs).Delete(readyGs.ObjectMeta.Name, nil) // nolint: errcheck
 
-	_, err = e2eframework.PingGameServer("UNHEALTHY", fmt.Sprintf("%s:%d", readyGs.Status.Address,
-		readyGs.Status.Ports[0].Port))
+	_, err = e2eframework.SendGameServerUDP(readyGs, "UNHEALTHY")
 
 	if err != nil {
 		t.Fatalf("Could not ping GameServer: %v", err)
@@ -134,8 +130,7 @@ func TestSDKSetAnnotation(t *testing.T) {
 	defer framework.AgonesClient.StableV1alpha1().GameServers(defaultNs).Delete(readyGs.ObjectMeta.Name, nil) // nolint: errcheck
 
 	assert.Equal(t, readyGs.Status.State, v1alpha1.GameServerStateReady)
-	reply, err := e2eframework.PingGameServer("ANNOTATION", fmt.Sprintf("%s:%d", readyGs.Status.Address,
-		readyGs.Status.Ports[0].Port))
+	reply, err := e2eframework.SendGameServerUDP(readyGs, "ANNOTATION")
 
 	if err != nil {
 		t.Fatalf("Could ping GameServer: %v", err)

--- a/test/e2e/ping_test.go
+++ b/test/e2e/ping_test.go
@@ -84,7 +84,7 @@ func TestPingUDP(t *testing.T) {
 	assert.Nil(t, err)
 
 	expected := "hello"
-	reply, err := e2eframework.PingGameServer(expected, fmt.Sprintf("%s:%d", externalIP, p))
+	reply, err := e2eframework.SendUDP(fmt.Sprintf("%s:%d", externalIP, p), expected)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, reply)
 }


### PR DESCRIPTION
Renamed `PingGameServer` to `SendUDP`, as I think that explains the function better, and also implemented a utility function of `SendGameServerUDP` for sending messages to GameServers.

Kept `SendUDP` as we use it to e2e test the Ping UDP endpoints.