### PR TITLE
Revert UnHealthy standalone GameServers to not be deleted

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -57,7 +57,7 @@ KIND_PROFILE ?= agones
 KIND_CONTAINER_NAME=kind-$(KIND_PROFILE)-control-plane
 
 # Game Server image to use while doing end-to-end tests
-GS_TEST_IMAGE ?= gcr.io/agones-images/udp-server:0.8
+GS_TEST_IMAGE ?= gcr.io/agones-images/udp-server:0.9
 
 # Directory that this Makefile is in.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/examples/fleet.yaml
+++ b/examples/fleet.yaml
@@ -67,4 +67,4 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.8
+            image: gcr.io/agones-images/udp-server:0.9

--- a/examples/simple-udp/Makefile
+++ b/examples/simple-udp/Makefile
@@ -27,7 +27,7 @@ REPOSITORY = gcr.io/agones-images
 
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 project_path := $(dir $(mkfile_path))
-server_tag = $(REPOSITORY)/udp-server:0.8
+server_tag = $(REPOSITORY)/udp-server:0.9
 root_path = $(realpath $(project_path)/../..)
 
 #   _____                    _

--- a/examples/simple-udp/fleet-distributed.yaml
+++ b/examples/simple-udp/fleet-distributed.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.8
+            image: gcr.io/agones-images/udp-server:0.9
             resources:
               requests:
                 memory: "32Mi"

--- a/examples/simple-udp/fleet.yaml
+++ b/examples/simple-udp/fleet.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.8
+            image: gcr.io/agones-images/udp-server:0.9
             resources:
               requests:
                 memory: "64Mi"

--- a/examples/simple-udp/gameserver.yaml
+++ b/examples/simple-udp/gameserver.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.8
+        image: gcr.io/agones-images/udp-server:0.9
         resources:
           requests:
             memory: "32Mi"

--- a/examples/simple-udp/gameserverset.yaml
+++ b/examples/simple-udp/gameserverset.yaml
@@ -31,4 +31,4 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.8
+            image: gcr.io/agones-images/udp-server:0.9

