### PR TITLE
 Merge hotfix 0.8.1 back into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v0.8.1](https://github.com/GoogleCloudPlatform/agones/tree/v0.8.1) (2019-03-14)
+
+[Full Changelog](https://github.com/GoogleCloudPlatform/agones/compare/v0.8.0...v0.8.1)
+
+**Fixed bugs:**
+
+- SDK Service Account was Hardcoded [\#629](https://github.com/GoogleCloudPlatform/agones/pull/629) ([markmandel](https://github.com/markmandel))
+
+**Merged pull requests:**
+
+- Tarballing source into the images for dependencies that are required by their licenses. [\#634](https://github.com/GoogleCloudPlatform/agones/pull/634) ([bbf](https://github.com/bbf))
+- 2 Hotfixes: Allow Helm to reference image digests and inject licenses [\#631](https://github.com/GoogleCloudPlatform/agones/pull/631) ([bbf](https://github.com/bbf))
+- \[Hotfix\] Prep work for hotfix 0.8.1 [\#628](https://github.com/GoogleCloudPlatform/agones/pull/628) ([markmandel](https://github.com/markmandel))
+
 ## [v0.8.0](https://github.com/GoogleCloudPlatform/agones/tree/v0.8.0) (2019-02-20)
 
 [Full Changelog](https://github.com/GoogleCloudPlatform/agones/compare/v0.8.0-rc...v0.8.0)
@@ -22,6 +36,7 @@
 
 **Merged pull requests:**
 
+- Release 0.8.0 [\#605](https://github.com/GoogleCloudPlatform/agones/pull/605) ([markmandel](https://github.com/markmandel))
 - Remove deprecation from FleetAllocation [\#603](https://github.com/GoogleCloudPlatform/agones/pull/603) ([markmandel](https://github.com/markmandel))
 - Remove -v from Go testing - becomes too noisy [\#595](https://github.com/GoogleCloudPlatform/agones/pull/595) ([markmandel](https://github.com/markmandel))
 - Minor tweaks to release process. [\#592](https://github.com/GoogleCloudPlatform/agones/pull/592) ([markmandel](https://github.com/markmandel))
@@ -80,6 +95,7 @@
 **Closed issues:**
 
 - Grafana: add graph of nodes in cluster [\#547](https://github.com/GoogleCloudPlatform/agones/issues/547)
+- Replace global allocation mutex with fine-grained concurrency controls. [\#535](https://github.com/GoogleCloudPlatform/agones/issues/535)
 - Approver access for @jkowalski [\#526](https://github.com/GoogleCloudPlatform/agones/issues/526)
 - Docker images layers not optimal [\#481](https://github.com/GoogleCloudPlatform/agones/issues/481)
 - Release 0.7.0 [\#477](https://github.com/GoogleCloudPlatform/agones/issues/477)

--- a/build/Makefile
+++ b/build/Makefile
@@ -297,8 +297,12 @@ lint: $(ensure-build-image)
 build-licenses:
 	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/extract-licenses.sh
 
+# Tarball source for dependencies that are required to be distributed with the image (MPL)
+build-required-src-dist:
+	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/build-required-src-dist.sh
+
 # Build the image for the gameserver controller
-build-controller-image: $(ensure-build-image) build-controller-binary build-licenses
+build-controller-image: $(ensure-build-image) build-controller-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_tag) $(DOCKER_BUILD_ARGS)
 
 # push the gameservers controller image
@@ -326,7 +330,7 @@ build-agones-sdk-binary-windows: $(ensure-build-image)
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server
 
 # Build the image for the gameserver sidecar
-build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses
+build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
 
 # Build a static binary for the ping service
@@ -340,7 +344,7 @@ push-ping-image: $(ensure-build-image)
 	docker push $(ping_tag)
 
 # Build the image for the ping service
-build-ping-image: $(ensure-build-image) build-ping-binary build-licenses
+build-ping-image: $(ensure-build-image) build-ping-binary build-licenses build-required-src-dist
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_tag) $(DOCKER_BUILD_ARGS)
 
 # Build the cpp sdk linux archive

--- a/build/Makefile
+++ b/build/Makefile
@@ -293,8 +293,12 @@ lint: $(ensure-build-image)
 	docker run -t -e "TERM=xterm-256color" --rm $(common_mounts) -w $(mount_path) $(DOCKER_RUN_ARGS) $(build_tag) bash -c \
 		"golangci-lint run ./examples/... && golangci-lint run --deadline $(LINT_TIMEOUT) ./..."
 
+# Extract licenses from source tree
+build-licenses:
+	docker run --rm $(common_mounts) $(build_tag) $(mount_path)/build/extract-licenses.sh
+
 # Build the image for the gameserver controller
-build-controller-image: $(ensure-build-image) build-controller-binary
+build-controller-image: $(ensure-build-image) build-controller-binary build-licenses
 	docker build $(agones_path)/cmd/controller/ --tag=$(controller_tag) $(DOCKER_BUILD_ARGS)
 
 # push the gameservers controller image
@@ -322,7 +326,7 @@ build-agones-sdk-binary-windows: $(ensure-build-image)
 		-o $(go_build_base_path)/cmd/sdk-server/bin/sdk-server.windows.amd64.exe $(go_rebuild_flags) $(go_version_flags) $(agones_package)/cmd/sdk-server
 
 # Build the image for the gameserver sidecar
-build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary
+build-agones-sdk-image: $(ensure-build-image) build-agones-sdk-binary build-licenses
 	docker build $(agones_path)/cmd/sdk-server/ --tag=$(sidecar_tag) $(DOCKER_BUILD_ARGS)
 
 # Build a static binary for the ping service
@@ -336,7 +340,7 @@ push-ping-image: $(ensure-build-image)
 	docker push $(ping_tag)
 
 # Build the image for the ping service
-build-ping-image: $(ensure-build-image) build-ping-binary
+build-ping-image: $(ensure-build-image) build-ping-binary build-licenses
 	docker build $(agones_path)/cmd/ping/ --tag=$(ping_tag) $(DOCKER_BUILD_ARGS)
 
 # Build the cpp sdk linux archive

--- a/build/extract-licenses.sh
+++ b/build/extract-licenses.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+append_license() {
+  lib=$1
+  path=$2
+  echo "================================================================================" >> ${TMP_LICENSES}
+  echo "= ${lib} licensed under: =" >> ${TMP_LICENSES}
+  echo >> ${TMP_LICENSES}
+  cat "$path" >> ${TMP_LICENSES}
+  echo >> ${TMP_LICENSES}
+  echo "= ${path} MD5 $(cat "${path}" | md5sum | awk '{print $1}')" >> ${TMP_LICENSES}
+  echo "================================================================================" >> ${TMP_LICENSES}
+  echo >> ${TMP_LICENSES}
+
+}
+
+SRC_ROOT=$(dirname "${BASH_SOURCE}")/..
+TMP_LICENSES=/tmp/LICENSES
+
+cd ${SRC_ROOT}
+
+# Clear file
+echo > ${TMP_LICENSES}
+
+append_license "Agones" "LICENSE"
+
+while read -r entry; do
+  LIBRARY=${entry#vendor\/}
+  LIBRARY=$(expr match "$LIBRARY" '\(.*\)/LICENSE.*\?')
+  append_license ${LIBRARY} ${entry}
+done <<< "$(find vendor/ -regextype posix-extended -iregex '.*LICENSE(\.txt)?')"
+
+for ddir in ${SRC_ROOT}/cmd/controller/bin/ ${SRC_ROOT}/cmd/ping/bin/ ${SRC_ROOT}/cmd/sdk-server/bin/ ; do
+  mkdir -p ${ddir}
+  cp ${TMP_LICENSES} ${ddir}
+done
+

--- a/build/includes/release.mk
+++ b/build/includes/release.mk
@@ -25,6 +25,7 @@
 
 # generate a changelog using github-changelog-generator
 gen-changelog: RELEASE_VERSION ?= $(base_version)
+gen-changelog: RELEASE_BRANCH ?= master
 gen-changelog:
 	read -p 'Github Token: ' TOKEN && \
     docker run -it --rm -v "$(agones_path)":/project markmandel/github-changelog-generator \
@@ -32,6 +33,7 @@ gen-changelog:
 		--bug-labels=kind/bug --enhancement-labels=kind/feature \
 		--breaking-labels=kind/breaking --security-labels=area/security \
 		--future-release "v$(RELEASE_VERSION)" \
+		--release-branch=$(RELEASE_BRANCH) \
 		--token $$TOKEN
 
 # Creates a release. Version defaults to the base_version

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -1,9 +1,24 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine:3.8
 
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
-COPY  --chown=agones:root ./bin/controller /home/agones/controller
+COPY --chown=agones:root ./bin/controller /home/agones/controller
+COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
 
 USER agones
 ENTRYPOINT ["/home/agones/controller"]

--- a/cmd/controller/Dockerfile
+++ b/cmd/controller/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --update add ca-certificates && \
     adduser -D agones
 
 COPY --chown=agones:root ./bin/controller /home/agones/controller
-COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
+COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
 USER agones
 ENTRYPOINT ["/home/agones/controller"]

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -59,6 +59,7 @@ const (
 	sidecarImageFlag             = "sidecar-image"
 	sidecarCPURequestFlag        = "sidecar-cpu-request"
 	sidecarCPULimitFlag          = "sidecar-cpu-limit"
+	sdkServerAccountFlag         = "sdk-service-account"
 	pullSidecarFlag              = "always-pull-sidecar"
 	minPortFlag                  = "min-port"
 	maxPortFlag                  = "max-port"
@@ -188,7 +189,7 @@ func main() {
 
 	gsController := gameservers.NewController(wh, health,
 		ctlConf.MinPort, ctlConf.MaxPort, ctlConf.SidecarImage, ctlConf.AlwaysPullSidecar,
-		ctlConf.SidecarCPURequest, ctlConf.SidecarCPULimit,
+		ctlConf.SidecarCPURequest, ctlConf.SidecarCPULimit, ctlConf.SdkServiceAccount,
 		kubeClient, kubeInformerFactory, extClient, agonesClient, agonesInformerFactory)
 	gsSetController := gameserversets.NewController(wh, health, gsCounter,
 		kubeClient, extClient, agonesClient, agonesInformerFactory)
@@ -231,6 +232,7 @@ func parseEnvFlags() config {
 	viper.SetDefault(sidecarCPURequestFlag, "0")
 	viper.SetDefault(sidecarCPULimitFlag, "0")
 	viper.SetDefault(pullSidecarFlag, false)
+	viper.SetDefault(sdkServerAccountFlag, "agones-sdk")
 	viper.SetDefault(certFileFlag, filepath.Join(base, "certs/server.crt"))
 	viper.SetDefault(keyFileFlag, filepath.Join(base, "certs/server.key"))
 	viper.SetDefault(enablePrometheusMetricsFlag, true)
@@ -246,6 +248,7 @@ func parseEnvFlags() config {
 	pflag.String(sidecarCPULimitFlag, viper.GetString(sidecarCPULimitFlag), "Flag to overwrite the GameServer sidecar container's cpu limit. Can also use SIDECAR_CPU_LIMIT env variable")
 	pflag.String(sidecarCPURequestFlag, viper.GetString(sidecarCPURequestFlag), "Flag to overwrite the GameServer sidecar container's cpu request. Can also use SIDECAR_CPU_REQUEST env variable")
 	pflag.Bool(pullSidecarFlag, viper.GetBool(pullSidecarFlag), "For development purposes, set the sidecar image to have a ImagePullPolicy of Always. Can also use ALWAYS_PULL_SIDECAR env variable")
+	pflag.String(sdkServerAccountFlag, viper.GetString(sdkServerAccountFlag), "Overwrite what service account default for GameServer Pods. Defaults to Can also use SDK_SERVICE_ACCOUNT")
 	pflag.Int32(minPortFlag, 0, "Required. The minimum port that that a GameServer can be allocated to. Can also use MIN_PORT env variable.")
 	pflag.Int32(maxPortFlag, 0, "Required. The maximum port that that a GameServer can be allocated to. Can also use MAX_PORT env variable")
 	pflag.String(keyFileFlag, viper.GetString(keyFileFlag), "Optional. Path to the key file")
@@ -266,6 +269,7 @@ func parseEnvFlags() config {
 	runtime.Must(viper.BindEnv(sidecarCPULimitFlag))
 	runtime.Must(viper.BindEnv(sidecarCPURequestFlag))
 	runtime.Must(viper.BindEnv(pullSidecarFlag))
+	runtime.Must(viper.BindEnv(sdkServerAccountFlag))
 	runtime.Must(viper.BindEnv(minPortFlag))
 	runtime.Must(viper.BindEnv(maxPortFlag))
 	runtime.Must(viper.BindEnv(keyFileFlag))
@@ -297,6 +301,7 @@ func parseEnvFlags() config {
 		SidecarImage:          viper.GetString(sidecarImageFlag),
 		SidecarCPURequest:     request,
 		SidecarCPULimit:       limit,
+		SdkServiceAccount:     viper.GetString(sdkServerAccountFlag),
 		AlwaysPullSidecar:     viper.GetBool(pullSidecarFlag),
 		KeyFile:               viper.GetString(keyFileFlag),
 		CertFile:              viper.GetString(certFileFlag),
@@ -319,6 +324,7 @@ type config struct {
 	SidecarImage          string
 	SidecarCPURequest     resource.Quantity
 	SidecarCPULimit       resource.Quantity
+	SdkServiceAccount     string
 	AlwaysPullSidecar     bool
 	PrometheusMetrics     bool
 	Stackdriver           bool

--- a/cmd/ping/Dockerfile
+++ b/cmd/ping/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --update add ca-certificates && \
     adduser -D agones
 
 COPY --chown=agones:root ./bin/ping /home/agones/ping
+COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
 
 USER agones
 ENTRYPOINT ["/home/agones/ping"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -1,9 +1,24 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine:3.8
 
 RUN apk --update add ca-certificates && \
     adduser -D agones
 
 COPY --chown=agones:root ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
+COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
 
 USER agones
 ENTRYPOINT ["/home/agones/sdk-server"]

--- a/cmd/sdk-server/Dockerfile
+++ b/cmd/sdk-server/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --update add ca-certificates && \
     adduser -D agones
 
 COPY --chown=agones:root ./bin/sdk-server.linux.amd64 /home/agones/sdk-server
-COPY --chown=agones:root ./bin/LICENSES /home/agones/LICENSES
+COPY --chown=agones:root ./bin/LICENSES ./bin/dependencies-src.tgz /home/agones/
 
 USER agones
 ENTRYPOINT ["/home/agones/sdk-server"]

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -84,6 +84,8 @@ spec:
           value: {{ .Values.agones.image.sdk.alwaysPull | quote }}
         - name: SIDECAR_CPU_REQUEST
           value: {{ .Values.agones.image.sdk.cpuRequest | quote }}
+        - name: SDK_SERVICE_ACCOUNT
+          value: {{ .Values.agones.serviceaccount.sdk | quote }}
         - name: PROMETHEUS_EXPORTER
           value: {{ .Values.agones.metrics.prometheusEnabled | quote }}
         - name: STACKDRIVER_EXPORTER

--- a/install/helm/agones/templates/controller.yaml
+++ b/install/helm/agones/templates/controller.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: {{ .Values.agones.serviceaccount.controller }}
       containers:
       - name: agones-controller
-        image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ .Values.agones.image.tag }}"
+        image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.controller.name}}:{{ default .Values.agones.image.tag .Values.agones.image.controller.tag }}"
         imagePullPolicy: {{ .Values.agones.image.controller.pullPolicy }}
         env:
         # minimum port that can be exposed to GameServer traffic
@@ -79,7 +79,7 @@ spec:
         - name: MAX_PORT
           value: {{ .Values.gameservers.maxPort | quote }}
         - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
-          value: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.sdk.name}}:{{ .Values.agones.image.tag }}"
+          value: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.sdk.name}}:{{ default .Values.agones.image.tag .Values.agones.image.sdk.tag }}"
         - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
           value: {{ .Values.agones.image.sdk.alwaysPull | quote }}
         - name: SIDECAR_CPU_REQUEST

--- a/install/helm/agones/templates/ping.yaml
+++ b/install/helm/agones/templates/ping.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       containers:
         - name: agones-ping
-          image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.ping.name}}:{{ .Values.agones.image.tag }}"
+          image: "{{ .Values.agones.image.registry }}/{{ .Values.agones.image.ping.name}}:{{ default .Values.agones.image.tag .Values.agones.image.ping.tag }}"
           imagePullPolicy: {{ .Values.agones.image.ping.pullPolicy }}
 {{- if .Values.agones.ping.resources }}
           resources:

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -20,7 +20,11 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 ---
@@ -31,7 +35,11 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 rules:
@@ -74,7 +82,11 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -108,7 +120,11 @@ metadata:
   namespace: default
   labels:
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 ---
@@ -119,7 +135,11 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 rules:
@@ -137,7 +157,11 @@ metadata:
   namespace: default
   labels:
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -173,7 +197,11 @@ metadata:
   labels:
     component: crd
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -368,7 +396,11 @@ metadata:
   labels:
     component: crd
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -433,7 +465,11 @@ metadata:
   labels:
     component: crd
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -514,7 +550,11 @@ metadata:
   labels:
     component: crd
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -672,7 +712,11 @@ metadata:
   labels:
     component: crd
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -789,7 +833,11 @@ metadata:
   labels:
     component: crd
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -979,7 +1027,11 @@ metadata:
   labels:
     stable.agones.dev/role: controller
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1015,7 +1067,11 @@ metadata:
   labels:
     component: controller
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1060,7 +1116,11 @@ spec:
       serviceAccountName: agones-controller
       containers:
       - name: agones-controller
+<<<<<<< HEAD
         image: "gcr.io/agones-images/agones-controller:0.9.0"
+=======
+        image: "gcr.io/agones-images/agones-controller:0.8.1"
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
         imagePullPolicy: IfNotPresent
         env:
         # minimum port that can be exposed to GameServer traffic
@@ -1070,7 +1130,11 @@ spec:
         - name: MAX_PORT
           value: "8000"
         - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
+<<<<<<< HEAD
           value: "gcr.io/agones-images/agones-sdk:0.9.0"
+=======
+          value: "gcr.io/agones-images/agones-sdk:0.8.1"
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
         - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
           value: "false"
         - name: SIDECAR_CPU_REQUEST
@@ -1138,7 +1202,11 @@ metadata:
   labels:
     component: ping
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1175,7 +1243,11 @@ spec:
       priorityClassName: agones-system
       containers:
         - name: agones-ping
+<<<<<<< HEAD
           image: "gcr.io/agones-images/agones-ping:0.9.0"
+=======
+          image: "gcr.io/agones-images/agones-ping:0.8.1"
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -1199,7 +1271,11 @@ metadata:
   labels:
     component: ping
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1220,7 +1296,11 @@ metadata:
   labels:
     component: ping
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1316,7 +1396,11 @@ metadata:
   labels:
     component: controller
     app: agones
+<<<<<<< HEAD
     chart: agones-0.9.0
+=======
+    chart: agones-0.8.1
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 webhooks:
@@ -1348,7 +1432,11 @@ metadata:
   namespace: agones-system
   labels:
     app: agones-manual
+<<<<<<< HEAD
     chart: "agones-0.9.0"
+=======
+    chart: "agones-0.8.1"
+>>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: "agones-manual"
     heritage: "Tiller"
 type: Opaque

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -1139,6 +1139,8 @@ spec:
           value: "false"
         - name: SIDECAR_CPU_REQUEST
           value: "30m"
+        - name: SDK_SERVICE_ACCOUNT
+          value: "agones-sdk"
         - name: PROMETHEUS_EXPORTER
           value: "true"
         - name: STACKDRIVER_EXPORTER

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -20,11 +20,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 ---
@@ -35,11 +31,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 rules:
@@ -82,11 +74,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -120,11 +108,7 @@ metadata:
   namespace: default
   labels:
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 ---
@@ -135,11 +119,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 rules:
@@ -157,11 +137,7 @@ metadata:
   namespace: default
   labels:
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 subjects:
@@ -197,11 +173,7 @@ metadata:
   labels:
     component: crd
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -396,11 +368,7 @@ metadata:
   labels:
     component: crd
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -465,11 +433,7 @@ metadata:
   labels:
     component: crd
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -550,11 +514,7 @@ metadata:
   labels:
     component: crd
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -712,11 +672,7 @@ metadata:
   labels:
     component: crd
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -833,11 +789,7 @@ metadata:
   labels:
     component: crd
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1027,11 +979,7 @@ metadata:
   labels:
     stable.agones.dev/role: controller
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1067,11 +1015,7 @@ metadata:
   labels:
     component: controller
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1116,11 +1060,7 @@ spec:
       serviceAccountName: agones-controller
       containers:
       - name: agones-controller
-<<<<<<< HEAD
         image: "gcr.io/agones-images/agones-controller:0.9.0"
-=======
-        image: "gcr.io/agones-images/agones-controller:0.8.1"
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
         imagePullPolicy: IfNotPresent
         env:
         # minimum port that can be exposed to GameServer traffic
@@ -1130,11 +1070,7 @@ spec:
         - name: MAX_PORT
           value: "8000"
         - name: SIDECAR_IMAGE # overwrite the GameServer sidecar image that is used
-<<<<<<< HEAD
           value: "gcr.io/agones-images/agones-sdk:0.9.0"
-=======
-          value: "gcr.io/agones-images/agones-sdk:0.8.1"
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
         - name: ALWAYS_PULL_SIDECAR # set the sidecar imagePullPolicy to Always
           value: "false"
         - name: SIDECAR_CPU_REQUEST
@@ -1204,11 +1140,7 @@ metadata:
   labels:
     component: ping
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1245,11 +1177,7 @@ spec:
       priorityClassName: agones-system
       containers:
         - name: agones-ping
-<<<<<<< HEAD
           image: "gcr.io/agones-images/agones-ping:0.9.0"
-=======
-          image: "gcr.io/agones-images/agones-ping:0.8.1"
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -1273,11 +1201,7 @@ metadata:
   labels:
     component: ping
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1298,11 +1222,7 @@ metadata:
   labels:
     component: ping
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 spec:
@@ -1398,11 +1318,7 @@ metadata:
   labels:
     component: controller
     app: agones
-<<<<<<< HEAD
     chart: agones-0.9.0
-=======
-    chart: agones-0.8.1
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: agones-manual
     heritage: Tiller
 webhooks:
@@ -1434,11 +1350,7 @@ metadata:
   namespace: agones-system
   labels:
     app: agones-manual
-<<<<<<< HEAD
     chart: "agones-0.9.0"
-=======
-    chart: "agones-0.8.1"
->>>>>>> [Hotfix] Prep work for hotfix 0.8.1
     release: "agones-manual"
     heritage: "Tiller"
 type: Opaque

--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -375,14 +375,6 @@ func (gs *GameServer) Pod(sidecars ...corev1.Container) (*corev1.Pod, error) {
 
 	gs.podObjectMeta(pod)
 
-	// if the service account is not set, then you are in the "opinionated"
-	// mode. If the user sets the service account, we assume they know what they are
-	// doing, and don't disable the gameserver container.
-	if pod.Spec.ServiceAccountName == "" {
-		pod.Spec.ServiceAccountName = SidecarServiceAccountName
-		gs.disableServiceAccount(pod)
-	}
-
 	i, gsContainer, err := gs.FindGameServerContainer()
 	// this shouldn't happen, but if it does.
 	if err != nil {
@@ -472,8 +464,8 @@ func (gs *GameServer) podScheduling(pod *corev1.Pod) {
 	}
 }
 
-// disableServiceAccount disables the service account for the gameserver container
-func (gs *GameServer) disableServiceAccount(pod *corev1.Pod) {
+// DisableServiceAccount disables the service account for the gameserver container
+func (gs *GameServer) DisableServiceAccount(pod *corev1.Pod) {
 	// gameservers don't get access to the k8s api.
 	emptyVol := corev1.Volume{Name: "empty", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}
 	pod.Spec.Volumes = append(pod.Spec.Volumes, emptyVol)

--- a/pkg/apis/stable/v1alpha1/gameserver.go
+++ b/pkg/apis/stable/v1alpha1/gameserver.go
@@ -76,8 +76,6 @@ const (
 	// GameServerContainerAnnotation is the annotation that stores
 	// which container is the container that runs the dedicated game server
 	GameServerContainerAnnotation = stable.GroupName + "/container"
-	// SidecarServiceAccountName is the default service account for managing access to get/update GameServers
-	SidecarServiceAccountName = "agones-sdk"
 	// DevAddressAnnotation is an annotation to indicate that a GameServer hosted outside of Agones.
 	// A locally hosted GameServer is not managed by Agones it is just simply registered.
 	DevAddressAnnotation = "stable.agones.dev/dev-address"

--- a/pkg/apis/stable/v1alpha1/gameserver_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserver_test.go
@@ -416,7 +416,7 @@ func TestGameServerDisableServiceAccount(t *testing.T) {
 	assert.Len(t, pod.Spec.Containers, 1)
 	assert.Empty(t, pod.Spec.Containers[0].VolumeMounts)
 
-	gs.disableServiceAccount(pod)
+	gs.DisableServiceAccount(pod)
 	assert.Len(t, pod.Spec.Containers, 1)
 	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
 	assert.Equal(t, "/var/run/secrets/kubernetes.io/serviceaccount", pod.Spec.Containers[0].VolumeMounts[0].MountPath)

--- a/pkg/apis/stable/v1alpha1/gameserver_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserver_test.go
@@ -322,7 +322,6 @@ func TestGameServerPod(t *testing.T) {
 	assert.Equal(t, "gameserver", pod.ObjectMeta.Labels[stable.GroupName+"/role"])
 	assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Labels[GameServerPodLabel])
 	assert.Equal(t, fixture.Spec.Container, pod.ObjectMeta.Annotations[GameServerContainerAnnotation])
-	assert.Equal(t, "agones-sdk", pod.Spec.ServiceAccountName)
 	assert.True(t, metav1.IsControlledBy(pod, fixture))
 	assert.Equal(t, fixture.Spec.Ports[0].HostPort, pod.Spec.Containers[0].Ports[0].HostPort)
 	assert.Equal(t, fixture.Spec.Ports[0].ContainerPort, pod.Spec.Containers[0].Ports[0].ContainerPort)

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -528,9 +528,12 @@ func (c *Controller) createGameServerPod(gs *v1alpha1.GameServer) (*v1alpha1.Gam
 		return gs, err
 	}
 
-	// apply the sdk service account
+	// if the service account is not set, then you are in the "opinionated"
+	// mode. If the user sets the service account, we assume they know what they are
+	// doing, and don't disable the gameserver container.
 	if pod.Spec.ServiceAccountName == "" {
 		pod.Spec.ServiceAccountName = c.sdkServiceAccount
+		gs.DisableServiceAccount(pod)
 	}
 
 	c.addGameServerHealthCheck(gs, pod)

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -776,6 +776,7 @@ func TestControllerCreateGameServerPod(t *testing.T) {
 
 			assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Name)
 			assert.Equal(t, fixture.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
+			assert.Equal(t, "sdk-service-account", pod.Spec.ServiceAccountName)
 			assert.Equal(t, "gameserver", pod.ObjectMeta.Labels[stable.GroupName+"/role"])
 			assert.Equal(t, fixture.ObjectMeta.Name, pod.ObjectMeta.Labels[v1alpha1.GameServerPodLabel])
 			assert.True(t, metav1.IsControlledBy(pod, fixture))
@@ -1189,7 +1190,8 @@ func newFakeController() (*Controller, agtesting.Mocks) {
 	wh := webhooks.NewWebHook(http.NewServeMux())
 	c := NewController(wh, healthcheck.NewHandler(),
 		10, 20, "sidecar:dev", false,
-		resource.MustParse("0.05"), resource.MustParse("0.1"), m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
+		resource.MustParse("0.05"), resource.MustParse("0.1"), "sdk-service-account",
+		m.KubeClient, m.KubeInformerFactory, m.ExtClient, m.AgonesClient, m.AgonesInformerFactory)
 	c.recorder = m.FakeRecorder
 	return c, m
 }

--- a/site/config.toml
+++ b/site/config.toml
@@ -86,9 +86,9 @@ github_repo = "https://github.com/GoogleCloudPlatform/agones"
 gcs_engine_id = "002375903941309441958:rceiko9wfuw"
 
 # current release branch - could be rc
-release_branch = "release-0.8.0"
+release_branch = "release-0.8.1"
 # the main version. Never is rc.
-release_version = "0.8.0"
+release_version = "0.8.1"
 
 # User interface configuration
 [params.ui]

--- a/site/content/en/blog/releases/0.8.1.md
+++ b/site/content/en/blog/releases/0.8.1.md
@@ -1,0 +1,42 @@
+---
+title: "0.8.1 - Helm Configuration Hotfix"
+linkTitle: "0.8.0"
+date: 2019-03-14
+description:
+---
+
+Hotfixes to Helm configuration options, and bug fixes. 
+
+As always, huge thanks to the team of people working on Agones! 
+
+Details:
+Check the <a href="https://github.com/GoogleCloudPlatform/agones/tree/release-0.8.1" data-proofer-ignore>README</a> for details on features, installation and usage.
+
+This is the 0.8.1 release of Agones.
+
+Check the <a href="https://github.com/GoogleCloudPlatform/agones/tree/release-0.8.1" data-proofer-ignore>README</a> for details on features, installation and usage.
+
+**Merged pull requests:**
+
+- Tarballing source into the images for dependencies that are required by their licenses. [\#634](https://github.com/GoogleCloudPlatform/agones/pull/634) ([bbf](https://github.com/bbf))
+- 2 Hotfixes: Allow Helm to reference image digests and inject licenses [\#631](https://github.com/GoogleCloudPlatform/agones/pull/631) ([bbf](https://github.com/bbf))
+- \[Hotfix\] Prep work for hotfix 0.8.1 [\#628](https://github.com/GoogleCloudPlatform/agones/pull/628) ([markmandel](https://github.com/markmandel))
+
+See <a href="https://github.com/GoogleCloudPlatform/agones/blob/release-0.8.1/CHANGELOG.md" data-proofer-ignore>CHANGELOG</a> for more details on changes.
+
+This software is currently alpha, and subject to change. Not to be used in production systems.
+
+Images available with this release:
+
+- [gcr.io/agones-images/agones-controller:0.8.1](https://gcr.io/agones-images/agones-controller:0.8.1)
+- [gcr.io/agones-images/agones-sdk:0.8.1](https://gcr.io/agones-images/agones-sdk:0.8.1)
+- [gcr.io/agones-images/agones-ping:0.8.1](https://gcr.io/agones-images/agones-ping:0.8.1)
+- [gcr.io/agones-images/cpp-simple-server:0.4](https://gcr.io/agones-images/cpp-simple-server:0.4)
+- [gcr.io/agones-images/udp-server:0.7](https://gcr.io/agones-images/udp-server:0.7)
+- [gcr.io/agones-images/xonotic-example:0.4](https://gcr.io/agones-images/xonotic-example:0.4)
+
+Helm chart available with this release:
+
+- <a href="https://agones.dev/chart/stable/agones-0.8.1.tgz" data-proofer-ignore><code>helm install agones/agones --version 0.8.1</code></a>
+
+> Make sure to add our stable helm repository using `helm repo add https://agones.dev/chart/stable`


### PR DESCRIPTION
This is almost identical to all the previously approved PRs for 0.8.1

The only difference is that GameServer.DisableServiceAccount needed to be
made public, and get called from the GameServer controller instead.

I've left all the original commits, as I figured it made sense to maintain the history in this instance (although happy to take dissenting opinions).