### PR TITLE
Add secret list and watch permissions to RBAC rules

### DIFF
--- a/install/helm/agones/templates/serviceaccounts/controller.yaml
+++ b/install/helm/agones/templates/serviceaccounts/controller.yaml
@@ -44,7 +44,7 @@ rules:
   resources: ["pods"]
   verbs: ["create", "delete", "list", "watch"]
 - apiGroups: [""]
-  resources: ["nodes"]
+  resources: ["nodes", "secrets"]
   verbs: ["list", "watch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
@@ -64,6 +64,7 @@ rules:
 - apiGroups: ["multicluster.agones.dev"]
   resources: ["gameserverallocationpolicies"]
   verbs: ["create", "delete", "get", "list", "update", "watch"]
+
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/yaml/install.yaml
+++ b/install/yaml/install.yaml
@@ -42,7 +42,7 @@ rules:
   resources: ["pods"]
   verbs: ["create", "delete", "list", "watch"]
 - apiGroups: [""]
-  resources: ["nodes"]
+  resources: ["nodes", "secrets"]
   verbs: ["list", "watch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
@@ -62,6 +62,7 @@ rules:
 - apiGroups: ["multicluster.agones.dev"]
   resources: ["gameserverallocationpolicies"]
   verbs: ["create", "delete", "get", "list", "update", "watch"]
+
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -70,9 +70,9 @@ var (
 )
 
 const (
-	secretClientCertName = "client-cert"
-	secretClientKeyName  = "client-key"
-	secretCaCertName     = "ca-cert"
+	secretClientCertName = "client.crt"
+	secretClientKeyName  = "client.key"
+	secretCaCertName     = "ca.crt"
 )
 
 // Controller is a the GameServerAllocation controller
@@ -375,6 +375,7 @@ func (c *Controller) allocateFromRemoteCluster(gsa v1alpha1.GameServerAllocation
 		return nil, err
 	}
 	if response.StatusCode >= 400 {
+		// For error responses return the body without deserializing to an object.
 		return nil, errors.New(string(data))
 	}
 

--- a/pkg/gameserverallocations/controller_test.go
+++ b/pkg/gameserverallocations/controller_test.go
@@ -1014,7 +1014,7 @@ func TestCreateRestClientError(t *testing.T) {
 				return true, &corev1.SecretList{
 					Items: []corev1.Secret{{
 						Data: map[string][]byte{
-							"client-cert": clientCert,
+							"client.crt": clientCert,
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "secret-name",
@@ -1038,8 +1038,8 @@ func TestCreateRestClientError(t *testing.T) {
 				return true, &corev1.SecretList{
 					Items: []corev1.Secret{{
 						Data: map[string][]byte{
-							"client-cert": []byte("XXX"),
-							"client-key":  []byte("XXX"),
+							"client.crt": []byte("XXX"),
+							"client.key": []byte("XXX"),
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "secret-name",
@@ -1159,9 +1159,9 @@ func getTestSecret(secretName string, serverCert []byte) *corev1.SecretList {
 		Items: []corev1.Secret{
 			{
 				Data: map[string][]byte{
-					"ca-cert":     serverCert,
-					"client-key":  clientKey,
-					"client-cert": clientCert,
+					"ca.crt":     serverCert,
+					"client.key": clientKey,
+					"client.crt": clientCert,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName,

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -2227,6 +2227,8 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 
 
 
+
+
 {{% feature publishVersion="0.10.0" %}}
 <p>Packages:</p>
 <ul>


### PR DESCRIPTION
1. Add secret list and watch permissions to RBAC rules for agones-controller service account. https://github.com/GoogleCloudPlatform/agones/issues/597
2. Renamed secrets to have their extensions in the name.
