### PR TITLE
Add status subresource for FleetAutoscaler

### DIFF
--- a/install/helm/agones/templates/crds/fleetautoscaler.yaml
+++ b/install/helm/agones/templates/crds/fleetautoscaler.yaml
@@ -78,4 +78,7 @@ spec:
                           type: string
                     url:
                       type: string
+  subresources:
+    # status enables the status subresource.
+    status: {}
 {{- end }}

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -53,16 +53,13 @@ rules:
   resources: ["gameservers", "gameserversets"]
   verbs: ["create", "delete", "get", "list", "update", "watch"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["gameserversets/status"]
-  verbs: ["update"]
-- apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
   verbs: ["patch"]
 - apiGroups: ["stable.agones.dev"]
   resources: ["fleets", "fleetallocations", "fleetautoscalers"]
   verbs: ["get", "list", "update", "watch"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["fleets/status"]
+  resources: ["fleets/status",  "fleetautoscalers/status", "gameserversets/status"]
   verbs: ["update"]
 
 ---

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -51,16 +51,13 @@ rules:
   resources: ["gameservers", "gameserversets"]
   verbs: ["create", "delete", "get", "list", "update", "watch"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["gameserversets/status"]
-  verbs: ["update"]
-- apiGroups: ["stable.agones.dev"]
   resources: ["gameservers"]
   verbs: ["patch"]
 - apiGroups: ["stable.agones.dev"]
   resources: ["fleets", "fleetallocations", "fleetautoscalers"]
   verbs: ["get", "list", "update", "watch"]
 - apiGroups: ["stable.agones.dev"]
-  resources: ["fleets/status"]
+  resources: ["fleets/status",  "fleetautoscalers/status", "gameserversets/status"]
   verbs: ["update"]
 
 ---
@@ -517,6 +514,9 @@ spec:
                           type: string
                     url:
                       type: string
+  subresources:
+    # status enables the status subresource.
+    status: {}
 
 ---
 # Source: agones/templates/crds/gameserver.yaml

--- a/pkg/fleetautoscalers/controller.go
+++ b/pkg/fleetautoscalers/controller.go
@@ -258,7 +258,7 @@ func (c *Controller) updateStatus(fas *stablev1alpha1.FleetAutoscaler, currentRe
 			c.recorder.Eventf(fas, corev1.EventTypeWarning, "ScalingLimited", "Scaling fleet %s was limited to maximum size of %d", fas.Spec.FleetName, desiredReplicas)
 		}
 
-		_, err := c.fleetAutoscalerGetter.FleetAutoscalers(fas.ObjectMeta.Namespace).Update(fasCopy)
+		_, err := c.fleetAutoscalerGetter.FleetAutoscalers(fas.ObjectMeta.Namespace).UpdateStatus(fasCopy)
 		if err != nil {
 			return errors.Wrapf(err, "error updating status for fleetautoscaler %s", fas.ObjectMeta.Name)
 		}
@@ -276,7 +276,7 @@ func (c *Controller) updateStatusUnableToScale(fas *stablev1alpha1.FleetAutoscal
 	fasCopy.Status.DesiredReplicas = 0
 
 	if !apiequality.Semantic.DeepEqual(fas.Status, fasCopy.Status) {
-		_, err := c.fleetAutoscalerGetter.FleetAutoscalers(fas.ObjectMeta.Namespace).Update(fasCopy)
+		_, err := c.fleetAutoscalerGetter.FleetAutoscalers(fas.ObjectMeta.Namespace).UpdateStatus(fasCopy)
 		if err != nil {
 			return errors.Wrapf(err, "error updating status for fleetautoscaler %s", fas.ObjectMeta.Name)
 		}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -124,6 +124,7 @@ func (f *Framework) WaitForGameServerState(gs *v1alpha1.GameServer, state v1alph
 }
 
 // WaitForFleetCondition waits for the Fleet to be in a specific condition or fails the test if the condition can't be met in 5 minutes.
+// nolint: dupl
 func (f *Framework) WaitForFleetCondition(t *testing.T, flt *v1alpha1.Fleet, condition func(fleet *v1alpha1.Fleet) bool) {
 	t.Helper()
 	logrus.WithField("fleet", flt.Name).Info("waiting for fleet condition")
@@ -138,6 +139,25 @@ func (f *Framework) WaitForFleetCondition(t *testing.T, flt *v1alpha1.Fleet, con
 	if err != nil {
 		logrus.WithField("fleet", flt.Name).WithError(err).Info("error waiting for fleet condition")
 		t.Fatalf("error waiting for fleet condition on fleet %v", flt.Name)
+	}
+}
+
+// WaitForFleetAutoScalerCondition waits for the FleetAutoscaler to be in a specific condition or fails the test if the condition can't be met in 2 minutes.
+// nolint: dupl
+func (f *Framework) WaitForFleetAutoScalerCondition(t *testing.T, fas *v1alpha1.FleetAutoscaler, condition func(fas *v1alpha1.FleetAutoscaler) bool) {
+	t.Helper()
+	logrus.WithField("fleetautoscaler", fas.Name).Info("waiting for fleetautoscaler condition")
+	err := wait.PollImmediate(2*time.Second, 2*time.Minute, func() (bool, error) {
+		fleetautoscaler, err := f.AgonesClient.StableV1alpha1().FleetAutoscalers(fas.ObjectMeta.Namespace).Get(fas.ObjectMeta.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		return condition(fleetautoscaler), nil
+	})
+	if err != nil {
+		logrus.WithField("fleetautoscaler", fas.Name).WithError(err).Info("error waiting for fleetautoscaler condition")
+		t.Fatalf("error waiting for fleetautoscaler condition on fleetautoscaler %v", fas.Name)
 	}
 }
 


### PR DESCRIPTION
Add E2E test of FleetAutoscaler status update.
Update serviceaccounts permissions accordingly. 

For #329 .