### PR TITLE
Updated the filtering condition on GameServerShutdown to include the undeleted Unhealthy GSs

### DIFF
--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -23,6 +23,7 @@ import (
 	e2eframework "agones.dev/agones/test/e2e/framework"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -176,7 +177,11 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = framework.WaitForGameServerState(newGs, v1alpha1.GameServerStateUnhealthy, 10*time.Second)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
+
+	_, err = gameServers.Get(newGs.Name, metav1.GetOptions{})
+	assert.NotNil(t, err)
+	assert.True(t, errors.IsNotFound(err))
 }
 
 func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {


### PR DESCRIPTION
Fixed the filtering condition on GameServerShutdown to include the undeleted Unhealthy GSs.
After the change the Unhealthy servers are (eventually) being deleted(see the graph below).

Also remove the WaitForCacheSync call during the GS creation. This improves the allocation and overall performance.

![image](https://user-images.githubusercontent.com/17522001/56632806-687c5780-6610-11e9-9db5-329d892b631a.png)
