### PR TITLE
Add Reserved GameServer State

### DIFF
--- a/pkg/apis/stable/v1alpha1/fleet.go
+++ b/pkg/apis/stable/v1alpha1/fleet.go
@@ -71,6 +71,9 @@ type FleetStatus struct {
 	Replicas int32 `json:"replicas"`
 	// ReadyReplicas are the number of Ready GameServer replicas
 	ReadyReplicas int32 `json:"readyReplicas"`
+	// ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+	// Reserved instances won't be deleted on scale down, but won't cause an autoscaler to scale up.
+	ReservedReplicas int32 `json:"reservedReplicas"`
 	// AllocatedReplicas are the number of Allocated GameServer replicas
 	AllocatedReplicas int32 `json:"allocatedReplicas"`
 }

--- a/pkg/apis/stable/v1alpha1/gameserver_test.go
+++ b/pkg/apis/stable/v1alpha1/gameserver_test.go
@@ -460,6 +460,27 @@ func TestGameServerGetDevAddress(t *testing.T) {
 	assert.Equal(t, "", devAddress, "dev-address IP address should be 127.1.1.1")
 }
 
+func TestGameServerIsDeletable(t *testing.T) {
+	gs := &GameServer{Status: GameServerStatus{State: GameServerStateStarting}}
+	assert.True(t, gs.IsDeletable())
+
+	gs.Status.State = GameServerStateAllocated
+	assert.False(t, gs.IsDeletable())
+
+	gs.Status.State = GameServerStateReserved
+	assert.False(t, gs.IsDeletable())
+
+	now := metav1.Now()
+	gs.ObjectMeta.DeletionTimestamp = &now
+	assert.True(t, gs.IsDeletable())
+
+	gs.Status.State = GameServerStateAllocated
+	assert.True(t, gs.IsDeletable())
+
+	gs.Status.State = GameServerStateReady
+	assert.True(t, gs.IsDeletable())
+}
+
 func TestGameServerApplyToPodGameServerContainer(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apis/stable/v1alpha1/gameserverset.go
+++ b/pkg/apis/stable/v1alpha1/gameserverset.go
@@ -70,6 +70,8 @@ type GameServerSetStatus struct {
 	Replicas int32 `json:"replicas"`
 	// ReadyReplicas are the number of Ready GameServer replicas
 	ReadyReplicas int32 `json:"readyReplicas"`
+	// ReservedReplicas are the number of Reserved GameServer replicas
+	ReservedReplicas int32 `json:"reservedReplicas"`
 	// AllocatedReplicas are the number of Allocated GameServer replicas
 	AllocatedReplicas int32 `json:"allocatedReplicas"`
 }

--- a/pkg/fleetautoscalers/controller_test.go
+++ b/pkg/fleetautoscalers/controller_test.go
@@ -456,12 +456,13 @@ func defaultFixtures() (*v1alpha1.FleetAutoscaler, *v1alpha1.Fleet) {
 			UID:       "1234",
 		},
 		Spec: v1alpha1.FleetSpec{
-			Replicas: 5,
+			Replicas: 8,
 			Template: v1alpha1.GameServerTemplateSpec{},
 		},
 		Status: v1alpha1.FleetStatus{
 			Replicas:          5,
 			ReadyReplicas:     3,
+			ReservedReplicas:  3,
 			AllocatedReplicas: 2,
 		},
 	}

