### PR TITLE
Implement multicluster allocation for local cluster allocation.

### DIFF
--- a/install/helm/agones/templates/hooks/sa.yaml
+++ b/install/helm/agones/templates/hooks/sa.yaml
@@ -44,7 +44,7 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
-- apiGroups: ["stable.agones.dev"]
+- apiGroups: ["stable.agones.dev", "multicluster.agones.dev"]
   resources: ["fleets", "fleetallocations", "fleetautoscalers", "gameservers", "gameserversets", "gameserverallocationpolicies"]
   verbs: ["delete", "list" ]
 - apiGroups: [""]

--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -61,6 +61,9 @@ rules:
 - apiGroups: ["stable.agones.dev"]
   resources: ["fleets/status",  "fleetautoscalers/status", "gameserversets/status"]
   verbs: ["update"]
+- apiGroups: ["multicluster.agones.dev"]
+  resources: ["gameserverallocationpolicies"]
+  verbs: ["create", "delete", "get", "list", "update", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -59,6 +59,9 @@ rules:
 - apiGroups: ["stable.agones.dev"]
   resources: ["fleets/status",  "fleetautoscalers/status", "gameserversets/status"]
   verbs: ["update"]
+- apiGroups: ["multicluster.agones.dev"]
+  resources: ["gameserverallocationpolicies"]
+  verbs: ["create", "delete", "get", "list", "update", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/apis/allocation/v1alpha1/gameserverallocation.go
+++ b/pkg/apis/allocation/v1alpha1/gameserverallocation.go
@@ -62,6 +62,10 @@ type GameServerAllocationList struct {
 
 // GameServerAllocationSpec is the spec for a GameServerAllocation
 type GameServerAllocationSpec struct {
+	// MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+	// Otherwise, allocation will happen locally.
+	MultiClusterSetting MultiClusterSetting `json:"multiClusterSetting,omitempty"`
+
 	// Required The required allocation. Defaults to all GameServers.
 	Required metav1.LabelSelector `json:"required,omitempty"`
 
@@ -76,6 +80,12 @@ type GameServerAllocationSpec struct {
 	// MetaPatch is optional custom metadata that is added to the game server at allocation
 	// You can use this to tell the server necessary session data
 	MetaPatch MetaPatch `json:"metadata,omitempty"`
+}
+
+// MultiClusterSetting specifies settings for multi-cluster allocation.
+type MultiClusterSetting struct {
+	Enabled        bool                 `json:"enabled,omitempty"`
+	PolicySelector metav1.LabelSelector `json:"policySelector,omitempty"`
 }
 
 // MetaPatch is the metadata used to patch the GameServer metadata on allocation

--- a/pkg/apis/multicluster/v1alpha1/gameserverallocationpolicy.go
+++ b/pkg/apis/multicluster/v1alpha1/gameserverallocationpolicy.go
@@ -80,7 +80,7 @@ func (it *ConnectionInfoIterator) Next() *ClusterConnectionInfo {
 		currPriority := it.orderedPriorities[it.currPriority]
 		clusterPolicy := it.priorityToCluster[currPriority]
 
-		if result := it.getClusterConnectionInfo(&clusterPolicy); result == nil {
+		if result := it.getClusterConnectionInfo(clusterPolicy); result == nil {
 			// If there is no cluster with the current priority, choose cluster with next highest priority
 			it.currPriority++
 		} else {
@@ -127,10 +127,10 @@ func NewConnectionInfoIterator(policies []*GameServerAllocationPolicy) *Connecti
 }
 
 // getClusterConnectionInfo returns a ClusterConnectionInfo selected base on weighted randomization.
-func (it *ConnectionInfoIterator) getClusterConnectionInfo(clusterPolicy *clusterToPolicy) *ClusterConnectionInfo {
+func (it *ConnectionInfoIterator) getClusterConnectionInfo(clusterPolicy clusterToPolicy) *ClusterConnectionInfo {
 	connections := []*ClusterConnectionInfo{}
 	weights := []int{}
-	for cluster, policies := range *clusterPolicy {
+	for cluster, policies := range clusterPolicy {
 		if _, ok := it.clusterBlackList[cluster]; ok {
 			continue
 		}
@@ -142,7 +142,7 @@ func (it *ConnectionInfoIterator) getClusterConnectionInfo(clusterPolicy *cluste
 		return nil
 	}
 
-	return selectRandomWeighted(connections, &weights)
+	return selectRandomWeighted(connections, weights)
 }
 
 // avgWeight calculates average over allocation policy Weight field.
@@ -158,9 +158,9 @@ func avgWeight(policies []*GameServerAllocationPolicy) int {
 }
 
 // selectRandomWeighted selects a ClusterConnectionInfo info from a weighted list of ClusterConnectionInfo
-func selectRandomWeighted(connections []*ClusterConnectionInfo, weights *[]int) *ClusterConnectionInfo {
+func selectRandomWeighted(connections []*ClusterConnectionInfo, weights []int) *ClusterConnectionInfo {
 	sum := 0
-	for _, weight := range *weights {
+	for _, weight := range weights {
 		sum += weight
 	}
 
@@ -170,7 +170,7 @@ func selectRandomWeighted(connections []*ClusterConnectionInfo, weights *[]int) 
 
 	rand := rand.Intn(sum)
 	sum = 0
-	for i, weight := range *weights {
+	for i, weight := range weights {
 		sum += weight
 		if rand < sum {
 			return connections[i]

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -25,11 +25,13 @@ import (
 
 	"agones.dev/agones/pkg/apis"
 	"agones.dev/agones/pkg/apis/allocation/v1alpha1"
+	multiclusterv1alpha1 "agones.dev/agones/pkg/apis/multicluster/v1alpha1"
 	"agones.dev/agones/pkg/apis/stable"
 	stablev1alpha1 "agones.dev/agones/pkg/apis/stable/v1alpha1"
 	"agones.dev/agones/pkg/client/clientset/versioned"
 	getterv1alpha1 "agones.dev/agones/pkg/client/clientset/versioned/typed/stable/v1alpha1"
 	"agones.dev/agones/pkg/client/informers/externalversions"
+	multiclusterlisterv1alpha1 "agones.dev/agones/pkg/client/listers/multicluster/v1alpha1"
 	listerv1alpha1 "agones.dev/agones/pkg/client/listers/stable/v1alpha1"
 	"agones.dev/agones/pkg/gameservers"
 	"agones.dev/agones/pkg/util/apiserver"
@@ -69,13 +71,14 @@ type Controller struct {
 	readyGameServers gameServerCacheEntry
 	// Instead of selecting the top one, controller selects a random one
 	// from the topNGameServerCount of Ready gameservers
-	topNGameServerCount int
-	gameServerSynced    cache.InformerSynced
-	gameServerGetter    getterv1alpha1.GameServersGetter
-	gameServerLister    listerv1alpha1.GameServerLister
-	stop                <-chan struct{}
-	workerqueue         *workerqueue.WorkerQueue
-	recorder            record.EventRecorder
+	topNGameServerCount    int
+	gameServerSynced       cache.InformerSynced
+	gameServerGetter       getterv1alpha1.GameServersGetter
+	gameServerLister       listerv1alpha1.GameServerLister
+	allocationPolicyLister multiclusterlisterv1alpha1.GameServerAllocationPolicyLister
+	stop                   <-chan struct{}
+	workerqueue            *workerqueue.WorkerQueue
+	recorder               record.EventRecorder
 }
 
 // gameserver cache to keep the Ready state gameserver.
@@ -153,11 +156,12 @@ func NewController(apiServer *apiserver.APIServer,
 
 	agonesInformer := agonesInformerFactory.Stable().V1alpha1()
 	c := &Controller{
-		counter:             counter,
-		topNGameServerCount: topNGameServerCnt,
-		gameServerSynced:    agonesInformer.GameServers().Informer().HasSynced,
-		gameServerGetter:    agonesClient.StableV1alpha1(),
-		gameServerLister:    agonesInformer.GameServers().Lister(),
+		counter:                counter,
+		topNGameServerCount:    topNGameServerCnt,
+		gameServerSynced:       agonesInformer.GameServers().Informer().HasSynced,
+		gameServerGetter:       agonesClient.StableV1alpha1(),
+		gameServerLister:       agonesInformer.GameServers().Lister(),
+		allocationPolicyLister: agonesInformerFactory.Multicluster().V1alpha1().GameServerAllocationPolicies().Lister(),
 	}
 	c.baseLogger = runtime.NewLoggerWithType(c)
 	c.workerqueue = workerqueue.NewWorkerQueue(c.syncGameServers, c.baseLogger, logfields.GameServerKey, stable.GroupName+".GameServerUpdateController")
@@ -289,8 +293,26 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 		return c.serialisation(r, w, status, apiserver.Codecs)
 	}
 
+	// If multi-cluster setting is enabled, allocate base on the multicluster allocation policy.
+	var out *v1alpha1.GameServerAllocation
+	if gsa.Spec.MultiClusterSetting.Enabled {
+		out, err = c.applyMultiClusterAllocation(gsa)
+	} else {
+		out, err = c.allocateFromLocalCluster(gsa)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return c.serialisation(r, w, out, scheme.Codecs)
+}
+
+// allocateFromLocalCluster allocates gameservers from the local cluster.
+func (c *Controller) allocateFromLocalCluster(gsa *v1alpha1.GameServerAllocation) (*v1alpha1.GameServerAllocation, error) {
 	var gs *stablev1alpha1.GameServer
-	err = Retry(allocationRetry, func() error {
+	err := Retry(allocationRetry, func() error {
+		var err error
 		gs, err = c.allocate(gsa)
 		return err
 	})
@@ -298,7 +320,7 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 	if err != nil && err != ErrNoGameServerReady && err != ErrConflictInGameServerSelection {
 		// this will trigger syncing of the cache (assuming cache might not be up to date)
 		c.workerqueue.EnqueueImmediately(gs)
-		return err
+		return nil, err
 	}
 
 	if err == ErrNoGameServerReady {
@@ -315,8 +337,51 @@ func (c *Controller) allocationHandler(w http.ResponseWriter, r *http.Request, n
 	}
 
 	c.loggerForGameServerAllocation(gsa).Info("game server allocation")
+	return gsa, nil
+}
 
-	return c.serialisation(r, w, gsa, scheme.Codecs)
+// applyMultiClusterAllocation retrieves allocation policies and iterate on policies.
+// Then allocate gameservers from local or remote cluster accordingly.
+func (c *Controller) applyMultiClusterAllocation(gsa *v1alpha1.GameServerAllocation) (*v1alpha1.GameServerAllocation, error) {
+	var result *v1alpha1.GameServerAllocation
+
+	selector, err := metav1.LabelSelectorAsSelector(&gsa.Spec.MultiClusterSetting.PolicySelector)
+	if err != nil {
+		return nil, err
+	}
+
+	policies, err := c.allocationPolicyLister.GameServerAllocationPolicies(gsa.ObjectMeta.Namespace).List(selector)
+	if err != nil {
+		return nil, err
+	} else if len(policies) == 0 {
+		return c.allocateFromLocalCluster(gsa)
+	}
+
+	it := multiclusterv1alpha1.NewConnectionInfoIterator(policies)
+	for {
+		connectionInfo := it.Next()
+		if connectionInfo == nil {
+			break
+		}
+		if connectionInfo.ClusterName == gsa.ObjectMeta.ClusterName {
+			result, err = c.allocateFromLocalCluster(gsa)
+			c.baseLogger.Error(err)
+		} else {
+			result, err = c.allocateFromRemoteCluster(*gsa, connectionInfo, gsa.ObjectMeta.Namespace)
+			c.baseLogger.Error(err)
+		}
+		if result != nil {
+			return result, nil
+		}
+	}
+	return nil, err
+}
+
+// allocateFromRemoteCluster allocates gameservers from a remote cluster by making
+// an http call to allocation service in that cluster.
+func (c *Controller) allocateFromRemoteCluster(gsa v1alpha1.GameServerAllocation, connectionInfo *multiclusterv1alpha1.ClusterConnectionInfo, namespace string) (*v1alpha1.GameServerAllocation, error) {
+	// TODO: implement getting secrets and making rest call to remote cluster
+	return nil, nil
 }
 
 // allocationDeserialization processes the request and namespace, and attempts to deserialise its values

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -2226,6 +2226,7 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 
 
 
+
 {{% feature publishVersion="0.10.0" %}}
 <p>Packages:</p>
 <ul>
@@ -2302,6 +2303,20 @@ GameServerAllocationSpec
 <br/>
 <br/>
 <table>
+<tr>
+<td>
+<code>multiClusterSetting</code></br>
+<em>
+<a href="#MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>required</code></br>
@@ -2389,6 +2404,20 @@ GameServerAllocationStatus
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>multiClusterSetting</code></br>
+<em>
+<a href="#MultiClusterSetting">
+MultiClusterSetting
+</a>
+</em>
+</td>
+<td>
+<p>MultiClusterPolicySelector if specified, multi-cluster policies are applied.
+Otherwise, allocation will happen locally.</p>
+</td>
+</tr>
 <tr>
 <td>
 <code>required</code></br>
@@ -2559,6 +2588,47 @@ map[string]string
 <code>annotations</code></br>
 <em>
 map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="MultiClusterSetting">MultiClusterSetting
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GameServerAllocationSpec">GameServerAllocationSpec</a>)
+</p>
+<p>
+<p>MultiClusterSetting specifies settings for multi-cluster allocation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enabled</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>policySelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
 </em>
 </td>
 <td>


### PR DESCRIPTION
- Introduce allocation service API for enabling multi-cluster allocations.
- Implementing the logic to choose between local or remove allocation to be applied. (remote allocation is todo and will be done in the next PR)
- Enable the RBAC policies for allocation policies.
