### PR TITLE
Abstract build image ensuring and building

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -81,8 +81,8 @@ common_mounts = -v $(build_path)/.config/gcloud:/root/.config/gcloud \
 # Its possible for this to change in the future, so it gets its own variable.
 workdir_path = $(mount_path)
 
+build_version = $(call sha,$(build_path)/build-image/Dockerfile)
 build_tag = agones-build:$(build_version)
-build_remote_tag = $(REGISTRY)/$(build_tag)
 controller_tag = $(REGISTRY)/agones-controller:$(VERSION)
 sidecar_tag = $(REGISTRY)/agones-sdk:$(VERSION)
 ping_tag = $(REGISTRY)/agones-ping:$(VERSION)
@@ -177,6 +177,7 @@ include ./includes/$(osinclude)
 # personal includes, excluded from the git repository
 -include ./local-includes/*.mk
 
+include ./includes/build-image.mk
 include ./includes/release.mk
 include ./includes/google-cloud.mk
 include ./includes/minikube.mk
@@ -392,37 +393,6 @@ shell: $(ensure-build-image)
 godoc:
 	docker run -p 8888:8888 --rm $(common_mounts) -v $(build_path)/.index:/root/.index \
 		$(build_tag) godoc -http=":8888" -index=true
-
-# Creates the build docker image
-build-build-image:
-	docker build --tag=$(build_tag) $(build_path)/build-image $(DOCKER_BUILD_ARGS)
-
-# Deletes the local build docker image
-clean-build-image:
-	docker rmi $(build_tag)
-
-ensure-build-config:
-	-mkdir -p $(kubeconfig_path)
-	-mkdir -p $(build_path)/.gocache
-	-mkdir -p $(build_path)/.config/gcloud
-	-mkdir -p $(helm_path)
-
-# create the build image if it doesn't exist
-ensure-build-image: ensure-build-config
-	@if [ -z $$(docker images -q $(build_tag)) ]; then\
-		echo "Could not find $(build_tag) image. Building...";\
-		$(MAKE) build-build-image;\
-	fi
-
-# attempt to pull the image, if it exists and rename it to the local tag
-# exit's clean if it doesn't exist, so can be used on CI
-pull-build-image:
-	-docker pull $(build_remote_tag) && docker tag $(build_remote_tag) $(build_tag)
-
-# push the local build image up to your repository
-push-build-image:
-	docker tag $(build_tag) $(build_remote_tag)
-	docker push $(build_remote_tag)
 
 # start pprof with a web ui
 pprof-web:

--- a/build/includes/build-image.mk
+++ b/build/includes/build-image.mk
@@ -1,0 +1,57 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#   ____        _ _     _   ___
+#  | __ ) _   _(_) | __| | |_ _|_ __ ___   __ _  __ _  ___
+#  |  _ \| | | | | |/ _` |  | || '_ ` _ \ / _` |/ _` |/ _ \
+#  | |_) | |_| | | | (_| |  | || | | | | | (_| | (_| |  __/
+#  |____/ \__,_|_|_|\__,_| |___|_| |_| |_|\__,_|\__, |\___|
+#                                               |___/
+
+build_remote_tag = $(REGISTRY)/$(build_tag)
+
+# Creates the build docker image
+build-build-image:
+	docker build --tag=$(build_tag) $(build_path)/build-image $(DOCKER_BUILD_ARGS)
+
+# Deletes the local build docker image
+clean-build-image:
+	docker rmi $(build_tag)
+
+ensure-build-config:
+	-mkdir -p $(kubeconfig_path)
+	-mkdir -p $(build_path)/.gocache
+	-mkdir -p $(build_path)/.config/gcloud
+	-mkdir -p $(helm_path)
+
+# create the build image if it doesn't exist
+ensure-build-image: ensure-build-config
+	$(MAKE) ensure-image IMAGE_TAG=$(build_tag) BUILD_TARGET=build-build-image
+
+# attempt to pull the image, if it exists and rename it to the local tag
+# exit's clean if it doesn't exist, so can be used on CI
+pull-build-image:
+	-docker pull $(build_remote_tag) && docker tag $(build_remote_tag) $(build_tag)
+
+# push the local build image up to your repository
+push-build-image:
+	docker tag $(build_tag) $(build_remote_tag)
+	docker push $(build_remote_tag)
+
+# ensure passed in image exists, if not, run the target
+ensure-image:
+	@if [ -z $$(docker images -q $(IMAGE_TAG)) ]; then\
+		echo "Could not find $(IMAGE_TAG) image. Building...";\
+		$(MAKE) $(BUILD_TARGET);\
+	fi

--- a/build/includes/linux.mk
+++ b/build/includes/linux.mk
@@ -23,9 +23,8 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
-# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
-# it automatically rebuilds
-build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
+# Get the sha for a file
+sha = $(shell sha256sum $(1) | head -c 10)
 
 # Minikube executable
 MINIKUBE ?= minikube

--- a/build/includes/macos.mk
+++ b/build/includes/macos.mk
@@ -23,9 +23,8 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
-# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
-# it automatically rebuilds
-build_version := $(shell shasum -a 256 $(build_path)/build-image/Dockerfile | head -c 10)
+# Get the sha for a file
+sha = $(shell shasum -a 256 $(1) | head -c 10)
 
 # Minikube executable
 MINIKUBE ?= minikube

--- a/build/includes/windows.mk
+++ b/build/includes/windows.mk
@@ -23,9 +23,8 @@
 #     \_/ \__,_|_|  |_|\__,_|_.__/|_|\___|___/
 #
 
-# Use a hash of the Dockerfile for the tag, so when the Dockerfile changes,
-# it automatically rebuilds
-build_version := $(shell sha256sum $(build_path)/build-image/Dockerfile | head -c 10)
+# Get the sha for a file
+sha = $(shell sha256sum $(1) | head -c 10)
 
 # Minikube executable
 MINIKUBE ?= minikube.exe


### PR DESCRIPTION
This is setup work, to enable SDK build images to also take advantage of the same scaffolding we use to only rebuild build images once they have changed.

Functionality is exactly the same!