--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -509,11 +509,13 @@ func (c *Controller) updateFleetStatus(fleet *stablev1alpha1.Fleet) error {
 	fCopy := fleet.DeepCopy()
 	fCopy.Status.Replicas = 0
 	fCopy.Status.ReadyReplicas = 0
+	fCopy.Status.ReservedReplicas = 0
 	fCopy.Status.AllocatedReplicas = 0
 
 	for _, gsSet := range list {
 		fCopy.Status.Replicas += gsSet.Status.Replicas
 		fCopy.Status.ReadyReplicas += gsSet.Status.ReadyReplicas
+		fCopy.Status.ReservedReplicas += gsSet.Status.ReservedReplicas
 		fCopy.Status.AllocatedReplicas += gsSet.Status.AllocatedReplicas
 	}
 

--- a/pkg/fleets/controller_test.go
+++ b/pkg/fleets/controller_test.go
@@ -364,6 +364,7 @@ func TestControllerUpdateFleetStatus(t *testing.T) {
 	gsSet1.ObjectMeta.Name = "gsSet1"
 	gsSet1.Status.Replicas = 3
 	gsSet1.Status.ReadyReplicas = 2
+	gsSet1.Status.ReservedReplicas = 4
 	gsSet1.Status.AllocatedReplicas = 1
 
 	gsSet2 := fleet.GameServerSet()
@@ -371,6 +372,7 @@ func TestControllerUpdateFleetStatus(t *testing.T) {
 	gsSet2.ObjectMeta.Name = "gsSet2"
 	gsSet2.Status.Replicas = 5
 	gsSet2.Status.ReadyReplicas = 5
+	gsSet2.Status.ReservedReplicas = 3
 	gsSet2.Status.AllocatedReplicas = 2
 
 	m.AgonesClient.AddReactor("list", "gameserversets",
@@ -387,6 +389,7 @@ func TestControllerUpdateFleetStatus(t *testing.T) {
 
 			assert.Equal(t, gsSet1.Status.Replicas+gsSet2.Status.Replicas, fleet.Status.Replicas)
 			assert.Equal(t, gsSet1.Status.ReadyReplicas+gsSet2.Status.ReadyReplicas, fleet.Status.ReadyReplicas)
+			assert.Equal(t, gsSet1.Status.ReservedReplicas+gsSet2.Status.ReservedReplicas, fleet.Status.ReservedReplicas)
 			assert.Equal(t, gsSet1.Status.AllocatedReplicas+gsSet2.Status.AllocatedReplicas, fleet.Status.AllocatedReplicas)
 			return true, fleet, nil
 		})

--- a/pkg/gameserversets/controller.go
+++ b/pkg/gameserversets/controller.go
@@ -387,16 +387,16 @@ func computeReconciliationAction(strategy apis.SchedulingStrategy, list []*v1alp
 		potentialDeletions = append(potentialDeletions, gs)
 	}
 
-	// pass 1 - count allocated servers only, since those can't be touched
+	// pass 1 - count allocated/reserved servers only, since those can't be touched
 	for _, gs := range list {
-		if gs.IsAllocated() {
+		if !gs.IsDeletable() {
 			upCount++
 		}
 	}
 
 	// pass 2 - handle all other statuses
 	for _, gs := range list {
-		if gs.IsAllocated() {
+		if !gs.IsDeletable() {
 			// already handled above
 			continue
 		}
@@ -422,6 +422,8 @@ func computeReconciliationAction(strategy apis.SchedulingStrategy, list []*v1alp
 		case v1alpha1.GameServerStateRequestReady:
 			handleGameServerUp(gs)
 		case v1alpha1.GameServerStateReady:
+			handleGameServerUp(gs)
+		case v1alpha1.GameServerStateReserved:
 			handleGameServerUp(gs)
 
 		// GameServerStateShutdown - already handled above
@@ -600,6 +602,8 @@ func computeStatus(list []*v1alpha1.GameServer) v1alpha1.GameServerSetStatus {
 			status.ReadyReplicas++
 		case v1alpha1.GameServerStateAllocated:
 			status.AllocatedReplicas++
+		case v1alpha1.GameServerStateReserved:
+			status.ReservedReplicas++
 		}
 	}
 

--- a/pkg/gameserversets/controller_test.go
+++ b/pkg/gameserversets/controller_test.go
@@ -100,7 +100,7 @@ func TestComputeReconciliationAction(t *testing.T) {
 			desc: "DeleteServers",
 			list: []*v1alpha1.GameServer{
 				gsWithState(v1alpha1.GameServerStateReady),
-				gsWithState(v1alpha1.GameServerStateReady),
+				gsWithState(v1alpha1.GameServerStateReserved),
 				gsWithState(v1alpha1.GameServerStateReady),
 			},
 			targetReplicaCount:     1,
@@ -127,6 +127,16 @@ func TestComputeReconciliationAction(t *testing.T) {
 				gsWithState(v1alpha1.GameServerStateReady),
 				gsWithState(v1alpha1.GameServerStateAllocated),
 				gsWithState(v1alpha1.GameServerStateAllocated),
+			},
+			targetReplicaCount:     0,
+			wantNumServersToDelete: 1,
+		},
+		{
+			desc: "DeleteIgnoresReservedServers",
+			list: []*v1alpha1.GameServer{
+				gsWithState(v1alpha1.GameServerStateReady),
+				gsWithState(v1alpha1.GameServerStateReserved),
+				gsWithState(v1alpha1.GameServerStateReserved),
 			},
 			targetReplicaCount:     0,
 			wantNumServersToDelete: 1,
@@ -270,6 +280,14 @@ func TestComputeStatus(t *testing.T) {
 			gsWithState(v1alpha1.GameServerStateCreating),
 			gsWithState(v1alpha1.GameServerStateReady),
 		}, v1alpha1.GameServerSetStatus{ReadyReplicas: 1, AllocatedReplicas: 2, Replicas: 4}},
+		{
+			list: []*v1alpha1.GameServer{
+				gsWithState(v1alpha1.GameServerStateReserved),
+				gsWithState(v1alpha1.GameServerStateReserved),
+				gsWithState(v1alpha1.GameServerStateReady),
+			},
+			wantStatus: v1alpha1.GameServerSetStatus{Replicas: 3, ReadyReplicas: 1, ReservedReplicas: 2},
+		},
 	}
 
 	for _, tc := range cases {

--- a/site/content/en/docs/Reference/agones_crd_api_reference.html
+++ b/site/content/en/docs/Reference/agones_crd_api_reference.html
@@ -2229,6 +2229,9 @@ Generated with <code>gen-crd-api-reference-docs</code>.
 
 
 
+
+
+
 {{% feature publishVersion="0.10.0" %}}
 <p>Packages:</p>
 <ul>
@@ -3823,6 +3826,18 @@ int32
 </tr>
 <tr>
 <td>
+<code>reservedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas are the total number of Reserved GameServer replicas in this fleet.
+Reserved instances won&rsquo;t be deleted on scale down, but won&rsquo;t cause an autoscaler to scale up.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>allocatedReplicas</code></br>
 <em>
 int32
@@ -4008,6 +4023,17 @@ int32
 </td>
 <td>
 <p>ReadyReplicas are the number of Ready GameServer replicas</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reservedReplicas</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>ReservedReplicas are the number of Reserved GameServer replicas</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This adds the `Reserved` state to the GameServer state system.

- Ensures that `Reserved` cannot be deleted on scale down, rolling   updates, etc
- Enforcing the correct rules for the autoscaling system (i.e don't  auto scale up on Reserve)
- Adds ReservedReplicas to GameServerSet and Fleet Status values

This does not implement the sdk.Reserve() functionality, that will come in a later PR.