### PR TITLE
Add hash of account to clusterrolebinding name to support multiple accounts

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -692,7 +692,7 @@ If you get this error when building Agones in WSL (`make build`, `make test` or 
 
 #### Error: cluster-admin-binding already exists
 
-This surfaces while running `make gcloud-auth-cluster`. The solution is to run `kubectl delete clusterrolebinding cluster-admin-binding` then run `make gcloud-auth-cluster` again. If you run into a permission denied error when attempting the delete operation, you need to run `sudo chown <your username> <path to .kube/config>` to change ownership of the file to yourself.
+This surfaces while running `make gcloud-auth-cluster`. The solution is to run `kubectl describe clusterrolebinding | grep cluster-admin-binding- -A10`, find clusterrolebinding which belongs to your `User` account and then run `kubectl delete clusterrolebindings cluster-admin-binding-<md5Hash>` where `<md5Hash>` is a value specific to your account. Now you can execute `make gcloud-auth-cluster` again. If you run into a permission denied error when attempting the delete operation, you need to run `sudo chown <your username> <path to .kube/config>` to change ownership of the file to yourself.
 
 #### Error: releases do not exist
 

--- a/build/includes/google-cloud.mk
+++ b/build/includes/google-cloud.mk
@@ -65,7 +65,8 @@ gcloud-auth-cluster: $(ensure-build-image)
 	docker run --rm $(common_mounts) $(build_tag) gcloud config set container/cluster $(GCP_CLUSTER_NAME)
 	docker run --rm $(common_mounts) $(build_tag) gcloud config set compute/zone $(GCP_CLUSTER_ZONE)
 	docker run --rm $(common_mounts) $(build_tag) gcloud container clusters get-credentials $(GCP_CLUSTER_NAME)
-	-docker run --rm $(common_mounts) $(build_tag) bash -c 'kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $$(gcloud config get-value account)'
+	-docker run --rm $(common_mounts) $(build_tag) bash -c 'echo - n $$(gcloud config get-value account) | md5sum | cut -b-32 > /tmp/hash && \
+	kubectl create clusterrolebinding cluster-admin-binding-$$(cat /tmp/hash) --clusterrole cluster-admin --user $$(gcloud config get-value account)'
 
 # authenticate our docker configuration so that you can do a docker push directly
 # to the gcr.io repository

--- a/site/content/en/docs/Guides/troubleshooting.md
+++ b/site/content/en/docs/Guides/troubleshooting.md
@@ -47,7 +47,7 @@ Once this is done, you can `kubectl delete gs --all` and clean everything up (if
 
 Some troubleshooting steps:
 
-1. Run `kubectl describe clusterrolebinding cluster-admin-binding` and make sure your email is in there. This may be
+1. Run `kubectl describe clusterrolebinding | grep cluster-admin-binding- -A10` and make sure your email is in there. This may be
 _case sensitive_ so you may need to compare it to the case you used.
 1. In the [GKE tutorial]({{< ref "/docs/Installation#enabling-creation-of-rbac-resources" >}}) `gcloud config get-value accounts` 
 will return a lowercase email address, so if you are using a CamelCase email, you may want to type that in manually.


### PR DESCRIPTION
Use md5sum util hash to generate the suffix based on the current GC user
account.

Closes #662 