### PR TITLE
Move GameServer to Unheathy when Pod Deleted

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -499,7 +499,7 @@ func (c *Controller) syncDevelopmentGameServer(gs *v1alpha1.GameServer) (*v1alph
 	}
 
 	gsCopy := gs.DeepCopy()
-	ports := []v1alpha1.GameServerStatusPort{}
+	var ports []v1alpha1.GameServerStatusPort
 	for _, p := range gs.Spec.Ports {
 		ports = append(ports, p.Status())
 	}

--- a/pkg/gameservers/health_test.go
+++ b/pkg/gameservers/health_test.go
@@ -79,7 +79,6 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 
 	type expected struct {
 		updated bool
-		state   v1alpha1.GameServerState
 	}
 	fixtures := map[string]struct {
 		state    v1alpha1.GameServerState
@@ -89,21 +88,30 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 			state: v1alpha1.GameServerStateStarting,
 			expected: expected{
 				updated: true,
-				state:   v1alpha1.GameServerStateUnhealthy,
 			},
 		},
-		"scheduled": {
-			state: v1alpha1.GameServerStateScheduled,
+		"shutdown": {
+			state: v1alpha1.GameServerStateShutdown,
 			expected: expected{
 				updated: false,
-				state:   v1alpha1.GameServerStateScheduled,
+			},
+		},
+		"unhealthy": {
+			state: v1alpha1.GameServerStateUnhealthy,
+			expected: expected{
+				updated: false,
 			},
 		},
 		"ready": {
 			state: v1alpha1.GameServerStateReady,
 			expected: expected{
 				updated: true,
-				state:   v1alpha1.GameServerStateUnhealthy,
+			},
+		},
+		"allocated": {
+			state: v1alpha1.GameServerStateAllocated,
+			expected: expected{
+				updated: true,
 			},
 		},
 	}
@@ -128,7 +136,7 @@ func TestHealthControllerSyncGameServer(t *testing.T) {
 				updated = true
 				ua := action.(k8stesting.UpdateAction)
 				gsObj := ua.GetObject().(*v1alpha1.GameServer)
-				assert.Equal(t, test.expected.state, gsObj.Status.State)
+				assert.Equal(t, v1alpha1.GameServerStateUnhealthy, gsObj.Status.State)
 				return true, gsObj, nil
 			})
 
@@ -207,6 +215,15 @@ func TestHealthControllerRun(t *testing.T) {
 
 	podWatch.Modify(pod)
 
+	select {
+	case <-updated:
+	case <-time.After(10 * time.Second):
+		assert.FailNow(t, "timeout on GameServer update")
+	}
+
+	agtesting.AssertEventContains(t, m.FakeRecorder.Events, string(v1alpha1.GameServerStateUnhealthy))
+
+	podWatch.Delete(pod)
 	select {
 	case <-updated:
 	case <-time.After(10 * time.Second):

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -832,7 +832,7 @@ func TestFleetRecreateGameServerOnPodDeletion(t *testing.T) {
 	err = podClient.Delete(pod.ObjectMeta.Name, nil)
 	assert.NoError(t, err)
 
-	err = wait.Poll(time.Second, 30*time.Second, func() (done bool, err error) {
+	err = wait.Poll(time.Second, time.Minute, func() (done bool, err error) {
 		_, err = alpha1.GameServers(defaultNs).Get(gs.ObjectMeta.Name, metav1.GetOptions{})
 
 		if err != nil && k8serrors.IsNotFound(err) {


### PR DESCRIPTION
There was only implementation of GameServer's being moved to Unhealthy on very specific Pod events (container crash, being unschedulable), but never on Pod removal as a whole.

Also it was locked down to specific states, which made it very fragile.

Reworked this so that any of the above now triggers a GameServer being moved to an Unhealthy state.

Closes #678