### PR TITLE
Packed Strategy Gameserverallocation fix

### DIFF
--- a/pkg/gameserverallocations/controller.go
+++ b/pkg/gameserverallocations/controller.go
@@ -604,10 +604,16 @@ func (c *Controller) findReadyGameServerForAllocation(gsa *v1alpha1.GameServerAl
 	}
 
 	var bestGSList []stablev1alpha1.GameServer
+	bestNode := ""
 	for nodeName, gs := range allocationSet {
 		count := counts[nodeName]
-		// bestGS == nil: if there is no best GameServer, then this node & GameServer is the always the best
+		// bestGS == nil: if there is no best GameServer, then this node & GameServer is always the best
 		if bestGS == nil || comparator(*bestCount, count) {
+			if gsa.Spec.Scheduling == apis.Packed && bestNode != gs.Status.NodeName {
+				bestNode = gs.Status.NodeName
+				// Clear the list if we found new node for Packed strategy
+				bestGSList = bestGSList[:0]
+			}
 			bestCount = &count
 			bestGS = gs
 			bestGSList = append(bestGSList, *gs)

--- a/pkg/gameserverallocations/find.go
+++ b/pkg/gameserverallocations/find.go
@@ -18,10 +18,13 @@ import "agones.dev/agones/pkg/gameservers"
 
 // packedComparator prioritises Nodes with GameServers that are allocated, and then Nodes with the most
 // Ready GameServers -- this will bin pack allocated game servers together.
+// If all other criterias are equal than sort by NodeNames alphabetically.
 func packedComparator(bestCount, currentCount gameservers.NodeCount) bool {
 	if currentCount.Allocated == bestCount.Allocated && currentCount.Ready > bestCount.Ready {
 		return true
 	} else if currentCount.Allocated > bestCount.Allocated {
+		return true
+	} else if currentCount.NodeName < bestCount.NodeName {
 		return true
 	}
 

--- a/pkg/gameservers/pernodecounter.go
+++ b/pkg/gameservers/pernodecounter.go
@@ -48,6 +48,9 @@ type NodeCount struct {
 	Ready int64
 	// Allocated is allocated out
 	Allocated int64
+	// Name of a node suitable for dealing with tie situations on Packed Strategy
+	// When NodeCount1.Ready == NodeCount2.Ready on different nodes as well as Allocated
+	NodeName string
 }
 
 // NewPerNodeCounter returns a new PerNodeCounter
@@ -153,7 +156,7 @@ func (pnc *PerNodeCounter) Run(_ int, stop <-chan struct{}) error {
 	for _, gs := range gsList {
 		_, ok := counts[gs.Status.NodeName]
 		if !ok {
-			counts[gs.Status.NodeName] = &NodeCount{}
+			counts[gs.Status.NodeName] = &NodeCount{NodeName: gs.Status.NodeName}
 		}
 
 		switch gs.Status.State {
@@ -189,7 +192,7 @@ func (pnc *PerNodeCounter) inc(gs *v1alpha1.GameServer, ready, allocated int64) 
 
 	_, ok := pnc.counts[gs.Status.NodeName]
 	if !ok {
-		pnc.counts[gs.Status.NodeName] = &NodeCount{}
+		pnc.counts[gs.Status.NodeName] = &NodeCount{NodeName: gs.Status.NodeName}
 	}
 
 	pnc.counts[gs.Status.NodeName].Allocated += allocated


### PR DESCRIPTION
Add `NodeName` compare for Packed Strategy when draw in Ready and Allocated Gameservers count per `Node`.

When we are performing node search using the Packed Strategy and we have all gameservers spread equally between nodes, we will select node alphabetically. In that case simultaneous calls to allocate will result in first nodeName in lexicographic order. 
Clear the list of best GameServers when Packed.
As we go through GS list we were adding Gameservers from different nodes.

Verified on GKE with `simple-udp` server that issue does not reproduce on Packed strategy.

Closes #783