### PR TITLE
Group make test output in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -61,7 +61,7 @@ steps:
   waitFor:
     - lint
   dir: "build"
-  args: [ "-j", "3", "test" ]
+  args: [ "-j", "4", "--output-sync=target", "test" ]
 
 #
 # Push the build image, can run while we do other things.


### PR DESCRIPTION
Having merged output is impossible to track and work out what failed in these steps. So let's group the output!