### PR TITLE
Fix for front link. Not sure what happened?

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -23,7 +23,7 @@ linkTitle = "Agones"
 <strong>What is Agones?</strong>
 
 An open source, batteries-included, multiplayer dedicated game server scaling and
-orchestration platform that can run anywhere [Kubernetes](https://kubernetes.io) can run.
+orchestration platform that can run anywhere <a class="text-primary" href="https://kubernetes.io">Kubernetes</a> can run.
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" >}}


### PR DESCRIPTION
Front page has `What is Agones? An open source, batteries-included, mulitplayer dedicated game server scaling and orchestration platform that can run anywhere [Kubernetes](https://kubernetes.io) can run.` displaying :man_facepalming: 