### PR TITLE
Prevent race conditions by syncing node cache on GameServer controller

### DIFF
--- a/pkg/gameservers/controller.go
+++ b/pkg/gameservers/controller.go
@@ -70,6 +70,7 @@ type Controller struct {
 	gameServerLister       listerv1alpha1.GameServerLister
 	gameServerSynced       cache.InformerSynced
 	nodeLister             corelisterv1.NodeLister
+	nodeSynced             cache.InformerSynced
 	portAllocator          *PortAllocator
 	healthController       *HealthController
 	workerqueue            *workerqueue.WorkerQueue
@@ -114,6 +115,7 @@ func NewController(
 		gameServerLister:       gameServers.Lister(),
 		gameServerSynced:       gsInformer.HasSynced,
 		nodeLister:             kubeInformerFactory.Core().V1().Nodes().Lister(),
+		nodeSynced:             kubeInformerFactory.Core().V1().Nodes().Informer().HasSynced,
 		portAllocator:          NewPortAllocator(minPort, maxPort, kubeInformerFactory, agonesInformerFactory),
 		healthController:       NewHealthController(kubeClient, agonesClient, kubeInformerFactory, agonesInformerFactory),
 	}
@@ -298,7 +300,7 @@ func (c *Controller) Run(workers int, stop <-chan struct{}) error {
 	}
 
 	c.baseLogger.Info("Wait for cache sync")
-	if !cache.WaitForCacheSync(stop, c.gameServerSynced, c.podSynced) {
+	if !cache.WaitForCacheSync(stop, c.gameServerSynced, c.podSynced, c.nodeSynced) {
 		return errors.New("failed to wait for caches to sync")
 	}
 

--- a/pkg/gameservers/controller_test.go
+++ b/pkg/gameservers/controller_test.go
@@ -944,7 +944,7 @@ func TestControllerSyncGameServerRequestReadyState(t *testing.T) {
 			return true, gs, nil
 		})
 
-		_, cancel := agtesting.StartInformers(m, c.gameServerSynced)
+		_, cancel := agtesting.StartInformers(m, c.podSynced)
 		defer cancel()
 
 		gs, err := c.syncGameServerRequestReadyState(gsFixture)
@@ -983,7 +983,7 @@ func TestControllerSyncGameServerRequestReadyState(t *testing.T) {
 			return true, gs, nil
 		})
 
-		_, cancel := agtesting.StartInformers(m, c.gameServerSynced)
+		_, cancel := agtesting.StartInformers(m, c.podSynced, c.nodeSynced)
 		defer cancel()
 
 		gs, err := c.syncGameServerRequestReadyState(gsFixture)


### PR DESCRIPTION
Added cache.InformerSynced for Nodes on startup, to avoid race conditions.

This also included fix for flakey tests for the same reason.