--- a/examples/simple-udp/main.go
+++ b/examples/simple-udp/main.go
@@ -85,6 +85,8 @@ func readWriteLoop(conn net.PacketConn, stop chan struct{}, s *sdk.SDK) {
 		switch parts[0] {
 		// shuts down the gameserver
 		case "EXIT":
+			// respond here, as we os.Exit() before we get to below
+			respond(conn, sender, "ACK: "+txt+"\n")
 			exit(s)
 
 		// turns off the health pings

--- a/install/helm/agones/templates/NOTES.txt
+++ b/install/helm/agones/templates/NOTES.txt
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.8
+        image: gcr.io/agones-images/udp-server:0.9
 
 Finally don't forget to explore our documentation and usage guides on how to develop and host dedicated game servers on top of Agones. :
 

--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -729,8 +729,7 @@ func (c *Controller) syncGameServerRequestReadyState(gs *v1alpha1.GameServer) (*
 
 // syncGameServerShutdownState deletes the GameServer (and therefore the backing Pod) if it is in shutdown state
 func (c *Controller) syncGameServerShutdownState(gs *v1alpha1.GameServer) error {
-	if !gs.ObjectMeta.DeletionTimestamp.IsZero() ||
-		(gs.Status.State != v1alpha1.GameServerStateShutdown && gs.Status.State != v1alpha1.GameServerStateUnhealthy) {
+	if !(gs.Status.State == v1alpha1.GameServerStateShutdown && gs.ObjectMeta.DeletionTimestamp.IsZero()) {
 		return nil
 	}
 

--- a/pkg/gameservers/health.go
+++ b/pkg/gameservers/health.go
@@ -164,8 +164,7 @@ func (hc *HealthController) syncGameServer(key string) error {
 	}
 
 	// at this point we don't care, we're already Unhealthy / deleting
-	if !gs.ObjectMeta.DeletionTimestamp.IsZero() || gs.Status.State == v1alpha1.GameServerStateShutdown ||
-		gs.Status.State == v1alpha1.GameServerStateUnhealthy {
+	if gs.IsBeingDeleted() || gs.Status.State == v1alpha1.GameServerStateUnhealthy {
 		return nil
 	}
 

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -467,7 +467,7 @@ func computeReconciliationAction(strategy apis.SchedulingStrategy, list []*v1alp
 		toDelete = append(toDelete, potentialDeletions[0:deleteCount]...)
 	}
 
-	if deleteCount > maxDeletions {
+	if len(toDelete) > maxDeletions {
 		toDelete = toDelete[0:maxDeletions]
 		partialReconciliation = true
 	}

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -157,6 +157,44 @@ func TestComputeReconciliationAction(t *testing.T) {
 			wantNumServersToAdd: 0,
 			wantIsPartial:       true,
 		},
+		{
+			desc: "DeletingUnhealthyGameServers",
+			list: []*v1alpha1.GameServer{
+				gsWithState(v1alpha1.GameServerStateReady),
+				gsWithState(v1alpha1.GameServerStateUnhealthy),
+				gsWithState(v1alpha1.GameServerStateUnhealthy),
+			},
+			targetReplicaCount:     3,
+			wantNumServersToAdd:    2,
+			wantNumServersToDelete: 2,
+		},
+		{
+			desc: "DeletingErrorGameServers",
+			list: []*v1alpha1.GameServer{
+				gsWithState(v1alpha1.GameServerStateReady),
+				gsWithState(v1alpha1.GameServerStateError),
+				gsWithState(v1alpha1.GameServerStateError),
+			},
+			targetReplicaCount:     3,
+			wantNumServersToAdd:    2,
+			wantNumServersToDelete: 2,
+		},
+		{
+			desc: "DeletingPartialGameServers",
+			list: []*v1alpha1.GameServer{
+				gsWithState(v1alpha1.GameServerStateReady),
+				gsWithState(v1alpha1.GameServerStateUnhealthy),
+				gsWithState(v1alpha1.GameServerStateError),
+				gsWithState(v1alpha1.GameServerStateUnhealthy),
+				gsWithState(v1alpha1.GameServerStateError),
+				gsWithState(v1alpha1.GameServerStateUnhealthy),
+				gsWithState(v1alpha1.GameServerStateError),
+			},
+			targetReplicaCount:     3,
+			wantNumServersToAdd:    2,
+			wantNumServersToDelete: 3,
+			wantIsPartial:          true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/sdkserver/sdkserver.go
+++ b/pkg/sdkserver/sdkserver.go
@@ -252,6 +252,12 @@ func (s *SDKServer) updateState() error {
 		return err
 	}
 
+	// if we are currently in shutdown/being deleted, there is no escaping
+	if gs.IsBeingDeleted() {
+		s.logger.Info("GameServerState being shutdown. Skipping update.")
+		return nil
+	}
+
 	// if the state is currently unhealthy, you can't go back to Ready
 	if gs.Status.State == stablev1alpha1.GameServerStateUnhealthy {
 		s.logger.Info("GameServerState already unhealthy. Skipping update.")
@@ -484,7 +490,7 @@ func (s *SDKServer) sendGameServerUpdate(gs *stablev1alpha1.GameServer) {
 func (s *SDKServer) runHealth() {
 	s.checkHealth()
 	if !s.healthy() {
-		s.logger.WithField("gameServerName", s.gameServerName).Info("being marked as not healthy")
+		s.logger.WithField("gameServerName", s.gameServerName).Info("has failed health check")
 		s.enqueueState(stablev1alpha1.GameServerStateUnhealthy)
 	}
 }

--- a/site/content/en/docs/Advanced/limiting-resources.md
+++ b/site/content/en/docs/Advanced/limiting-resources.md
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.8
+        image: gcr.io/agones-images/udp-server:0.9
         resources:
           limit:
             cpu: "250m" #this is our limit here

--- a/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
+++ b/site/content/en/docs/Advanced/scheduling-and-autoscaling.md
@@ -79,7 +79,7 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.8
+            image: gcr.io/agones-images/udp-server:0.9
 ```
 
 This is the *default* Fleet scheduling strategy. It is designed for dynamic Kubernetes environments, wherein you wish 
@@ -134,7 +134,7 @@ spec:
         spec:
           containers:
           - name: simple-udp
-            image: gcr.io/agones-images/udp-server:0.8
+            image: gcr.io/agones-images/udp-server:0.9
 ```
 
 This Fleet scheduling strategy is designed for static Kubernetes environments, such as when you are running Kubernetes

--- a/site/content/en/docs/Advanced/service-accounts.md
+++ b/site/content/en/docs/Advanced/service-accounts.md
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: my-special-service-account # a custom service account
       containers:
       - name: simple-udp
-        image: gcr.io/agones-images/udp-server:0.8
+        image: gcr.io/agones-images/udp-server:0.9
 ```
 
 If a service account is configured, the mounted key is not overwritten, as it assumed that you want to have full control

--- a/site/content/en/docs/Getting Started/create-fleet.md
+++ b/site/content/en/docs/Getting Started/create-fleet.md
@@ -111,7 +111,7 @@ Spec:
           Creation Timestamp:  <nil>
         Spec:
           Containers:
-            Image:  gcr.io/agones-images/udp-server:0.8
+            Image:  gcr.io/agones-images/udp-server:0.9
             Name:   simple-udp
             Resources:
 Status:
@@ -351,7 +351,7 @@ status:
           creationTimestamp: null
         spec:
           containers:
-          - image: gcr.io/agones-images/udp-server:0.8
+          - image: gcr.io/agones-images/udp-server:0.9
             name: simple-udp
             resources: {}
     status:

--- a/site/content/en/docs/Getting Started/create-gameserver.md
+++ b/site/content/en/docs/Getting Started/create-gameserver.md
@@ -107,7 +107,7 @@ Spec:
       Creation Timestamp:  <nil>
     Spec:
       Containers:
-        Image:  gcr.io/agones-images/udp-server:0.8
+        Image:  gcr.io/agones-images/udp-server:0.9
         Name:   simple-udp
         Resources:
           Limits:

--- a/site/content/en/docs/Guides/access-api.md
+++ b/site/content/en/docs/Guides/access-api.md
@@ -90,7 +90,7 @@ func main() {
 		Spec: v1alpha1.GameServerSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "udp-server", Image: "gcr.io/agones-images/udp-server:0.8"}},
+					Containers: []corev1.Container{{Name: "udp-server", Image: "gcr.io/agones-images/udp-server:0.9"}},
 				},
 			},
 		},
@@ -178,7 +178,7 @@ $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/
             "kind": "GameServer",
             "metadata": {
                 "annotations": {
-                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"stable.agones.dev/v1alpha1\",\"kind\":\"GameServer\",\"metadata\":{\"annotations\":{},\"name\":\"simple-udp\",\"namespace\":\"default\"},\"spec\":{\"containerPort\":7654,\"hostPort\":7777,\"portPolicy\":\"static\",\"template\":{\"spec\":{\"containers\":[{\"image\":\"gcr.io/agones-images/udp-server:0.8\",\"name\":\"simple-udp\"}]}}}}\n"
+                    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"stable.agones.dev/v1alpha1\",\"kind\":\"GameServer\",\"metadata\":{\"annotations\":{},\"name\":\"simple-udp\",\"namespace\":\"default\"},\"spec\":{\"containerPort\":7654,\"hostPort\":7777,\"portPolicy\":\"static\",\"template\":{\"spec\":{\"containers\":[{\"image\":\"gcr.io/agones-images/udp-server:0.9\",\"name\":\"simple-udp\"}]}}}}\n"
                 },
                 "clusterName": "",
                 "creationTimestamp": "2018-03-02T21:41:05Z",
@@ -210,7 +210,7 @@ $ curl http://localhost:8001/apis/stable.agones.dev/v1alpha1/namespaces/default/
                     "spec": {
                         "containers": [
                             {
-                                "image": "gcr.io/agones-images/udp-server:0.8",
+                                "image": "gcr.io/agones-images/udp-server:0.9",
                                 "name": "simple-udp",
                                 "resources": {}
                             }
@@ -317,7 +317,7 @@ $ curl -d '{"apiVersion":"stable.agones.dev/v1alpha1","kind":"FleetAllocation","
                     "spec": {
                         "containers": [
                             {
-                                "image": "gcr.io/agones-images/udp-server:0.8",
+                                "image": "gcr.io/agones-images/udp-server:0.9",
                                 "name": "simple-udp",
                                 "resources": {}
                             }

--- a/test/e2e/fleet_test.go
+++ b/test/e2e/fleet_test.go
@@ -853,6 +853,8 @@ func TestFleetRecreateGameServerOnPodDeletion(t *testing.T) {
 	framework.WaitForFleetCondition(t, flt, e2e.FleetReadyCount(flt.Spec.Replicas))
 }
 
+// TOXO: e2e test run shutdown on lots of gameservers
+
 // Counts the number of gameservers with the specified scheduling strategy in a fleet
 func countFleetScheduling(gsList []v1alpha1.GameServer, scheduling apis.SchedulingStrategy) int {
 	count := 0

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -94,6 +94,8 @@ func (f *Framework) CreateGameServerAndWaitUntilReady(ns string, gs *v1alpha1.Ga
 		return nil, fmt.Errorf("Ready GameServer instance has no port: %v", readyGs.Status)
 	}
 
+	logrus.WithField("name", newGs.ObjectMeta.Name).Info("GameServer Ready")
+
 	return readyGs, nil
 }
 

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -208,27 +208,7 @@ func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 	err = podClient.Delete(pod.ObjectMeta.Name, nil)
 	assert.NoError(t, err)
 
-	// TODO [markmandel@google.com]: Should GameServers that are Unhealthy and not in a fleet be deleted?
-	err = wait.PollImmediate(2*time.Second, time.Minute, func() (bool, error) {
-		gs, err := framework.AgonesClient.StableV1alpha1().GameServers(readyGs.Namespace).Get(readyGs.ObjectMeta.Name, metav1.GetOptions{})
-
-		// just in case
-		if k8serrors.IsNotFound(err) {
-			return true, nil
-		}
-
-		if err != nil {
-			logrus.WithError(err).Warn("error retrieving gameserver")
-			return false, nil
-		}
-
-		if gs.Status.State == v1alpha1.GameServerStateUnhealthy {
-			return true, nil
-		}
-
-		return false, nil
-	})
-
+	_, err = framework.WaitForGameServerState(readyGs, v1alpha1.GameServerStateUnhealthy, 10*time.Second)
 	assert.NoError(t, err)
 }
 
@@ -313,6 +293,27 @@ func TestGameServerSelfAllocate(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestGameServerShutdown(t *testing.T) {
+	t.Parallel()
+	gs := defaultGameServer()
+	readyGs, err := framework.CreateGameServerAndWaitUntilReady(defaultNs, gs)
+	if err != nil {
+		t.Fatalf("Could not get a GameServer ready: %v", err)
+	}
+	assert.Equal(t, readyGs.Status.State, v1alpha1.GameServerStateReady)
+
+	reply, err := e2eframework.SendGameServerUDP(readyGs, "EXIT")
+
+	if err != nil {
+		t.Fatalf("Could not message GameServer: %v", err)
+	}
+
+	assert.Equal(t, "ACK: EXIT\n", reply)
+	// TOXO: write a e2e test for server shutdown!
+		// work from here!
+}
+
 
 func defaultGameServer() *v1alpha1.GameServer {
 	gs := &v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{GenerateName: "udp-server", Namespace: defaultNs},

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -175,14 +175,10 @@ func TestUnhealthyGameServersWithoutFreePorts(t *testing.T) {
 	}
 
 	newGs, err := gameServers.Create(gs.DeepCopy())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
-	_, err = framework.WaitForGameServerState(newGs, v1alpha1.GameServerStateUnhealthy, 10*time.Second)
-	assert.NotNil(t, err)
-
-	_, err = gameServers.Get(newGs.Name, metav1.GetOptions{})
-	assert.NotNil(t, err)
-	assert.True(t, k8serrors.IsNotFound(err))
+	_, err = framework.WaitForGameServerState(newGs, v1alpha1.GameServerStateUnhealthy, time.Minute)
+	assert.NoError(t, err)
 }
 
 func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
@@ -208,7 +204,7 @@ func TestGameServerUnhealthyAfterDeletingPod(t *testing.T) {
 	err = podClient.Delete(pod.ObjectMeta.Name, nil)
 	assert.NoError(t, err)
 
-	_, err = framework.WaitForGameServerState(readyGs, v1alpha1.GameServerStateUnhealthy, 10*time.Second)
+	_, err = framework.WaitForGameServerState(readyGs, v1alpha1.GameServerStateUnhealthy, time.Minute)
 	assert.NoError(t, err)
 }
 
@@ -310,7 +306,7 @@ func TestGameServerShutdown(t *testing.T) {
 
 	assert.Equal(t, "ACK: EXIT\n", reply)
 
-	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+	err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 		gs, err = framework.AgonesClient.StableV1alpha1().GameServers(defaultNs).Get(readyGs.ObjectMeta.Name, metav1.GetOptions{})
 
 		if k8serrors.IsNotFound(err) {
@@ -322,7 +318,6 @@ func TestGameServerShutdown(t *testing.T) {
 
 	assert.NoError(t, err)
 }
-
 
 func defaultGameServer() *v1alpha1.GameServer {
 	gs := &v1alpha1.GameServer{ObjectMeta: metav1.ObjectMeta{GenerateName: "udp-server", Namespace: defaultNs},

--- a/test/e2e/gameserver_test.go
+++ b/test/e2e/gameserver_test.go
@@ -304,14 +304,23 @@ func TestGameServerShutdown(t *testing.T) {
 	assert.Equal(t, readyGs.Status.State, v1alpha1.GameServerStateReady)
 
 	reply, err := e2eframework.SendGameServerUDP(readyGs, "EXIT")
-
 	if err != nil {
 		t.Fatalf("Could not message GameServer: %v", err)
 	}
 
 	assert.Equal(t, "ACK: EXIT\n", reply)
-	// TOXO: write a e2e test for server shutdown!
-		// work from here!
+
+	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+		gs, err = framework.AgonesClient.StableV1alpha1().GameServers(defaultNs).Get(readyGs.ObjectMeta.Name, metav1.GetOptions{})
+
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		return false, err
+	})
+
+	assert.NoError(t, err)
 }
 
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -34,8 +34,8 @@ func TestMain(m *testing.M) {
 	usr, _ := user.Current()
 	kubeconfig := flag.String("kubeconfig", filepath.Join(usr.HomeDir, "/.kube/config"),
 		"kube config path, e.g. $HOME/.kube/config")
-	gsimage := flag.String("gameserver-image", "gcr.io/agones-images/udp-server:0.8",
-		"gameserver image to use for those tests, gcr.io/agones-images/udp-server:0.8")
+	gsimage := flag.String("gameserver-image", "gcr.io/agones-images/udp-server:0.9",
+		"gameserver image to use for those tests, gcr.io/agones-images/udp-server:0.9")
 	pullSecret := flag.String("pullsecret", "",
 		"optional secret to be used for pulling the gameserver and/or Agones SDK sidecar images")
 	stressTestLevel := flag.Int("stress", 0, "enable stress test at given level 0-100")


### PR DESCRIPTION
This PR does several things:

- Revert back to standalone GameServers that are unhealthy to not be deleted. This should be a better debugging experience when trying to determine why a live GameServer is moving to Unhealthy - as it stays persistent outside a Fleet lifecycle
- Attempt to fix the bug wherein Unhealthy GameServers where leaking when shutting down GameServers that where in fleets - especially  at scale
- Add more testing around shutdown scenarios, such as Shutdown,  Unhealthy, pod deletion and more.