### PR TITLE
Flaky: Fix test for TestGameServerUnhealthyAfterDeletingPod

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -107,6 +107,7 @@ func (f *Framework) WaitForGameServerState(gs *v1alpha1.GameServer, state v1alph
 		readyGs, pollErr = f.AgonesClient.StableV1alpha1().GameServers(gs.Namespace).Get(gs.Name, metav1.GetOptions{})
 
 		if pollErr != nil {
+			logrus.WithError(pollErr).Warn("error retrieving gameserver")
 			return false, nil
 		}
 


### PR DESCRIPTION
Change in behaviour on Unhealthy GameServers that are not in Fleets (deleted vs just being marked as Unhealthy), caused this e2e test to be flaky.

Added a TODO to review if we are still happy with this, since release is coming up, and having stable tests is most important right now.