### PR TITLE
Add Agones Kubernetes API docs generator

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -352,7 +352,7 @@ The second step is to prepare your cluster for the Agones deployments. Run `make
 
 Now you're ready to begin the development/test cycle:
 - `make build` will build Agones
-- `make test` will run local tests
+- `make test` will run local tests, which includes `site-test` target
 - `make push` will push the Agones images to your image repository 
 - `make test-e2e` will run end-to-end tests in your cluster
 - `make install` will install/upgrade Agones into your cluster
@@ -411,6 +411,18 @@ Build the cpp sdk static and dynamic libraries (linux libraries only)
 
 #### `make test`
 Run the linter and tests
+
+#### `make site-server`
+Generate `https://agones.dev` website locally and host on `http://localhost:1313`
+
+#### `make site-test`
+Check the links in website
+
+#### `make gen-api-docs`
+Generate Agones CRD reference documentation [Agones CRD API reference](../site/content/en/docs/Reference/agones_crd_api_reference.html). Set `feature` shortcode with proper version automatically
+
+#### `make test-gen-api-docs`
+Verifies that there is no changes in generated [Agones CRD API reference](../site/content/en/docs/Reference/agones_crd_api_reference.html) compared to the current one (useful for CI)
 
 #### `make push`
 Pushes all built images up to the `$(REGISTRY)`

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -123,6 +123,11 @@ RUN mkdir /tmp/hugo && \
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - && \
     apt-get install -y nodejs
 
+# install API reference docs generator
+RUN mkdir -p /go/src/github.com/ahmetb && \
+    cd /go/src/github.com/ahmetb && git clone https://github.com/ahmetb/gen-crd-api-reference-docs && \
+    cd ./gen-crd-api-reference-docs && go build
+
 # html checker
 RUN mkdir /tmp/htmltest && \
     wget -O /tmp/htmltest/htmltest.tar.gz https://github.com/wjdp/htmltest/releases/download/v0.10.1/htmltest_0.10.1_linux_amd64.tar.gz && \

--- a/site/assets/templates/pkg.tpl
+++ b/site/assets/templates/pkg.tpl
@@ -1,0 +1,46 @@
+{{ define "packages" }}
+
+{{ with .packages}}
+<p>Packages:</p>
+<ul>
+    {{ range . }}
+    <li>
+        <a href="#{{- packageDisplayName . -}}">{{ packageDisplayName . }}</a>
+    </li>
+    {{ end }}
+</ul>
+{{ end}}
+
+{{ range .packages }}
+    <h2 id="{{- packageDisplayName . -}}">
+        {{- packageDisplayName . -}}
+    </h2>
+
+    {{ with .DocComments }}
+    <p>
+        {{ safe (renderComments .) }}
+    </p>
+    {{ end }}
+
+    Resource Types:
+    <ul>
+    {{- range (visibleTypes (sortedTypes .Types)) -}}
+        {{ if isExportedType . -}}
+        <li>
+            <a href="#{{ typeIdentifier . }}">{{ typeIdentifier . }}</a>
+        </li>
+        {{- end }}
+    {{- end -}}
+    </ul>
+
+    {{ range (visibleTypes (sortedTypes .Types))}}
+        {{ template "type" .  }}
+    {{ end }}
+    <hr/>
+{{ end }}
+
+<p><em>
+    Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>
+
+{{ end }}

