### PR TITLE
Adds a .clang-format file making Google style the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !.gcloudignore
 !.eslintrc.*
 !.nycrc
+!.clang-format
 *.iml
 bin
 *.o

--- a/sdks/cpp/.clang-format
+++ b/sdks/cpp/.clang-format
@@ -1,0 +1,3 @@
+# Use the Google style in this project.
+# https://google.github.io/styleguide/cppguide.html
+BasedOnStyle: Google


### PR DESCRIPTION
This change should probably have been part of PR #716, but I forgot.

`.clang-format` is a standard file that the `clang-format` tool(s) look for. This file will tell all clang-format invocations to by-default use the "Google" style. This means that someone running `clang-format -i foo.cc` within the `sdks/cpp/...` directory hierarchy will automatically use the correct style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/agones/724)
<!-- Reviewable:end -->
