### PR TITLE
Simplify homepage messaging

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -22,31 +22,37 @@ linkTitle = "Agones"
 {{% blocks/lead color="primary" %}}
 <strong>What is Agones?</strong>
 
-Agones is an open source project that is built to be a batteries-included, dedicated game server scaling and
-orchestration platform. It is built as a native extension of [Kubernetes](https://kubernetes.io), with the flexibility you need to tailor
-it to the requirements of your multiplayer game. Anywhere you can run Kubernetes, you can run Agones.
-
+An open source, batteries-included, mulitplayer dedicated game server scaling and
+orchestration platform that can run anywhere [Kubernetes](https://kubernetes.io) can run.
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" >}}
-{{% blocks/feature icon="fas fa-file-code" title="Fleets of GameServers" url="./docs/getting-started/" %}}
-Define Fleets of GameServers, autoscaling and more, through YAML or the Kubernetes API.
+{{% blocks/feature icon="fas fa-file-code" title="Orchestrate Game Servers" url="./docs/getting-started/" %}}
+Define and manage groups of ready gameservers through YAML configuration or API calls.
 {{% /blocks/feature %}}
 
-
-{{% blocks/feature icon="fas fa-wrench" title="Integrated SDK" url="./docs/guides/client-sdks/" %}}
+{{% blocks/feature icon="fas fa-wrench" title="Integrate any Engine" url="./docs/guides/client-sdks/" %}}
 Integrated SDK for managing game server lifecyle, health and configuration.
 
 Tools for local development included!
 {{% /blocks/feature %}}
 
 
-{{% blocks/feature icon="fas fa-chart-area" title="Metrics" url="./docs/guides/metrics/" %}}
+{{% blocks/feature icon="fas fa-chart-area" title="Metrics and Monitoring" url="./docs/guides/metrics/" %}}
 Integration with [OpenCensus](https://opencensus.io/)
-for backend agnostic game server metrics and monitoring
+for backend agnostic game server metrics and monitoring dashboards
 {{% /blocks/feature %}}
 
 
+{{< /blocks/section >}}
+
+{{< blocks/section >}}
+<div class="col">
+<h2 class="text-center">Companies using Agones</h2>
+<p class="text-center">
+  coming soon!
+</p>
+</div
 {{< /blocks/section >}}
 
 {{< blocks/section  >}}


### PR DESCRIPTION
Pulling back on some of the Kubernetes terminology, and using some more generic language, to try and reach a slightly wider audience who (a) don't necessarily know Kubernetes very well, or possibly also don't know (b) dedicated game servers are used for multiplayer games either.

Also trying to keep things to shorter sentences, that are easier to parse and understand.

Also included a "Companies that use Agones" section, to setup for external parties to submit PRs to add to the list.