--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -10,7 +10,11 @@ description: >
 ---
 
 Installing Agones creates several [Custom Resource Definitions (CRD)](https://kubernetes.io/docs/concepts/api-extension/custom-resources),
-which can be accessed and manipulated through the Kubernetes API.
+which can be accessed and manipulated through the Kubernetes API. 
+
+{{% feature publishVersion="0.9.0" %}}
+The detailed list of Agones CRDs with their parameters could be found here - [Agones CRD API Reference](../../reference/agones_crd_api_reference/).
+{{% /feature %}}
 
 Kubernetes has multiple [client libraries](https://kubernetes.io/docs/reference/using-api/client-libraries/), however,
 at time of writing, only

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -1,0 +1,2219 @@
++++
+title="Agones Kubernetes API"
+description="Detailed list of Agones Custom Resource Definitions available"
++++
+
+{{% feature publishVersion="0.8.0" %}}
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#stable.agones.dev">stable.agones.dev</a>
+</li>
+</ul>
+<h2 id="stable.agones.dev">stable.agones.dev</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#Fleet">Fleet</a>
+</li><li>
+<a href="#FleetAllocation">FleetAllocation</a>
+</li><li>
+<a href="#FleetAutoscaler">FleetAutoscaler</a>
+</li><li>
+<a href="#GameServer">GameServer</a>
+</li><li>
+<a href="#GameServerAllocation">GameServerAllocation</a>
+</li><li>
+<a href="#GameServerSet">GameServerSet</a>
+</li></ul>
+<h3 id="Fleet">Fleet
+</h3>
+<p>
+<p>Fleet is the data structure for a Fleet resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+stable.agones.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Fleet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#FleetSpec">
+FleetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAllocation">FleetAllocation
+</h3>
+<p>
+<p>FleetAllocation is the data structure for allocating against a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+stable.agones.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>FleetAllocation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#FleetAllocationSpec">
+FleetAllocationSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="#MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#FleetAllocationStatus">
+FleetAllocationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscaler">FleetAutoscaler
+</h3>
+<p>
+<p>FleetAutoscaler is the data structure for a FleetAutoscaler resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+stable.agones.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>FleetAutoscaler</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#FleetAutoscalerSpec">
+FleetAutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+<a href="#FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#FleetAutoscalerStatus">
+FleetAutoscalerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServer">GameServer
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAllocationStatus">FleetAllocationStatus</a>)
+</p>
+<p>
+<p>GameServer is the data structure for a gameserver resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+stable.agones.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServer</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code></br>
+<em>
+<a href="#Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#GameServerStatus">
+GameServerStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerAllocation">GameServerAllocation
+</h3>
+<p>
+<p>GameServerAllocation is the data structure for allocating against a set of
+GameServers, defined <code>required</code> and <code>preferred</code> selectors</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+stable.agones.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerAllocation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#GameServerAllocationSpec">
+GameServerAllocationSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>required</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Required The required allocation. Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+[]Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Preferred ordered list of preferred allocations out of the <code>required</code> set.
+If the first selector is not matched,
+the selection attempts the second selector, and so on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="#MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#GameServerAllocationStatus">
+GameServerAllocationStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerSet">GameServerSet
+</h3>
+<p>
+<p>GameServerSet is the data structure a set of GameServers
+This matches philosophically with the relationship between
+Depoyments and ReplicaSets</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+stable.agones.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GameServerSet</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#GameServerSetSpec">
+GameServerSetSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#GameServerSetStatus">
+GameServerSetStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="BufferPolicy">BufferPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>BufferPolicy controls the desired behavior of the buffer policy.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>maxReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MaxReplicas is the maximum amount of replicas that the fleet may have.
+It must be bigger than both MinReplicas and BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>MinReplicas is the minimum amount of replicas that the fleet must have
+If zero, it is ignored.
+If non zero, it must be smaller than MaxReplicas and bigger than BufferSize</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>bufferSize</code></br>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>BufferSize defines how many replicas the autoscaler tries to have ready all the time
+Value can be an absolute number (ex: 5) or a percentage of desired gs instances (ex: 15%)
+Absolute number is calculated from percentage by rounding up.
+Example: when this is set to 20%, the autoscaler will make sure that 20%
+of the fleet&rsquo;s game server replicas are ready. When this is set to 20,
+the autoscaler will make sure that there are 20 available game servers
+Must be bigger than 0
+Note: by &ldquo;ready&rdquo; we understand in this case &ldquo;non-allocated&rdquo;; this is done to ensure robustness
+and computation stability in different edge case (fleet just created, not enough
+capacity in the cluster etc)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAllocationSpec">FleetAllocationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAllocation">FleetAllocation</a>)
+</p>
+<p>
+<p>FleetAllocationSpec is the spec for a Fleet
+Allocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="#MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAllocationStatus">FleetAllocationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAllocation">FleetAllocation</a>)
+</p>
+<p>
+<p>FleetAllocationStatus will contain the
+<code>GameServer</code> that has been allocated from
+a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>gameServer</code></br>
+<em>
+<a href="#GameServer">
+GameServer
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscaleRequest">FleetAutoscaleRequest
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleRequest defines the request to webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response. It allows us to distinguish instances of requests which are
+otherwise identical (parallel requests, requests when earlier requests did not modify etc)
+The UID is meant to track the round trip (request/response) between the Autoscaler and the WebHook, not the user request.
+It is suitable for correlating log entries between the webhook and apiserver, for either auditing or debugging.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the Fleet being scaled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace associated with the request (if any).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#FleetStatus">
+FleetStatus
+</a>
+</em>
+</td>
+<td>
+<p>The Fleet&rsquo;s status values</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscaleResponse">FleetAutoscaleResponse
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscaleReview">FleetAutoscaleReview</a>)
+</p>
+<p>
+<p>FleetAutoscaleResponse defines the response of webhook autoscaler endpoint</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<p>UID is an identifier for the individual request/response.
+This should be copied over from the corresponding FleetAutoscaleRequest.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scale</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Set to false if no scaling should occur to the Fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>The targeted replica count</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscaleReview">FleetAutoscaleReview
+</h3>
+<p>
+<p>FleetAutoscaleReview is passed to the webhook with a populated Request value,
+and then returned with a populated Response.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>request</code></br>
+<em>
+<a href="#FleetAutoscaleRequest">
+FleetAutoscaleRequest
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>response</code></br>
+<em>
+<a href="#FleetAutoscaleResponse">
+FleetAutoscaleResponse
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscalerPolicy">FleetAutoscalerPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscalerSpec">FleetAutoscalerSpec</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicy describes how to scale a fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#FleetAutoscalerPolicyType">
+FleetAutoscalerPolicyType
+</a>
+</em>
+</td>
+<td>
+<p>Type of autoscaling policy.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buffer</code></br>
+<em>
+<a href="#BufferPolicy">
+BufferPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Buffer policy config params. Present only if FleetAutoscalerPolicyType = Buffer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhook</code></br>
+<em>
+<a href="#WebhookPolicy">
+WebhookPolicy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Webhook policy config params. Present only if FleetAutoscalerPolicyType = Webhook.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscalerPolicyType">FleetAutoscalerPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>FleetAutoscalerPolicyType is the policy for autoscaling
+for a given Fleet</p>
+</p>
+<h3 id="FleetAutoscalerSpec">FleetAutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerSpec is the spec for a Fleet Scaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>fleetName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policy</code></br>
+<em>
+<a href="#FleetAutoscalerPolicy">
+FleetAutoscalerPolicy
+</a>
+</em>
+</td>
+<td>
+<p>Autoscaling policy</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetAutoscalerStatus">FleetAutoscalerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscaler">FleetAutoscaler</a>)
+</p>
+<p>
+<p>FleetAutoscalerStatus defines the current status of a FleetAutoscaler</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>currentReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>CurrentReplicas is the current number of gameserver replicas
+of the fleet managed by this autoscaler, as last seen by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>desiredReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>DesiredReplicas is the desired number of gameserver replicas
+of the fleet managed by this autoscaler, as last calculated by the autoscaler</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastScaleTime</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>lastScaleTime is the last time the FleetAutoscaler scaled the attached fleet,</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ableToScale</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>AbleToScale indicates that we can access the target fleet</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scalingLimited</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ScalingLimited indicates that the calculated scale would be above or below the range
+defined by MinReplicas and MaxReplicas, and has thus been capped.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetSpec">FleetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Fleet">Fleet</a>)
+</p>
+<p>
+<p>FleetSpec is the spec for a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#deploymentstrategy-v1-apps">
+Kubernetes apps/v1.DeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Deployment strategy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this Fleet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="FleetStatus">FleetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Fleet">Fleet</a>, 
+<a href="#FleetAutoscaleRequest">FleetAutoscaleRequest</a>)
+</p>
+<p>
+<p>FleetStatus is the status of a Fleet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas are the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerAllocationSpec">GameServerAllocationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationSpec is the spec for a GameServerAllocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>required</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Required The required allocation. Defaults to all GameServers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>preferred</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+[]Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Preferred ordered list of preferred allocations out of the <code>required</code> set.
+If the first selector is not matched,
+the selection attempts the second selector, and so on.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="#MetaPatch">
+MetaPatch
+</a>
+</em>
+</td>
+<td>
+<p>MetaPatch is optional custom metadata that is added to the game server at allocation
+You can use this to tell the server necessary session data</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerAllocationState">GameServerAllocationState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerAllocationStatus">GameServerAllocationStatus</a>)
+</p>
+<p>
+<p>GameServerAllocationState is the Allocation state</p>
+</p>
+<h3 id="GameServerAllocationStatus">GameServerAllocationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerAllocation">GameServerAllocation</a>)
+</p>
+<p>
+<p>GameServerAllocationStatus is the status for an GameServerAllocation resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code></br>
+<em>
+<a href="#GameServerAllocationState">
+GameServerAllocationState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of an GameServerAllocation, e.g. Allocated, or UnAllocated</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gameServerName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerPort">GameServerPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>GameServerPort defines a set of Ports that
+are to be exposed via the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the descriptive name of the port</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>portPolicy</code></br>
+<em>
+<a href="#PortPolicy">
+PortPolicy
+</a>
+</em>
+</td>
+<td>
+<p>PortPolicy defines the policy for how the HostPort is populated.
+Dynamic port will allocate a HostPort within the selected MIN_PORT and MAX_PORT range passed to the controller
+at installation time.
+When <code>static</code> is the policy specified, <code>HostPort</code> is required, to specify the port that game clients will
+connect to</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ContainerPort is the port that is being opened on the game server process</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>hostPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>HostPort the port exposed on the host for clients to connect to</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>protocol</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#protocol-v1-core">
+Kubernetes core/v1.Protocol
+</a>
+</em>
+</td>
+<td>
+<p>Protocol is the network protocol being used. Defaults to UDP. TCP is the only other option</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerSetSpec">GameServerSetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetSpec the specification for</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas are the number of GameServers that should be in this set</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#GameServerTemplateSpec">
+GameServerTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template the GameServer template to apply for this GameServerSet</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerSetStatus">GameServerSetStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerSet">GameServerSet</a>)
+</p>
+<p>
+<p>GameServerSetStatus is the status of a GameServerSet</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>replicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>Replicas the total number of current GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>readyReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReadyReplicas are the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>allocatedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>AllocatedReplicas are the number of Allocated GameServer replicas</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerSpec">GameServerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServer">GameServer</a>, 
+<a href="#GameServerTemplateSpec">GameServerTemplateSpec</a>)
+</p>
+<p>
+<p>GameServerSpec is the spec for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code></br>
+<em>
+<a href="#Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerState">GameServerState
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>GameServerState is the state for the GameServer</p>
+</p>
+<h3 id="GameServerStatus">GameServerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServer">GameServer</a>)
+</p>
+<p>
+<p>GameServerStatus is the status for a GameServer resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>state</code></br>
+<em>
+<a href="#GameServerState">
+GameServerState
+</a>
+</em>
+</td>
+<td>
+<p>GameServerState is the current state of a GameServer, e.g. Creating, Starting, Ready, etc</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#GameServerStatusPort">
+[]GameServerStatusPort
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerStatusPort">GameServerStatusPort
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerAllocationStatus">GameServerAllocationStatus</a>, 
+<a href="#GameServerStatus">GameServerStatus</a>)
+</p>
+<p>
+<p>GameServerStatusPort shows the port that was allocated to a
+GameServer.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>port</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GameServerTemplateSpec">GameServerTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetSpec">FleetSpec</a>, 
+<a href="#GameServerSetSpec">GameServerSetSpec</a>)
+</p>
+<p>
+<p>GameServerTemplateSpec is a template for GameServers</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#GameServerSpec">
+GameServerSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Container specifies which Pod container is the game server. Only required if there is more than one
+container defined</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ports</code></br>
+<em>
+<a href="#GameServerPort">
+[]GameServerPort
+</a>
+</em>
+</td>
+<td>
+<p>Ports are the array of ports that can be exposed via the game server</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>health</code></br>
+<em>
+<a href="#Health">
+Health
+</a>
+</em>
+</td>
+<td>
+<p>Health configures health checking</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scheduling</code></br>
+<em>
+<a href="#SchedulingStrategy">
+SchedulingStrategy
+</a>
+</em>
+</td>
+<td>
+<p>Scheduling strategy. Defaults to &ldquo;Packed&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the Pod that will be created for the GameServer</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Health">Health
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>Health configures health checking on the GameServer</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>disabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Disabled is whether health checking is disabled or not</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>periodSeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>PeriodSeconds is the number of seconds each health ping has to occur in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>failureThreshold</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>FailureThreshold how many failures in a row constitutes unhealthy</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>initialDelaySeconds</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>InitialDelaySeconds initial delay before checking health</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="MetaPatch">MetaPatch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAllocationSpec">FleetAllocationSpec</a>, 
+<a href="#GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MetaPatch is the metadata used to patch the GameServer metadata on allocation</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>labels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>annotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="PortPolicy">PortPolicy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerPort">GameServerPort</a>)
+</p>
+<p>
+<p>PortPolicy is the port policy for the GameServer</p>
+</p>
+<h3 id="SchedulingStrategy">SchedulingStrategy
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetSpec">FleetSpec</a>, 
+<a href="#GameServerAllocationSpec">GameServerAllocationSpec</a>, 
+<a href="#GameServerSetSpec">GameServerSetSpec</a>, 
+<a href="#GameServerSpec">GameServerSpec</a>)
+</p>
+<p>
+<p>SchedulingStrategy is the strategy that a Fleet &amp; GameServers will use
+when scheduling GameServers&rsquo; Pods across a cluster.</p>
+</p>
+<h3 id="WebhookPolicy">WebhookPolicy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#FleetAutoscalerPolicy">FleetAutoscalerPolicy</a>)
+</p>
+<p>
+<p>WebhookPolicy controls the desired behavior of the webhook policy.
+It contains the description of the webhook autoscaler service
+used to form url which is accessible inside the cluster</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>url</code> gives the location of the webhook, in standard URL form
+(<code>scheme://host:port/path</code>). Exactly one of <code>url</code> or <code>service</code>
+must be specified.</p>
+<p>The <code>host</code> should not refer to a service running in the cluster; use
+the <code>service</code> field instead. The host might be resolved via external
+DNS in some apiservers (e.g., <code>kube-apiserver</code> cannot resolve
+in-cluster DNS as that would be a layering violation). <code>host</code> may
+also be an IP address.</p>
+<p>Please note that using <code>localhost</code> or <code>127.0.0.1</code> as a <code>host</code> is
+risky unless you take great care to run this webhook on all hosts
+which run an apiserver which might need to make calls to this
+webhook. Such installs are likely to be non-portable, i.e., not easy
+to turn up in a new cluster.</p>
+<p>The scheme must be &ldquo;https&rdquo;; the URL must begin with &ldquo;https://&rdquo;.</p>
+<p>A path is optional, and if present may be any string permissible in
+a URL. You may use the path to pass an arbitrary string to the
+webhook, for example, a cluster identifier.</p>
+<p>Attempting to use a user or basic auth e.g. &ldquo;user:password@&rdquo; is not
+allowed. Fragments (&ldquo;#&hellip;&rdquo;) and query parameters (&ldquo;?&hellip;&rdquo;) are not
+allowed, either.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>service</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#servicereference-v1beta1-admissionregistration">
+Kubernetes admissionregistration/v1beta1.ServiceReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>service</code> is a reference to the service for this webhook. Either
+<code>service</code> or <code>url</code> must be specified.</p>
+<p>If the webhook is running within the cluster, then you should use <code>service</code>.</p>
+<p>Port 443 will be used if it is open, otherwise it is an error.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caBundle</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p><code>caBundle</code> is a PEM encoded CA bundle which will be used to validate the webhook&rsquo;s server certificate.
+If unspecified, system trust roots on the apiserver are used.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>.
+</em></p>
+{{% /feature %}}
+

--- a/site/gen-api-docs.sh
+++ b/site/gen-api-docs.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2019 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd /go/src/github.com/ahmetb/gen-crd-api-reference-docs
+cp /go/src/agones.dev/agones/site/assets/templates/pkg.tpl ./template
+
+FILE=${FILE:-/go/src/agones.dev/agones/site/content/en/docs/Reference/agones_crd_api_reference.html}
+VERSION=${VERSION:-"0.9.0"}
+
+HEAD="/tmp/head.html"
+RESULT="/tmp/agones_crd_api_reference.html"
+OLD="/tmp/old_docs.html"
+
+./gen-crd-api-reference-docs --config ./example-config.json --api-dir ../../../agones.dev/agones/pkg/apis/stable/v1alpha1/ --out-file $RESULT
+awk '/\ feature\ publishVersion/{flag=1;next}/\ \/feature/{flag=0}flag' $FILE > $OLD
+
+awk '//{flag=1}/\ feature\ publishVersion/{flag=0;exit}flag' $FILE > $HEAD
+doc_version=$(grep 'feature publishVersion=' $FILE )
+echo $doc_version
+publish='{{% feature publishVersion="'$VERSION'" %}}'
+expiry='{{% feature expiryVersion="'$VERSION'" %}}'
+function sedeasy {
+  sed -i "s/$(echo $1 | sed -e 's/\([[\/.*]\|\]\)/\\&/g')/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g" $3
+}
+
+diff $RESULT $OLD
+if [ $? -gt 0 ]
+then 
+echo "Output to a file $FILE"
+
+if [ "$publish" != "$doc_version" ]
+then 
+    echo "Tagging old docs with expiryVersion shortcode"
+
+    sedeasy "$doc_version" "$expiry"  $FILE 
+    cat $FILE > $HEAD
+fi
+cat $HEAD > $FILE
+echo -e '\n{{% feature publishVersion="'$VERSION'" %}}' >> $FILE
+cat $RESULT >> $FILE
+echo -e '{{% /feature %}}\n' >> $FILE
+fi


### PR DESCRIPTION
Add [gen-crd-api-reference-docs](https://github.com/ahmetb/gen-crd-api-reference-docs) utility into build-image, generate Agones CRD reference html document, map this doc to existent docs structure.
Covers #409.