### PR TITLE
Fix Down Scale on RollingUpdate

### DIFF
--- a/pkg/fleets/controller.go
+++ b/pkg/fleets/controller.go
@@ -223,7 +223,7 @@ func (c *Controller) loggerForFleetKey(key string) *logrus.Entry {
 func (c *Controller) loggerForFleet(f *v1alpha1.Fleet) *logrus.Entry {
 	fleetName := "NilFleet"
 	if f != nil {
-		fleetName = f.Namespace + "/" + f.Name
+		fleetName = f.ObjectMeta.Namespace + "/" + f.ObjectMeta.Name
 	}
 	return c.loggerForFleetKey(fleetName).WithField("fleet", f)
 }
@@ -278,6 +278,7 @@ func (c *Controller) syncFleet(key string) error {
 	}
 
 	active, rest := c.filterGameServerSetByActive(fleet, list)
+
 	// if there isn't an active gameServerSet, create one (but don't persist yet)
 	if active == nil {
 		c.loggerForFleet(fleet).Info("could not find active GameServerSet, creating")
@@ -416,13 +417,19 @@ func (c *Controller) rollingUpdateDeployment(fleet *stablev1alpha1.Fleet, active
 // and returns what its replica value should be set to
 func (c *Controller) rollingUpdateActive(fleet *stablev1alpha1.Fleet, active *stablev1alpha1.GameServerSet, rest []*stablev1alpha1.GameServerSet) (int32, error) {
 	replicas := active.Spec.Replicas
+	// always leave room for Allocated GameServers
+	sumAllocated := stablev1alpha1.SumStatusAllocatedReplicas(rest)
 
 	// if the active spec replicas are greater than or equal the fleet spec replicas, then we don't
 	// need to another rolling update upwards.
 	// Likewise if the active spec replicas don't equal the active status replicas, this means we are
 	// in the middle of a rolling update, and should wait for it to complete.
-	if active.Spec.Replicas >= fleet.Spec.Replicas || active.Spec.Replicas != active.Status.Replicas {
+
+	if active.Spec.Replicas != active.Status.Replicas {
 		return replicas, nil
+	}
+	if active.Spec.Replicas >= (fleet.Spec.Replicas - sumAllocated) {
+		return fleet.Spec.Replicas - sumAllocated, nil
 	}
 
 	r, err := intstr.GetValueFromIntOrPercent(fleet.Spec.Strategy.RollingUpdate.MaxSurge, int(fleet.Spec.Replicas), true)
@@ -439,12 +446,9 @@ func (c *Controller) rollingUpdateActive(fleet *stablev1alpha1.Fleet, active *st
 		replicas = fleet.LowerBoundReplicas(replicas - (total - maxSurge))
 	}
 
-	// always leave room for Allocated GameServers
-	sumAllocated := stablev1alpha1.SumStatusAllocatedReplicas(rest)
-
 	// make room for allocated game servers, but not over the fleet replica count
 	if replicas+sumAllocated > fleet.Spec.Replicas {
-		replicas = fleet.LowerBoundReplicas(replicas - sumAllocated)
+		replicas = fleet.LowerBoundReplicas(fleet.Spec.Replicas - sumAllocated)
 	}
 
 	c.loggerForFleet(fleet).WithField("gameserverset", active.ObjectMeta.Name).WithField("replicas", replicas).
@@ -506,7 +510,10 @@ func (c *Controller) updateFleetStatus(fleet *stablev1alpha1.Fleet) error {
 		return err
 	}
 
-	fCopy := fleet.DeepCopy()
+	fCopy, err := c.fleetGetter.Fleets(fleet.ObjectMeta.Namespace).Get(fleet.ObjectMeta.GetName(), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
 	fCopy.Status.Replicas = 0
 	fCopy.Status.ReadyReplicas = 0
 	fCopy.Status.ReservedReplicas = 0
@@ -518,8 +525,7 @@ func (c *Controller) updateFleetStatus(fleet *stablev1alpha1.Fleet) error {
 		fCopy.Status.ReservedReplicas += gsSet.Status.ReservedReplicas
 		fCopy.Status.AllocatedReplicas += gsSet.Status.AllocatedReplicas
 	}
-
-	_, err = c.fleetGetter.Fleets(fCopy.Namespace).UpdateStatus(fCopy)
+	_, err = c.fleetGetter.Fleets(fCopy.ObjectMeta.Namespace).UpdateStatus(fCopy)
 	return errors.Wrapf(err, "error updating status of fleet %s", fCopy.ObjectMeta.Name)
 }
 


### PR DESCRIPTION
rollingUpdateActive now returns valid target number of replicas with E2E test.

Fixing #800 Fleet does not scaled down after allocate and edit.