### PR TITLE
Fleetautoscaler: Add check to have minReplicas>0 when use percents bufferSize

### DIFF
--- a/pkg/apis/stable/v1alpha1/fleetautoscaler.go
+++ b/pkg/apis/stable/v1alpha1/fleetautoscaler.go
@@ -279,6 +279,17 @@ func (b *BufferPolicy) ValidateBufferPolicy(causes []metav1.StatusCause) []metav
 				Message: "bufferSize does not have a valid percentage value (1%-99%)",
 			})
 		}
+		// When there is no allocated gameservers in a fleet,
+		// Fleetautoscaler would reduce size of a fleet to MinReplicas.
+		// If we have 0 MinReplicas and 0 Allocated then Fleetautoscaler would set Ready Replicas to 0
+		// and we will not be able to raise the number of GS in a Fleet above zero
+		if b.MinReplicas < 1 {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Field:   "minReplicas",
+				Message: "minReplicas should be above 0 when used with percentage value bufferSize",
+			})
+		}
 	}
 	return causes
 }

--- a/pkg/apis/stable/v1alpha1/fleetautoscaler_test.go
+++ b/pkg/apis/stable/v1alpha1/fleetautoscaler_test.go
@@ -66,6 +66,7 @@ func TestFleetAutoscalerValidateUpdate(t *testing.T) {
 
 	t.Run("bufferSize good percent", func(t *testing.T) {
 		fas := defaultFixture()
+		fas.Spec.Policy.Buffer.MinReplicas = 1
 		fas.Spec.Policy.Buffer.BufferSize = intstr.FromString("20%")
 		causes := fas.Validate(nil)
 
@@ -74,6 +75,7 @@ func TestFleetAutoscalerValidateUpdate(t *testing.T) {
 
 	t.Run("bufferSize bad percent", func(t *testing.T) {
 		fas := defaultFixture()
+		fas.Spec.Policy.Buffer.MinReplicas = 1
 
 		fasCopy := fas.DeepCopy()
 		fasCopy.Spec.Policy.Buffer.BufferSize = intstr.FromString("120%")
@@ -98,6 +100,17 @@ func TestFleetAutoscalerValidateUpdate(t *testing.T) {
 		causes = fasCopy.Validate(nil)
 		assert.Len(t, causes, 1)
 		assert.Equal(t, "bufferSize", causes[0].Field)
+	})
+
+	t.Run("bad min replicas with percentage value of bufferSize", func(t *testing.T) {
+		fas := defaultFixture()
+		fas.Spec.Policy.Buffer.BufferSize = intstr.FromString("10%")
+		fas.Spec.Policy.Buffer.MinReplicas = 0
+
+		causes := fas.Validate(nil)
+
+		assert.Len(t, causes, 1)
+		assert.Equal(t, "minReplicas", causes[0].Field)
 	})
 }
 func TestFleetAutoscalerWebhookValidateUpdate(t *testing.T) {

--- a/site/content/en/docs/Reference/fleetautoscaler.md
+++ b/site/content/en/docs/Reference/fleetautoscaler.md
@@ -59,7 +59,8 @@ The `spec` field is the actual `FleetAutoscaler` specification and it is compose
                     as instances are being allocated or terminated
                     it can be specified either in absolute (i.e. 5) or percentage format (i.e. 5%)
     - `minReplicas` is the minimum fleet size to be set by this FleetAutoscaler. 
-                    if not specified, the minimum fleet size will be bufferSize
+                    if not specified, the minimum fleet size will be bufferSize if absolute value is used.
+                    When `bufferSize` in percentage format is used, `minReplicas` should be more than 0.
     - `maxReplicas` is the maximum fleet size that can be set by this FleetAutoscaler. Required. 
   - `webhook` parameters of the webhook policy type
     - `service` is a reference to the service for this webhook. Either `service` or `url` must be specified. If the webhook is running within the cluster, then you should use `service`. Port 8000 will be used if it is open, otherwise it is an error.


### PR DESCRIPTION
When n% is used for bufferSize, Fleet would have 0 Replicas forever if minReplicas set to 0 and no
GameServers were allocated. Currently we are calculating number of
GS in a fleet based on Allocated count.