### PR TITLE
Docs: FleetAllocation example fix

### DIFF
--- a/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
+++ b/site/content/en/docs/Getting Started/create-webhook-fleetautoscaler.md
@@ -364,7 +364,7 @@ If you're interested in more details for game server allocation, you should cons
 Here we only interested in triggering allocations to see the autoscaler in action.
 
 ```
-for i in {0..2} ; do kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/master/examples/simple-udp/fleetallocation.yaml -o yaml ; done
+for i in {0..1} ; do kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/agones/master/examples/simple-udp/fleetallocation.yaml -o yaml ; done
 ```
 
 #### 7. Check new Autoscaler and Fleet status


### PR DESCRIPTION
The example in the docs assumes a fleet with two game servers, then tries to allocate 3 game servers.

This results with a cryptic "NotFound" error resulting from trying to allocate a resource that doesn't exist.

A better solution may be to replace this example with GSA instead of FA.