### PR TITLE
CI Speedup: Cache Build SDK between builds

### DIFF
--- a/build/build-sdk-images/tool/base/Dockerfile
+++ b/build/build-sdk-images/tool/base/Dockerfile
@@ -14,8 +14,7 @@
 
 
 #
-# This image is manually built (for now)
-# as gcr.io/agones-images/grpc-cxx:1.16.1
+# Base images for SDKs
 #
 
 FROM debian:stretch

--- a/build/includes/build-image.mk
+++ b/build/includes/build-image.mk
@@ -42,12 +42,11 @@ ensure-build-image: ensure-build-config
 # attempt to pull the image, if it exists and rename it to the local tag
 # exit's clean if it doesn't exist, so can be used on CI
 pull-build-image:
-	-docker pull $(build_remote_tag) && docker tag $(build_remote_tag) $(build_tag)
+	$(MAKE) pull-remote-build-image REMOTE_TAG=$(build_remote_tag) LOCAL_TAG=$(build_tag)
 
 # push the local build image up to your repository
 push-build-image:
-	docker tag $(build_tag) $(build_remote_tag)
-	docker push $(build_remote_tag)
+	$(MAKE) push-remote-build-image REMOTE_TAG=$(build_remote_tag) LOCAL_TAG=$(build_tag)
 
 # ensure passed in image exists, if not, run the target
 ensure-image:
@@ -55,3 +54,12 @@ ensure-image:
 		echo "Could not find $(IMAGE_TAG) image. Building...";\
 		$(MAKE) $(BUILD_TARGET);\
 	fi
+
+# push a local build image up to a remote repository
+push-remote-build-image:
+	docker tag $(LOCAL_TAG) $(REMOTE_TAG)
+	docker push $(REMOTE_TAG)
+
+# pull a local image that may exist on a remote repository, to a local image
+pull-remote-build-image:
+	-docker pull $(REMOTE_TAG) && docker tag $(REMOTE_TAG) $(LOCAL_TAG)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,11 +37,41 @@ steps:
   args: ["bash", "-c", "echo 'FROM gcr.io/cloud-builders/docker\nRUN apt-get install make\nENTRYPOINT [\"/usr/bin/make\"]' > Dockerfile.build"]
   waitFor: ['-']
 - name: "gcr.io/cloud-builders/docker"
+  id: build-make-docker
   args: ['build', '-f', 'Dockerfile.build', '-t', 'make-docker', '.'] # we need docker and make to run everything.
+
+#
+# pull the main build image if it exists
+#
 - name: "make-docker"
-  id: make-docker
+  id: pull-build-image
   dir: "build"
-  args: ["pull-build-image"] # pull the build image if it exists
+  args: ["pull-build-image"]
+  waitFor:
+    - build-make-docker
+
+#
+# pull the sdk base image, if it exists
+#
+
+- name: "make-docker"
+  id: pull-build-sdk-base-image
+  dir: "build"
+  args: ["pull-build-sdk-base-image"]
+  waitFor:
+    - build-make-docker
+
+#
+# Ensure that there is the sdk base image, so that both tests
+# and build can use them
+#
+
+- name: "make-docker"
+  id: ensure-build-sdk-image-base
+  waitFor:
+    - pull-build-sdk-base-image
+  dir: "build"
+  args: ["ensure-build-sdk-image-base"]
 
 #
 # build the e2e test runner
@@ -60,7 +90,7 @@ steps:
 - name: "make-docker"
   id: lint
   waitFor:
-    - make-docker
+    - pull-build-image
   dir: "build"
   args: ["lint"] # pull the build image if it exists
 
@@ -72,6 +102,7 @@ steps:
   id: tests
   waitFor:
     - lint
+    - ensure-build-sdk-image-base
     - htmltest-restore-cache
   dir: "build"
   args: [ "-j", "4", "--output-sync=target", "test" ]
@@ -99,6 +130,16 @@ steps:
   args: ["push-build-image"] # push the build image (which won't do anything if it's already there)
 
 #
+# Push the sdk base build image, which can also run while we do other things
+#
+
+- name: "make-docker"
+  waitFor:
+    - ensure-build-sdk-image-base
+  dir: "build"
+  args: ["push-build-sdk-base-image"]
+
+#
 # Build all the images and sdks, and push them up to the repository
 #
 
@@ -106,6 +147,7 @@ steps:
   id: build
   waitFor:
     - lint
+    - ensure-build-sdk-image-base
   dir: "build"
   args: [ "-j", "4", "build"]
 - name: "make-docker"


### PR DESCRIPTION
This tags the base sdk image with the SHA of it's own Dockerfile, such that it will be rebuilt on Dockerfile change.

This also pushes the base SDK image up to GCR between builds, so that it doesn't get rebuilt every time.